### PR TITLE
New events table replacing state

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
-import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeStateRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItemRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.DocumentManagementService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
@@ -63,7 +63,7 @@ public class EnvelopeControllerTest {
     private EnvelopeRepository envelopeRepository;
 
     @Autowired
-    private EnvelopeStateRepository envelopeStateRepository;
+    private ProcessEventRepository processEventRepository;
 
     @Autowired
     private ScannableItemRepository scannableItemRepository;
@@ -89,7 +89,7 @@ public class EnvelopeControllerTest {
 
         envelopeProcessor = new EnvelopeProcessor(
             envelopeRepository,
-            envelopeStateRepository
+            processEventRepository
         );
 
         blobProcessorTask = new BlobProcessorTask(
@@ -106,6 +106,7 @@ public class EnvelopeControllerTest {
     public void cleanUp() throws Exception {
         testContainer.deleteIfExists();
         envelopeRepository.deleteAll();
+        processEventRepository.deleteAll();
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -145,6 +145,7 @@ public class BlobProcessorTaskTest {
             parse(originalMetaFile),
             "id", "zip_file_created_date", "amount", "amount_in_pence", "configuration", "json"
         );
+        assertThat(actualEnvelope.getLastEvent()).isEqualTo(DOC_UPLOADED);
         assertThat(actualEnvelope.getScannableItems())
             .extracting("documentUrl")
             .hasSameElementsAs(asList(DOCUMENT_URL1, DOCUMENT_URL2));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -111,6 +111,7 @@ public class BlobProcessorTaskTestForFailedStatus {
         // then
         Envelope actualEnvelope = envelopeRepository.findAll().get(0);
 
+        assertThat(actualEnvelope.getLastEvent()).isEqualTo(DOC_UPLOAD_FAILURE);
         assertThat(actualEnvelope.getScannableItems()).extracting("documentUrl").allMatch(ObjectUtils::isEmpty);
 
         // and
@@ -141,6 +142,7 @@ public class BlobProcessorTaskTestForFailedStatus {
         // then
         Envelope actualEnvelope = envelopeRepository.findAll().get(0);
 
+        assertThat(actualEnvelope.getLastEvent()).isEqualTo(DOC_UPLOAD_FAILURE);
         assertThat(actualEnvelope.getScannableItems()).extracting("documentUrl").allMatch(ObjectUtils::isEmpty);
 
         // and

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
@@ -125,6 +125,10 @@ public class Envelope {
         return zipFileName;
     }
 
+    public Event getLastEvent() {
+        return lastEvent;
+    }
+
     public void setLastEvent(Event lastEvent) {
         this.lastEvent = lastEvent;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
@@ -46,6 +46,8 @@ public class Envelope {
     private Timestamp zipFileCreatedDate;
     @JsonProperty("zip_file_name")
     private String zipFileName;
+    @JsonProperty("last_event")
+    private Event lastEvent = Event.ENVELOPE_CREATED;
 
     //We will need to retrieve all scannable item entities of Envelope every time hence fetch type is Eager
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, mappedBy = "envelope")
@@ -121,6 +123,10 @@ public class Envelope {
 
     public String getZipFileName() {
         return zipFileName;
+    }
+
+    public void setLastEvent(Event lastEvent) {
+        this.lastEvent = lastEvent;
     }
 
     private void assignSelfToChildren(List<? extends EnvelopeAssignable> assignables) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Event.java
@@ -1,7 +1,8 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
-public enum EnvelopeStatus {
+public enum Event {
 
+    ENVELOPE_CREATED,
     DOC_FAILURE, // generic failure while processing zip file. before uploading to document management
     DOC_UPLOADED,
     DOC_UPLOAD_FAILURE

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEvent.java
@@ -4,24 +4,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
-@Table(name = "envelope_state")
-public class EnvelopeState implements EnvelopeAssignable {
+@Table(name = "process_events")
+public class ProcessEvent implements EnvelopeAssignable {
 
     @Id
-    @GeneratedValue
-    private UUID id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
 
     private String container;
     @JsonProperty("zip_file_name")
@@ -29,21 +29,21 @@ public class EnvelopeState implements EnvelopeAssignable {
     @JsonProperty("created_at")
     private Timestamp createdAt = Timestamp.from(Instant.now());
     @Enumerated(EnumType.STRING)
-    private EnvelopeStatus status;
+    private Event event;
     private String reason;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "envelope_id")
     private Envelope envelope;
 
-    private EnvelopeState() {
+    private ProcessEvent() {
         // For use by hibernate.
     }
 
-    public EnvelopeState(String containerName, String zipFileName, EnvelopeStatus status) {
+    public ProcessEvent(String containerName, String zipFileName, Event event) {
         this.container = containerName;
         this.zipFileName = zipFileName;
-        this.status = status;
+        this.event = event;
     }
 
     public String getContainer() {
@@ -58,12 +58,12 @@ public class EnvelopeState implements EnvelopeAssignable {
         return createdAt;
     }
 
-    public UUID getId() {
+    public long getId() {
         return id;
     }
 
-    public EnvelopeStatus getStatus() {
-        return status;
+    public Event getEvent() {
+        return event;
     }
 
     public String getReason() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepository.java
@@ -2,7 +2,5 @@ package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
-
-public interface EnvelopeStateRepository extends JpaRepository<EnvelopeState, UUID> {
+public interface ProcessEventRepository extends JpaRepository<ProcessEvent, Long> {
 }

--- a/src/main/resources/db/migration/V005__Process_events.sql
+++ b/src/main/resources/db/migration/V005__Process_events.sql
@@ -1,0 +1,20 @@
+CREATE TABLE process_events (
+  id BIGSERIAL PRIMARY KEY,
+  container VARCHAR(50) NOT NULL,
+  zipFileName VARCHAR(255) NOT NULL,
+  createdAt TIMESTAMP NOT NULL,
+  envelope_id VARCHAR(50) NULL,
+  event VARCHAR(100) NOT NULL,
+  reason TEXT NULL
+);
+
+CREATE INDEX process_events_container_zip_idx ON process_events (container, zipFileName);
+CREATE INDEX process_events_container_event_idx ON process_events (container, event);
+CREATE INDEX process_events_zip_idx ON process_events (zipFileName);
+
+ALTER TABLE envelopes
+  ADD COLUMN lastEvent VARCHAR(100) NOT NULL DEFAULT 'ENVELOPE_CREATED';
+
+UPDATE envelopes e SET lastEvent = 'DOC_UPLOADED' WHERE id = (
+  SELECT envelope_id FROM scannable_items si WHERE si.documentUrl IS NOT NULL GROUP BY envelope_id
+);

--- a/src/main/resources/db/migration/V005__Process_events.sql
+++ b/src/main/resources/db/migration/V005__Process_events.sql
@@ -3,7 +3,7 @@ CREATE TABLE process_events (
   container VARCHAR(50) NOT NULL,
   zipFileName VARCHAR(255) NOT NULL,
   createdAt TIMESTAMP NOT NULL,
-  envelope_id VARCHAR(50) NULL,
+  envelope_id UUID NULL,
   event VARCHAR(100) NOT NULL,
   reason TEXT NULL
 );
@@ -13,7 +13,7 @@ CREATE INDEX process_events_container_event_idx ON process_events (container, ev
 CREATE INDEX process_events_zip_idx ON process_events (zipFileName);
 
 INSERT INTO process_events (container, zipFileName, createdAt, envelope_id, event, reason) (
-  SELECT container, zipFileName, createdAt, envelope_id, status, reason
+  SELECT container, zipFileName, createdAt, envelope_id::uuid, status, reason
   FROM envelope_state
 );
 

--- a/src/main/resources/db/migration/V005__Process_events.sql
+++ b/src/main/resources/db/migration/V005__Process_events.sql
@@ -12,6 +12,11 @@ CREATE INDEX process_events_container_zip_idx ON process_events (container, zipF
 CREATE INDEX process_events_container_event_idx ON process_events (container, event);
 CREATE INDEX process_events_zip_idx ON process_events (zipFileName);
 
+INSERT INTO process_events (container, zipFileName, createdAt, envelope_id, event, reason) (
+  SELECT container, zipFileName, createdAt, envelope_id, status, reason
+  FROM envelope_state
+);
+
 ALTER TABLE envelopes
   ADD COLUMN lastEvent VARCHAR(100) NOT NULL DEFAULT 'ENVELOPE_CREATED';
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Introduce envelope state](https://tools.hmcts.net/jira/browse/RPE-573)

### Change description ###

As discussed on Friday, the `envelope state` sort of introduces confusion to developers. Renaming the entity to `process event` as it is recording events during processing, hence `bulk_scan_processing`. Next PR will drop the retired table and default value in envelopes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
