### PR TITLE
Update: envelope pre upload failure status

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeStatus.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
 public enum EnvelopeStatus {
 
+    DOC_FAILURE, // generic failure while processing zip file. before uploading to document management
     DOC_UPLOADED,
     DOC_UPLOAD_FAILURE
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -131,8 +131,10 @@ public class BlobProcessorTask {
         String message,
         Envelope envelope
     ) {
-        if (isUploadFailure) {
-            envelopeProcessor.markAsUploadFailed(message, envelope, container, zipFileName);
-        }
+        EnvelopeProcessor.FailureMarker marker = isUploadFailure
+            ? envelopeProcessor::markAsUploadFailed
+            : envelopeProcessor::markAsGenericFailure;
+
+        marker.markAsFailure(message, envelope, container, zipFileName);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -126,15 +126,15 @@ public class BlobProcessorTask {
 
     private void markAsFailed(
         boolean isUploadFailure,
-        String container,
+        String containerName,
         String zipFileName,
         String message,
         Envelope envelope
     ) {
-        EnvelopeProcessor.FailureMarker marker = isUploadFailure
-            ? envelopeProcessor::markAsUploadFailed
-            : envelopeProcessor::markAsGenericFailure;
-
-        marker.markAsFailure(message, envelope, container, zipFileName);
+        if (isUploadFailure) {
+            envelopeProcessor.markAsUploadFailed(message, envelope, containerName, zipFileName);
+        } else {
+            envelopeProcessor.markAsGenericFailure(message, envelope, containerName, zipFileName);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
@@ -26,11 +26,6 @@ public class EnvelopeProcessor {
     private final EnvelopeRepository envelopeRepository;
     private final EnvelopeStateRepository envelopeStateRepository;
 
-    @FunctionalInterface
-    public interface FailureMarker {
-        void markAsFailure(String reason, Envelope envelope, String container, String zipFileName);
-    }
-
     public EnvelopeProcessor(
         EnvelopeRepository envelopeRepository,
         EnvelopeStateRepository envelopeStateRepository

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeStatus.DOC_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeStatus.DOC_UPLOADED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeStatus.DOC_UPLOAD_FAILURE;
 
@@ -24,6 +25,11 @@ public class EnvelopeProcessor {
 
     private final EnvelopeRepository envelopeRepository;
     private final EnvelopeStateRepository envelopeStateRepository;
+
+    @FunctionalInterface
+    public interface FailureMarker {
+        void markAsFailure(String reason, Envelope envelope, String container, String zipFileName);
+    }
 
     public EnvelopeProcessor(
         EnvelopeRepository envelopeRepository,
@@ -67,6 +73,17 @@ public class EnvelopeProcessor {
                 .newEnvelopeStatus(container, zipFileName)
                 .withEnvelope(envelope)
                 .withStatus(DOC_UPLOAD_FAILURE)
+                .withReason(reason)
+                .build()
+        );
+    }
+
+    public void markAsGenericFailure(String reason, Envelope envelope, String container, String zipFileName) {
+        envelopeStateRepository.save(
+            EnvelopeStatusBuilder
+                .newEnvelopeStatus(container, zipFileName)
+                .withEnvelope(envelope)
+                .withStatus(DOC_FAILURE)
                 .withReason(reason)
                 .build()
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Introduce envelope state](https://tools.hmcts.net/jira/browse/RPE-573)

### Change description ###

Last set of tests on "new" generic failure state. Line of work:

- #38 - state groundbase
- #39 - upload failure scenario

Next to come:

- Migrate to new data structure of having process events instead of envelope states
- Clean up envelope states

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
