### PR TITLE
Updated blob task to mark envelope as processed after blob deletion

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -340,7 +340,7 @@ public class BlobProcessorTaskTest {
             .header("ServiceAuthorization", "testServiceAuthHeader"))
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.envelopes[0].last_event", is("DOC_UPLOAD_FAILURE")));
+            .andExpect(jsonPath("$.envelopes[0].last_event", is(DOC_UPLOAD_FAILURE.toString())));
 
         //Check events created
         List<Event> actualEvents = processEventRepository.findAll().stream()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Event.java
@@ -5,5 +5,6 @@ public enum Event {
     ENVELOPE_CREATED,
     DOC_FAILURE, // generic failure while processing zip file. before uploading to document management
     DOC_UPLOADED,
-    DOC_UPLOAD_FAILURE
+    DOC_UPLOAD_FAILURE,
+    DOC_PROCESSED // when blob is successfully deleted after storing all docs in DM
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -117,6 +117,8 @@ public class BlobProcessorTask {
             envelopeProcessor.markAsUploaded(envelope, container.getName(), zipFilename);
 
             cloudBlockBlob.delete();
+
+            envelopeProcessor.markAsProcessed(envelope, container.getName(), zipFilename);
         } catch (Exception exception) {
             markAsFailed(isUploadFailure, container.getName(), zipFilename, exception.getMessage(), envelope);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
@@ -75,16 +75,15 @@ public class EnvelopeProcessor {
         Envelope envelope,
         String containerName,
         String zipFileName,
-        Event docProcessed
+        Event event
     ) {
-        ProcessEvent event = new ProcessEvent(containerName, zipFileName, docProcessed);
+        ProcessEvent processEvent = new ProcessEvent(containerName, zipFileName, event);
 
-        event.setEnvelope(envelope);
-        event.setReason(reason);
+        processEvent.setEnvelope(envelope);
+        processEvent.setReason(reason);
+        processEventRepository.save(processEvent);
 
-        processEventRepository.save(event);
-
-        envelope.setLastEvent(docProcessed);
+        envelope.setLastEvent(event);
         envelopeRepository.save(envelope);
     }
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-563


### Change description ###

- Added method to mark envelope status as doc_processed and create new event in events table.

- Refactored code to extract common code to a separate method to avoid duplication.

- Updated integration tests for blob processor tasks to verify envelope status and event creation.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```