### PR TITLE
Fix checkstyle dtd schema url

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style


### PR DESCRIPTION
I was getting errors running checkstyle locally.

Found fix here:
https://discuss.gradle.org/t/checkstyle-plugin-suncertpathbuilderexception/27394

New URL taken from latest google ruleset:
https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10.1/src/main/resources/google_checks.xml