### PR TITLE
Fix SonarCloud: use try-with-resources

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/document/InMemoryMultipartFile.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/document/InMemoryMultipartFile.java
@@ -79,7 +79,9 @@ public class InMemoryMultipartFile implements MultipartFile {
 
     @Override
     public void transferTo(File dest) throws IOException, IllegalStateException {
-        new FileOutputStream(dest).write(payload);
+        try (FileOutputStream stream = new FileOutputStream(dest)) {
+            stream.write(payload);
+        }
     }
 
     @Override


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
