### PR TITLE
[SKIP-PREVIEW] Adjust pmd ruleset

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -10,6 +10,7 @@
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor"/>
     <exclude name="LocalVariableCouldBeFinal"/>
+    <exclude name="MethodArgumentCouldBeFinal" />
   </rule>
   <rule ref="category/java/codestyle.xml/MethodNamingConventions">
     <properties>
@@ -26,6 +27,7 @@
     <exclude name="UseUtilityClass"/>
     <exclude name="LawOfDemeter"/><!-- does not apply to hmcts code style -->
     <exclude name="LoosePackageCoupling"/>
+    <exclude name="DataClass" />
   </rule>
   <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
     <properties>


### PR DESCRIPTION
Currently this repo has 524 (sic!) issues on Codacy.

Excluding 2 rules that I don't think are necessary:
- https://pmd.github.io/pmd-6.5.0/pmd_rules_java_codestyle.html#methodargumentcouldbefinal
Just a pain to put `final` on every method parameter
- https://pmd.github.io/pmd-6.5.0/pmd_rules_java_design.html#dataclass
Nothing wrong with data classes IMHO. In fact it's a *feature* in some modern languages.