### PR TITLE
Add endpoint for making updates to envelope status

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
@@ -65,10 +65,13 @@ public class EnvelopeController {
     ) {
         String serviceName = authService.authenticate(serviceAuthHeader);
 
+        // TODO: move to service
         switch (statusUpdate.status) {
             case CONSUMED:
                 envelopeUpdateService.markAsConsumed(id, serviceName);
                 break;
+            default:
+                throw new IllegalStateException("No code for handling status: " + statusUpdate.status);
         }
 
         return noContent().build();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
@@ -3,26 +3,39 @@ package uk.gov.hmcts.reform.bulkscanprocessor.controllers;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.in.StatusUpdate;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeMetadataResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.AuthService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeRetrieverService;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeUpdateService;
+
+import java.util.UUID;
+
+import static org.springframework.http.ResponseEntity.noContent;
 
 @RestController
 @RequestMapping(path = "envelopes", produces = MediaType.APPLICATION_JSON_VALUE)
 public class EnvelopeController {
 
     private final EnvelopeRetrieverService envelopeRetrieverService;
+    private final EnvelopeUpdateService envelopeUpdateService;
     private final AuthService authService;
 
     public EnvelopeController(
         EnvelopeRetrieverService envelopeRetrieverService,
+        EnvelopeUpdateService envelopeUpdateService,
         AuthService authService
     ) {
         this.envelopeRetrieverService = envelopeRetrieverService;
+        this.envelopeUpdateService = envelopeUpdateService;
         this.authService = authService;
     }
 
@@ -40,5 +53,24 @@ public class EnvelopeController {
         return new EnvelopeMetadataResponse(
             envelopeRetrieverService.getProcessedEnvelopesByJurisdiction(serviceName)
         );
+    }
+
+    @PutMapping(path = "/{id}/status")
+    @ApiOperation("Updates the status of given envelope")
+    @ApiResponse(code = 204, message = "Envelope updated")
+    public ResponseEntity<Void> updateStatus(
+        @PathVariable UUID id,
+        @RequestBody StatusUpdate statusUpdate,
+        @RequestHeader(name = "ServiceAuthorization", required = false) String serviceAuthHeader
+    ) {
+        String serviceName = authService.authenticate(serviceAuthHeader);
+
+        switch (statusUpdate.status) {
+            case CONSUMED:
+                envelopeUpdateService.markAsConsumed(id, serviceName);
+                break;
+        }
+
+        return noContent().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ResponseExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.EnvelopeNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidStatusChangeException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
@@ -43,6 +45,18 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
     ) {
         log.error(exc.getMessage(), exc);
         return status(BAD_REQUEST).build();
+    }
+
+    @ExceptionHandler(EnvelopeNotFoundException.class)
+    protected ResponseEntity<String> handleEnvelopeNotFound(EnvelopeNotFoundException exc) {
+        log.error(exc.getMessage(), exc);
+        return status(HttpStatus.NOT_FOUND).build();
+    }
+
+    @ExceptionHandler(InvalidStatusChangeException.class)
+    protected ResponseEntity<String> handleInvalidStatusChange(InvalidStatusChangeException exc) {
+        log.error(exc.getMessage(), exc);
+        return status(HttpStatus.FORBIDDEN).body(exc.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/in/NewStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/in/NewStatus.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.model.in;
+
+public enum NewStatus {
+    CONSUMED,
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/in/StatusUpdate.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/in/StatusUpdate.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.model.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StatusUpdate {
+
+    public final NewStatus status;
+
+    public StatusUpdate(
+        @JsonProperty("status") NewStatus status
+    ) {
+        this.status = status;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadEnvelopesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadEnvelopesControllerTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.AuthService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeRetrieverService;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeUpdateService;
 
 import java.io.IOException;
 import java.net.URL;
@@ -42,6 +43,9 @@ public class ReadEnvelopesControllerTest {
 
     @MockBean
     private EnvelopeRetrieverService envelopeRetrieverService;
+
+    @MockBean
+    private EnvelopeUpdateService envelopeUpdateService; //NOPMD
 
     @MockBean
     private AuthService authService;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadEnvelopesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadEnvelopesControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(EnvelopeController.class)
-public class EnvelopeControllerTest {
+public class ReadEnvelopesControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/UpdateStatusEnvelopesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/UpdateStatusEnvelopesControllerTest.java
@@ -1,0 +1,121 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controller;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.bulkscanprocessor.controllers.EnvelopeController;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.EnvelopeNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidStatusChangeException;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.AuthService;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeRetrieverService;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeUpdateService;
+
+import java.util.UUID;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(EnvelopeController.class)
+public class UpdateStatusEnvelopesControllerTest {
+
+    @MockBean private EnvelopeRetrieverService readService; //NOPMD
+    @MockBean private EnvelopeUpdateService updateService;
+    @MockBean private AuthService authService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final static String VALID_STATUS_UPDATE_REQ_BODY = "{\"status\": \"CONSUMED\"}";
+
+    @Test
+    public void should_return_400_if_new_status_is_invalid() throws Exception {
+        // when
+        MockHttpServletResponse res = sendUpdate("{\"status\": \"something_stupid\"}");
+
+        // then
+        assertThat(res.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    public void should_return_404_if_envelope_does_not_exist() throws Exception {
+        // given
+        UUID id = randomUUID();
+
+        doThrow(EnvelopeNotFoundException.class)
+            .when(updateService)
+            .markAsConsumed(eq(id), any());
+
+        // when
+        MockHttpServletResponse res = sendUpdate(id, VALID_STATUS_UPDATE_REQ_BODY);
+
+        // then
+        assertThat(res.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    public void should_return_204_if_envelope_was_updated_successfully() throws Exception {
+        // given
+        // no exception are thrown by services used
+
+        // when
+        MockHttpServletResponse res = sendUpdate(VALID_STATUS_UPDATE_REQ_BODY);
+
+        // then
+        assertThat(res.getStatus()).isEqualTo(204);
+    }
+
+    @Test
+    public void should_return_401_if_service_is_not_authenticated() throws Exception {
+        // given
+        doThrow(EnvelopeNotFoundException.class)
+            .when(authService)
+            .authenticate(any());
+
+        // when
+        MockHttpServletResponse res = sendUpdate(VALID_STATUS_UPDATE_REQ_BODY);
+
+        // then
+        assertThat(res.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    public void should_return_403_if_given_status_transition_is_not_allowed() throws Exception {
+        // given
+        doThrow(InvalidStatusChangeException.class)
+            .when(updateService)
+            .markAsConsumed(any(), any());
+
+        // when
+        MockHttpServletResponse res = sendUpdate(VALID_STATUS_UPDATE_REQ_BODY);
+
+        // then
+        assertThat(res.getStatus()).isEqualTo(403);
+    }
+
+    private MockHttpServletResponse sendUpdate(String body) throws Exception {
+        return sendUpdate(randomUUID(), body);
+    }
+
+    private MockHttpServletResponse sendUpdate(UUID id, String body) throws Exception {
+        return mockMvc
+            .perform(
+                put("/envelopes/" + id + "/status")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body)
+            )
+            .andReturn()
+            .getResponse();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/UpdateStatusEnvelopesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/UpdateStatusEnvelopesControllerTest.java
@@ -37,7 +37,7 @@ public class UpdateStatusEnvelopesControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    private final static String VALID_STATUS_UPDATE_REQ_BODY = "{\"status\": \"CONSUMED\"}";
+    private static final String VALID_STATUS_UPDATE_REQ_BODY = "{\"status\": \"CONSUMED\"}";
 
     @Test
     public void should_return_400_if_new_status_is_invalid() throws Exception {


### PR DESCRIPTION
plus unit tests.

integration and functional tests to come in next PR(s).

using `envelopes/{id}/status` route as suggested by Neil during planning 
(just `envelopes/{id}` would imply that this endpoint expects an entire envelope payload)