### PR TITLE
Fix an envelope deletion test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -75,10 +75,10 @@ public class EnvelopeDeletionTest {
         uploadZipFile(srcZipFilename, destZipFilename); // invalid due to missing json file
 
         // ensure that processing has happened
-        await()
-            .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
-            .pollDelay(scanDelay * 2, TimeUnit.MILLISECONDS)
-            .until(() -> storageHasFile(destZipFilename), is(true));
+        // TODO: replace with a polling-based solution
+        Thread.sleep(scanDelay + 15_000);
+
+        assertThat(storageHasFile(destZipFilename)).isTrue();
 
         testContainer.getBlockBlobReference(destZipFilename).delete();
         assertThat(storageHasFile(destZipFilename)).isFalse();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -62,6 +62,7 @@ public class EnvelopeDeletionTest {
 
         await()
             .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
+            .pollInterval(1, TimeUnit.SECONDS)
             .until(() -> storageHasFile(destZipFilename), is(false));
         assertThat(storageHasFile(destZipFilename)).isFalse();
     }


### PR DESCRIPTION
### Change description ###

- Fix an always-passing tests that didn't wait for processing
- Set a polling interval in a test to 1 second (default is 100 ms)
- Make sure blobs are deleted after tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
