### PR TITLE
Clean up token generation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/StorageConfiguration.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.config;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageCredentials;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,20 +13,14 @@ import java.net.URISyntaxException;
 public class StorageConfiguration {
 
     @Bean
-    public StorageCredentials getStorageCredentials(
+    public CloudBlobClient getCloudBlobClient(
         @Value("${storage.account_name}") String accountName,
         @Value("${storage.key}") String key
-    ) {
-        return new StorageCredentialsAccountAndKey(accountName, key);
-    }
+    ) throws URISyntaxException {
 
-    @Bean
-    public CloudStorageAccount getCloudStorageAccount(StorageCredentials storageCredentials) throws URISyntaxException {
-        return new CloudStorageAccount(storageCredentials, true);
-    }
-
-    @Bean
-    public CloudBlobClient getCloudBlobClient(CloudStorageAccount account) {
-        return account.createCloudBlobClient();
+        return new CloudStorageAccount(
+            new StorageCredentialsAccountAndKey(accountName, key),
+            true
+        ).createCloudBlobClient();
     }
 }


### PR DESCRIPTION
Tiny improvements:
- 1 bean instead of 3 in configuration
- simpler expiry date setting 