### PR TITLE
[PREVIEW]Enable senstive flag for blob storage account name and key

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -19,10 +19,12 @@ output "TEST_SCAN_DELAY" {
 }
 
 output "TEST_STORAGE_ACCOUNT_NAME" {
+  sensitive = true
   value = "${azurerm_storage_account.provider.name}"
 }
 
 output "TEST_STORAGE_ACCOUNT_KEY" {
+  sensitive = true
   value = "${azurerm_storage_account.provider.primary_access_key}"
 }
 


### PR DESCRIPTION
In Jenkins we will output will be as below 
```
10:59:12 TEST_STORAGE_ACCOUNT_KEY = <sensitive>
10:59:12 TEST_STORAGE_ACCOUNT_NAME = <sensitive>

```