### PR TITLE
 Integrated envelope controller with service auth

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -21,10 +21,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItemRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.DocumentManagementService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.BlobProcessorTask;
@@ -36,6 +39,7 @@ import java.net.URL;
 
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -152,6 +156,33 @@ public class EnvelopeControllerTest {
             .andExpect(content().string("{\"envelopes\":[]}"));
 
         verify(tokenValidator).getServiceName("testServiceAuthHeader");
+    }
+
+    @Test
+    public void should_throw_service_jurisdiction_config_not_found_exc_when_service_jurisdiction_mapping_is_not_found()
+        throws Exception {
+        given(tokenValidator.getServiceName("testServiceAuthHeader")).willReturn("test");
+
+        MvcResult result = this.mockMvc.perform(get("/envelopes")
+            .header("ServiceAuthorization", "testServiceAuthHeader"))
+            .andReturn();
+
+        assertThat(result.getResponse().getStatus()).isEqualTo(400);
+
+        assertThat(result.getResolvedException()).isInstanceOf(ServiceJuridictionConfigNotFoundException.class);
+
+        verify(tokenValidator).getServiceName("testServiceAuthHeader");
+    }
+
+    @Test
+    public void should_throw_unauthenticated_exception_when_service_auth_header_is_missing() throws Exception {
+        given(tokenValidator.getServiceName("testServiceAuthHeader")).willThrow(UnAuthenticatedException.class);
+
+        MvcResult result = this.mockMvc.perform(get("/envelopes")).andReturn();
+
+        assertThat(result.getResponse().getStatus()).isEqualTo(401);
+
+        assertThat(result.getResolvedException()).isInstanceOf(UnAuthenticatedException.class);
     }
 
     private String expectedEnvelopes() throws IOException {

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -4,3 +4,8 @@ spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDri
 spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/bulkscans
 
 flyway.noop.strategy=false
+
+mapping.servicesJurisdiction.test_service=SSCS
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+logging.level.org.hibernate.type=TRACE

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -6,6 +6,3 @@ spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/bulkscans
 flyway.noop.strategy=false
 
 mapping.servicesJurisdiction.test_service=SSCS
-logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-logging.level.org.hibernate.type=TRACE

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -6,3 +6,5 @@ spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/bulkscans
 flyway.noop.strategy=false
 
 mapping.servicesJurisdiction.test_service=SSCS
+
+idam.s2s-auth.url=false

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/AuthServiceConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/AuthServiceConfig.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.config;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +10,9 @@ import org.springframework.context.annotation.Lazy;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
+import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
+
+import java.util.List;
 
 @Configuration
 @Lazy
@@ -21,5 +26,23 @@ public class AuthServiceConfig {
         ServiceAuthorisationApi serviceAuthorisationApi
     ) {
         return AuthTokenGeneratorFactory.createDefaultGenerator(secret, name, serviceAuthorisationApi);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "idam.s2s-auth.url", havingValue = "false")
+    public AuthTokenValidator tokenValidatorStub() {
+        return new AuthTokenValidator() {
+            public void validate(String token) {
+                throw new NotImplementedException();
+            }
+
+            public void validate(String token, List<String> roles) {
+                throw new NotImplementedException();
+            }
+
+            public String getServiceName(String token) {
+                return "some_service_name";
+            }
+        };
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/AuthServiceConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/AuthServiceConfig.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
+import uk.gov.hmcts.reform.authorisation.validators.ServiceAuthTokenValidator;
 
 import java.util.List;
 
@@ -26,6 +27,12 @@ public class AuthServiceConfig {
         ServiceAuthorisationApi serviceAuthorisationApi
     ) {
         return AuthTokenGeneratorFactory.createDefaultGenerator(secret, name, serviceAuthorisationApi);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "idam.s2s-auth.url")
+    public AuthTokenValidator tokenValidator(ServiceAuthorisationApi s2sApi) {
+        return new ServiceAuthTokenValidator(s2sApi);
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceJurisdictionMappingConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceJurisdictionMappingConfig.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "mapping")
+public class ServiceJurisdictionMappingConfig {
+    private Map<String, String> servicesJurisdiction = new HashMap<>();
+
+    public Map<String, String> getServicesJurisdiction() {
+        return servicesJurisdiction;
+    }
+
+    public void setServicesJurisdiction(Map<String, String> servicesJurisdiction) {
+        this.servicesJurisdiction = servicesJurisdiction;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
@@ -4,9 +4,11 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeMetadataResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.AuthService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeRetrieverService;
 
 @RestController
@@ -14,17 +16,29 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeRetrieverService;
 public class EnvelopeController {
 
     private final EnvelopeRetrieverService envelopeRetrieverService;
+    private final AuthService authService;
 
-    public EnvelopeController(EnvelopeRetrieverService envelopeRetrieverService) {
+    public EnvelopeController(
+        EnvelopeRetrieverService envelopeRetrieverService,
+        AuthService authService
+    ) {
         this.envelopeRetrieverService = envelopeRetrieverService;
+        this.authService = authService;
     }
 
     @GetMapping
-    @ApiOperation(value = "Retrieves all envelopes", notes = "Returns an empty list when no envelopes were found")
+    @ApiOperation(
+        value = "Retrieves all envelopes for a given jurisdiction",
+        notes = "Returns an empty list when no envelopes were found"
+    )
     @ApiResponse(code = 200, message = "Success", response = EnvelopeMetadataResponse.class)
-    public EnvelopeMetadataResponse getEnvelopes() {
+    public EnvelopeMetadataResponse getEnvelopesByJurisdiction(
+        @RequestHeader(name = "ServiceAuthorization", required = false) String serviceAuthHeader
+    ) {
+        String serviceName = authService.authenticate(serviceAuthHeader);
+
         return new EnvelopeMetadataResponse(
-            envelopeRetrieverService.getAllEnvelopes()
+            envelopeRetrieverService.getAllEnvelopesForJurisdiction(serviceName)
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -2,7 +2,16 @@ package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
+
+    /**
+     * Finds envelopes for a given jurisdiction.
+     *
+     * @param jurisdiction jurisdiction for which envelopes needs to be retrieved
+     * @return A list of envelopes which belongs to the given jurisdiction.
+     */
+    List<Envelope> findByJurisdiction(String jurisdiction);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnableToGenerateSasTokenException;
 
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -28,6 +29,11 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
         return status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
+    @ExceptionHandler(UnAuthenticatedException.class)
+    protected ResponseEntity<String> handleUnAuthenticatedException(UnAuthenticatedException exc) {
+        log.error(exc.getMessage(), exc);
+        return status(HttpStatus.UNAUTHORIZED).build();
+    }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<Void> handleInternalException(Exception exception) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
@@ -38,7 +38,9 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(ServiceJuridictionConfigNotFoundException.class)
-    protected ResponseEntity<String> handleServiceJuridictionConfigNotFoundExceptionn(ServiceJuridictionConfigNotFoundException exc) {
+    protected ResponseEntity<String> handleServiceJuridictionConfigNotFoundException(
+        ServiceJuridictionConfigNotFoundException exc
+    ) {
         log.error(exc.getMessage(), exc);
         return status(BAD_REQUEST).build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnableToGenerateSasTokenException;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.ResponseEntity.status;
 
@@ -26,13 +28,19 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ServiceConfigNotFoundException.class)
     protected ResponseEntity<String> handleServiceConfigNotFoundException(ServiceConfigNotFoundException e) {
-        return status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        return status(BAD_REQUEST).body(e.getMessage());
     }
 
     @ExceptionHandler(UnAuthenticatedException.class)
     protected ResponseEntity<String> handleUnAuthenticatedException(UnAuthenticatedException exc) {
         log.error(exc.getMessage(), exc);
         return status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @ExceptionHandler(ServiceJuridictionConfigNotFoundException.class)
+    protected ResponseEntity<String> handleServiceJuridictionConfigNotFoundExceptionn(ServiceJuridictionConfigNotFoundException exc) {
+        log.error(exc.getMessage(), exc);
+        return status(BAD_REQUEST).build();
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ServiceJuridictionConfigNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ServiceJuridictionConfigNotFoundException.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class ServiceJuridictionConfigNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 6403249870901622284L;
+
+    public ServiceJuridictionConfigNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/UnAuthenticatedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/UnAuthenticatedException.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class UnAuthenticatedException extends RuntimeException {
+    private static final long serialVersionUID = -4672282254380424023L;
+
+    public UnAuthenticatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/AuthService.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
+
+@Component
+public class AuthService {
+
+    private final AuthTokenValidator authTokenValidator;
+
+    public AuthService(AuthTokenValidator authTokenValidator) {
+        this.authTokenValidator = authTokenValidator;
+    }
+
+    public String authenticate(String authHeader) {
+        if (authHeader == null) {
+            throw new UnAuthenticatedException("Missing ServiceAuthorization header");
+        } else {
+            return authTokenValidator.getServiceName(authHeader);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverService.java
@@ -2,26 +2,51 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.ServiceJurisdictionMappingConfig;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 
 import java.util.List;
 
 @Service
+@EnableConfigurationProperties(ServiceJurisdictionMappingConfig.class)
 public class EnvelopeRetrieverService {
 
     private static final Logger log = LoggerFactory.getLogger(EnvelopeRetrieverService.class);
 
     private final EnvelopeRepository envelopeRepository;
 
-    public EnvelopeRetrieverService(EnvelopeRepository envelopeRepository) {
+    private final ServiceJurisdictionMappingConfig serviceJurisdictionMappingConfig;
+
+    public EnvelopeRetrieverService(
+        EnvelopeRepository envelopeRepository,
+        ServiceJurisdictionMappingConfig serviceJurisdictionMappingConfig
+    ) {
         this.envelopeRepository = envelopeRepository;
+        this.serviceJurisdictionMappingConfig = serviceJurisdictionMappingConfig;
     }
 
-    public List<Envelope> getAllEnvelopes() {
-        log.info("Fetching all envelopes");
+    public List<Envelope> getAllEnvelopesForJurisdiction(String serviceName) {
+        String jurisdiction = getJurisdictionByServiceName(serviceName);
 
-        return envelopeRepository.findAll();
+        log.info("Fetching all envelopes for service {} and jurisdiction {}", serviceName, jurisdiction);
+
+        return envelopeRepository.findByJurisdiction(jurisdiction);
+    }
+
+    private String getJurisdictionByServiceName(String serviceName) {
+        String jurisdiction = serviceJurisdictionMappingConfig
+            .getServicesJurisdiction()
+            .getOrDefault(serviceName, null);
+
+        if (jurisdiction == null) {
+            throw new ServiceJuridictionConfigNotFoundException(
+                "No configuration mapping found for service " + serviceName
+            );
+        }
+        return jurisdiction;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,3 +66,7 @@ scheduling:
 
 scan:
   delay: ${SCAN_DELAY:30000} # In milliseconds
+
+mapping:
+  servicesJurisdiction:
+     sscs: SSCS

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/EnvelopeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/EnvelopeControllerTest.java
@@ -93,10 +93,12 @@ public class EnvelopeControllerTest {
     }
 
     @Test
-    public void should_throw_bad_request_when_service_jurisdiction_mapping_is_not_found_for_a_given_service() throws Exception {
+    public void should_throw_service_jurisdiction_config_not_found_exc_when_service_jurisdiction_mapping_is_not_found()
+        throws Exception {
         when(authService.authenticate("testServiceAuthHeader")).thenReturn("test");
 
-        when(envelopeRetrieverService.getAllEnvelopesForJurisdiction("test")).thenThrow(ServiceJuridictionConfigNotFoundException.class);
+        when(envelopeRetrieverService.getAllEnvelopesForJurisdiction("test"))
+            .thenThrow(ServiceJuridictionConfigNotFoundException.class);
 
         MvcResult result = this.mockMvc.perform(get("/envelopes")
             .header("ServiceAuthorization", "testServiceAuthHeader")).andReturn();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/EnvelopeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/EnvelopeControllerTest.java
@@ -13,12 +13,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.EnvelopeController;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.AuthService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeRetrieverService;
 
 import java.io.IOException;
 import java.net.URL;
-import java.sql.Timestamp;
 import java.util.List;
 
 import static com.google.common.io.Resources.getResource;
@@ -35,44 +36,63 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(EnvelopeController.class)
 public class EnvelopeControllerTest {
 
-    private static final Timestamp CURRENT_TIMESTAMP = new Timestamp(System.currentTimeMillis());
-
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private EnvelopeRetrieverService envelopeRetrieverService;
 
+    @MockBean
+    private AuthService authService;
+
     @Test
-    public void should_successfully_return_all_envelopes() throws Exception {
+    public void should_successfully_return_all_envelopes_for_a_given_jurisdiction() throws Exception {
         List<Envelope> envelopes = EnvelopeCreator.envelopes();
 
-        when(envelopeRetrieverService.getAllEnvelopes()).thenReturn(envelopes);
+        when(authService.authenticate("testServiceAuthHeader")).thenReturn("testServiceName");
+        when(envelopeRetrieverService.getAllEnvelopesForJurisdiction("testServiceName")).thenReturn(envelopes);
 
-
-        mockMvc.perform(get("/envelopes"))
+        mockMvc.perform(get("/envelopes")
+            .header("ServiceAuthorization", "testServiceAuthHeader"))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(content().json(expectedEnvelopes()));
 
-        verify(envelopeRetrieverService).getAllEnvelopes();
+        verify(envelopeRetrieverService).getAllEnvelopesForJurisdiction("testServiceName");
+        verify(authService).authenticate("testServiceAuthHeader");
     }
 
     @Test
     public void should_return_status_code_500_when_envelope_retrieval_throws_exception() throws Exception {
-        doThrow(new DataRetrievalFailureException("Cannot retrieve data"))
-            .when(envelopeRetrieverService).getAllEnvelopes();
+        when(authService.authenticate("testServiceAuthHeader")).thenReturn("testServiceName");
 
-        MvcResult result = this.mockMvc.perform(get("/envelopes")).andReturn();
+        doThrow(new DataRetrievalFailureException("Cannot retrieve data"))
+            .when(envelopeRetrieverService).getAllEnvelopesForJurisdiction("testServiceName");
+
+        MvcResult result = this.mockMvc.perform(get("/envelopes")
+            .header("ServiceAuthorization", "testServiceAuthHeader"))
+            .andReturn();
 
         assertThat(result.getResponse().getStatus()).isEqualTo(500);
 
         assertThat(result.getResolvedException().getMessage()).isEqualTo("Cannot retrieve data");
+
+        verify(authService).authenticate("testServiceAuthHeader");
+    }
+
+    @Test
+    public void should_throw_unauthenticated_exception_when_service_auth_header_is_missing() throws Exception {
+        when(authService.authenticate(null)).thenThrow(UnAuthenticatedException.class);
+
+        MvcResult result = this.mockMvc.perform(get("/envelopes")).andReturn();
+
+        assertThat(result.getResponse().getStatus()).isEqualTo(401);
+
+        assertThat(result.getResolvedException()).isInstanceOf(UnAuthenticatedException.class);
     }
 
     private String expectedEnvelopes() throws IOException {
         URL url = getResource("envelope.json");
         return Resources.toString(url, Charsets.toCharset("UTF-8"));
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/AuthServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/AuthServiceTest.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
+import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthServiceTest {
+
+    private static final String SERVICE_HEADER = "some-header";
+
+    @Mock
+    private AuthTokenValidator validator;
+
+    private AuthService service;
+
+    @Before
+    public void setUp() {
+        service = new AuthService(validator);
+    }
+
+    @After
+    public void tearDown() {
+        reset(validator);
+    }
+
+    @Test
+    public void should_throw_missing_header_exception_when_it_is_null() {
+        // when
+        Throwable exception = catchThrowable(() -> service.authenticate(null));
+
+        // then
+        assertThat(exception)
+            .isInstanceOf(UnAuthenticatedException.class)
+            .hasMessage("Missing ServiceAuthorization header");
+
+        // and
+        verify(validator, never()).getServiceName(anyString());
+    }
+
+    @Test
+    public void should_track_failure_in_service_dependency_when_invalid_token_received() {
+        // given
+        willThrow(InvalidTokenException.class).given(validator).getServiceName(anyString());
+
+        // when
+        Throwable exception = catchThrowable(() -> service.authenticate(SERVICE_HEADER));
+
+        // then
+        assertThat(exception).isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    public void should_track_successful_service_dependency_when_valid_token_received() {
+        // given
+        given(validator.getServiceName(SERVICE_HEADER)).willReturn("some-service");
+
+        // when
+        String serviceName = service.authenticate(SERVICE_HEADER);
+
+        // then
+        assertThat(serviceName).isEqualTo("some-service");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import com.microsoft.applicationinsights.core.dependencies.googlecommon.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.dao.DataRetrievalFailureException;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.ServiceJurisdictionMappingConfig;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
@@ -14,6 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -24,26 +27,39 @@ public class EnvelopeRetrieverServiceTest {
 
     private EnvelopeRetrieverService envelopeRetrieverService;
 
+    @Mock
+    private ServiceJurisdictionMappingConfig mappingConfig;
+
     @Before
     public void setUp() {
-        envelopeRetrieverService = new EnvelopeRetrieverService(envelopeRepository);
+        envelopeRetrieverService = new EnvelopeRetrieverService(envelopeRepository, mappingConfig);
     }
 
     @Test
-    public void should_return_all_envelopes_successfully() throws Exception {
+    public void should_return_all_envelopes_successfully_for_a_given_jurisdiction() throws Exception {
         List<Envelope> envelopes = EnvelopeCreator.envelopes();
 
-        when(envelopeRepository.findAll()).thenReturn(envelopes);
+        when(mappingConfig.getServicesJurisdiction()).thenReturn(ImmutableMap.of("testService", "testJurisdiction"));
 
-        assertThat(envelopeRetrieverService.getAllEnvelopes()).containsOnly(envelopes.get(0));
+        when(envelopeRepository.findByJurisdiction("testJurisdiction")).thenReturn(envelopes);
+
+        assertThat(envelopeRetrieverService.getAllEnvelopesForJurisdiction("testService"))
+            .containsOnly(envelopes.get(0));
+
+        verify(mappingConfig).getServicesJurisdiction();
+        verify(envelopeRepository).findByJurisdiction("testJurisdiction");
     }
 
     @Test
     public void should_throw_data_retrieval_failure_exception_when_repository_fails_to_retrieve_envelopes() {
-        when(envelopeRepository.findAll()).thenThrow(DataRetrievalFailureException.class);
+        when(mappingConfig.getServicesJurisdiction()).thenReturn(ImmutableMap.of("testService", "testJurisdiction"));
+        when(envelopeRepository.findByJurisdiction("testJurisdiction")).thenThrow(DataRetrievalFailureException.class);
 
-        Throwable throwable = catchThrowable(() -> envelopeRetrieverService.getAllEnvelopes());
+        Throwable throwable = catchThrowable(() ->
+            envelopeRetrieverService.getAllEnvelopesForJurisdiction("testService"));
 
         assertThat(throwable).isInstanceOf(DataRetrievalFailureException.class);
+
+        verify(mappingConfig).getServicesJurisdiction();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-563

### Change description ###

- This PR integrates envelope retrieval with s2s.

- Using s2s service name we would retrieve jurisdiction based on the configuration mapping between service name and jurisdiction.

- Updated unit and integration tests.

- Functional tests would be in a separate PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```