### PR TITLE
Single point of usage of envelope access service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
@@ -21,6 +21,12 @@ public class EnvelopeAccessService {
         this.mappings = accessProps.getMappings();
     }
 
+    /**
+     * Giving the service name check which jurisdiction it is allowed to access and return it.
+     *
+     * @param serviceName accessing the API
+     * @return configured jurisdiction
+     */
     public String getJurisdictionByServiceName(String serviceName) {
         return mappings
             .stream()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
@@ -2,18 +2,20 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
 public class EnvelopeAccessService {
 
-    private final EnvelopeAccessProperties access;
+    private final List<Mapping> mappings;
 
     public EnvelopeAccessService(EnvelopeAccessProperties accessProps) {
-        this.access = accessProps;
+        this.mappings = accessProps.getMappings();
     }
 
     /**
@@ -23,12 +25,11 @@ public class EnvelopeAccessService {
      */
     public void assertCanUpdate(String envelopeJurisdiction, String serviceName) {
         String serviceThanCanUpdateEnvelope =
-            access
-                .getMappings()
+            mappings
                 .stream()
                 .filter(m -> Objects.equals(m.getJurisdiction(), envelopeJurisdiction))
                 .findFirst()
-                .map(m -> m.getUpdateService())
+                .map(Mapping::getUpdateService)
                 .orElseThrow(() -> new ServiceConfigNotFoundException(
                     "No service configuration found to update envelopes in jurisdiction: " + envelopeJurisdiction
                 ));

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
@@ -32,7 +32,7 @@ public class EnvelopeAccessService {
             .stream()
             .filter(m -> Objects.equals(m.getReadService(), serviceName))
             .findFirst()
-            .map(Mapping::getJurisdiction)
+            .map(m -> m.getJurisdiction())
             .orElseThrow(() ->
                 new ServiceJuridictionConfigNotFoundException(
                     "No configuration mapping found for service " + serviceName
@@ -50,7 +50,7 @@ public class EnvelopeAccessService {
             .stream()
             .filter(m -> Objects.equals(m.getJurisdiction(), envelopeJurisdiction))
             .findFirst()
-            .map(Mapping::getUpdateService)
+            .map(m -> m.getUpdateService())
             .orElseThrow(() -> new ServiceConfigNotFoundException(
                 "No service configuration found to update envelopes in jurisdiction: " + envelopeJurisdiction
             ));

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
@@ -1,21 +1,37 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 
 import java.util.List;
 import java.util.Objects;
 
 @Service
+@EnableConfigurationProperties(EnvelopeAccessProperties.class)
 public class EnvelopeAccessService {
 
     private final List<Mapping> mappings;
 
     public EnvelopeAccessService(EnvelopeAccessProperties accessProps) {
         this.mappings = accessProps.getMappings();
+    }
+
+    public String getJurisdictionByServiceName(String serviceName) {
+        return mappings
+            .stream()
+            .filter(m -> Objects.equals(m.getReadService(), serviceName))
+            .findFirst()
+            .map(Mapping::getJurisdiction)
+            .orElseThrow(() ->
+                new ServiceJuridictionConfigNotFoundException(
+                    "No configuration mapping found for service " + serviceName
+                )
+            );
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
@@ -40,15 +40,14 @@ public class EnvelopeAccessService {
      * or configuration for the jurisdiction is not found.
      */
     public void assertCanUpdate(String envelopeJurisdiction, String serviceName) {
-        String serviceThanCanUpdateEnvelope =
-            mappings
-                .stream()
-                .filter(m -> Objects.equals(m.getJurisdiction(), envelopeJurisdiction))
-                .findFirst()
-                .map(Mapping::getUpdateService)
-                .orElseThrow(() -> new ServiceConfigNotFoundException(
-                    "No service configuration found to update envelopes in jurisdiction: " + envelopeJurisdiction
-                ));
+        String serviceThanCanUpdateEnvelope = mappings
+            .stream()
+            .filter(m -> Objects.equals(m.getJurisdiction(), envelopeJurisdiction))
+            .findFirst()
+            .map(Mapping::getUpdateService)
+            .orElseThrow(() -> new ServiceConfigNotFoundException(
+                "No service configuration found to update envelopes in jurisdiction: " + envelopeJurisdiction
+            ));
 
         if (!serviceThanCanUpdateEnvelope.equals(serviceName)) {
             throw new ForbiddenException(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverService.java
@@ -2,56 +2,37 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 
 import java.util.List;
-import java.util.Objects;
 
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.PROCESSED;
 
 @Service
-@EnableConfigurationProperties(EnvelopeAccessProperties.class)
 public class EnvelopeRetrieverService {
 
     private static final Logger log = LoggerFactory.getLogger(EnvelopeRetrieverService.class);
 
     private final EnvelopeRepository envelopeRepository;
-    private final EnvelopeAccessProperties envelopeAccessProperties;
+    private final EnvelopeAccessService envelopeAccessService;
 
     public EnvelopeRetrieverService(
         EnvelopeRepository envelopeRepository,
-        EnvelopeAccessProperties envelopeAccessProperties
+        EnvelopeAccessService envelopeAccessService
     ) {
         this.envelopeRepository = envelopeRepository;
-        this.envelopeAccessProperties = envelopeAccessProperties;
+        this.envelopeAccessService = envelopeAccessService;
     }
 
     public List<Envelope> getProcessedEnvelopesByJurisdiction(final String serviceName) {
         log.info("Fetch requested for envelopes for service {}", serviceName);
 
-        String jurisdiction = getJurisdictionByServiceName(serviceName);
+        String jurisdiction = envelopeAccessService.getJurisdictionByServiceName(serviceName);
 
         log.info("Fetching all processed envelopes for service {} and jurisdiction {}", serviceName, jurisdiction);
 
         return envelopeRepository.findByJurisdictionAndStatus(jurisdiction, PROCESSED);
-    }
-
-    private String getJurisdictionByServiceName(String serviceName) {
-        return envelopeAccessProperties
-            .getMappings()
-            .stream()
-            .filter(m -> Objects.equals(m.getReadService(), serviceName))
-            .findFirst()
-            .map(m -> m.getJurisdiction())
-            .orElseThrow(() ->
-                new ServiceJuridictionConfigNotFoundException(
-                    "No configuration mapping found for service " + serviceName
-                )
-            );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeStatusChangeValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeStatusChangeValidator.java
@@ -25,10 +25,9 @@ public class EnvelopeStatusChangeValidator {
      * Checks whether it's legal to transition from given status to another.
      */
     public void assertCanUpdate(Status from, Status to) {
-        boolean ok =
-            allowedTransitions
-                .getOrDefault(from, emptyList())
-                .contains(to);
+        boolean ok = allowedTransitions
+            .getOrDefault(from, emptyList())
+            .contains(to);
 
         if (!ok) {
             throw new InvalidStatusChangeException("Cannot change from status " + from + " to status " + to);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateService.java
@@ -47,7 +47,7 @@ public class EnvelopeUpdateService {
         Envelope envelope =
             envelopeRepo
                 .findById(envelopeId)
-                .orElseThrow(() -> new EnvelopeNotFoundException());
+                .orElseThrow(EnvelopeNotFoundException::new);
 
         accessService.assertCanUpdate(envelope.getJurisdiction(), serviceName);
         statusChangeValidator.assertCanUpdate(envelope.getStatus(), newStatus);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateService.java
@@ -47,7 +47,7 @@ public class EnvelopeUpdateService {
         Envelope envelope =
             envelopeRepo
                 .findById(envelopeId)
-                .orElseThrow(EnvelopeNotFoundException::new);
+                .orElseThrow(() -> new EnvelopeNotFoundException());
 
         accessService.assertCanUpdate(envelope.getJurisdiction(), serviceName);
         statusChangeValidator.assertCanUpdate(envelope.getStatus(), newStatus);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
@@ -2,10 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
@@ -15,22 +11,17 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@RunWith(MockitoJUnitRunner.class)
 public class EnvelopeAccessServiceTest {
-
-    @Mock
-    private EnvelopeAccessProperties accessProps;
 
     private EnvelopeAccessService service;
 
     @Before
     public void setUp() {
-        BDDMockito
-            .given(accessProps.getMappings())
-            .willReturn(asList(
-                new Mapping("jur_A", "read_A", "update_A"),
-                new Mapping("jur_B", "read_B", "update_B")
-            ));
+        EnvelopeAccessProperties accessProps = new EnvelopeAccessProperties();
+        accessProps.setMappings(asList(
+            new Mapping("jur_A", "read_A", "update_A"),
+            new Mapping("jur_B", "read_B", "update_B")
+        ));
 
         this.service = new EnvelopeAccessService(accessProps);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
@@ -24,15 +24,15 @@ public class EnvelopeAccessServiceTest {
     private EnvelopeAccessService service;
 
     @Before
-    public void setUp() throws Exception {
-        this.service = new EnvelopeAccessService(accessProps);
-
+    public void setUp() {
         BDDMockito
             .given(accessProps.getMappings())
             .willReturn(asList(
                 new Mapping("jur_A", "read_A", "update_A"),
                 new Mapping("jur_B", "read_B", "update_B")
             ));
+
+        this.service = new EnvelopeAccessService(accessProps);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -27,15 +26,8 @@ public class EnvelopeRetrieverServiceTest {
     @Mock
     private EnvelopeRepository envelopeRepository;
 
-    private EnvelopeRetrieverService envelopeRetrieverService;
-
     @Mock
     private EnvelopeAccessProperties envelopeAccess;
-
-    @Before
-    public void setUp() {
-        envelopeRetrieverService = new EnvelopeRetrieverService(envelopeRepository, envelopeAccess);
-    }
 
     @Test
     public void should_return_all_envelopes_successfully_for_a_given_jurisdiction() throws Exception {
@@ -46,6 +38,8 @@ public class EnvelopeRetrieverServiceTest {
 
         when(envelopeRepository.findByJurisdictionAndStatus("testJurisdiction", PROCESSED))
             .thenReturn(envelopes);
+
+        EnvelopeRetrieverService envelopeRetrieverService = getRetrieverService();
 
         assertThat(envelopeRetrieverService.getProcessedEnvelopesByJurisdiction("testService"))
             .containsOnly(envelopes.get(0));
@@ -61,9 +55,15 @@ public class EnvelopeRetrieverServiceTest {
         when(envelopeRepository.findByJurisdictionAndStatus("testJurisdiction", PROCESSED))
             .thenThrow(DataRetrievalFailureException.class);
 
+        EnvelopeRetrieverService envelopeRetrieverService = getRetrieverService();
+
         Throwable throwable = catchThrowable(() ->
             envelopeRetrieverService.getProcessedEnvelopesByJurisdiction("testService"));
 
         assertThat(throwable).isInstanceOf(DataRetrievalFailureException.class);
+    }
+
+    private EnvelopeRetrieverService getRetrieverService() {
+        return new EnvelopeRetrieverService(envelopeRepository, new EnvelopeAccessService(envelopeAccess));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -26,20 +27,24 @@ public class EnvelopeRetrieverServiceTest {
     @Mock
     private EnvelopeRepository envelopeRepository;
 
-    @Mock
-    private EnvelopeAccessProperties envelopeAccess;
+    private EnvelopeRetrieverService envelopeRetrieverService;
+
+    @Before
+    public void setUp() {
+        EnvelopeAccessProperties accessProps = new EnvelopeAccessProperties();
+        accessProps.setMappings(
+            singletonList(new Mapping("testJurisdiction", "testService", "testService"))
+        );
+        EnvelopeAccessService envelopeAccess = new EnvelopeAccessService(accessProps);
+        envelopeRetrieverService = new EnvelopeRetrieverService(envelopeRepository, envelopeAccess);
+    }
 
     @Test
     public void should_return_all_envelopes_successfully_for_a_given_jurisdiction() throws Exception {
         List<Envelope> envelopes = EnvelopeCreator.envelopes();
 
-        when(envelopeAccess.getMappings())
-            .thenReturn(singletonList(new Mapping("testJurisdiction", "testService", "testService")));
-
         when(envelopeRepository.findByJurisdictionAndStatus("testJurisdiction", PROCESSED))
             .thenReturn(envelopes);
-
-        EnvelopeRetrieverService envelopeRetrieverService = getRetrieverService();
 
         assertThat(envelopeRetrieverService.getProcessedEnvelopesByJurisdiction("testService"))
             .containsOnly(envelopes.get(0));
@@ -49,21 +54,12 @@ public class EnvelopeRetrieverServiceTest {
 
     @Test
     public void should_throw_data_retrieval_failure_exception_when_repository_fails_to_retrieve_envelopes() {
-        when(envelopeAccess.getMappings())
-            .thenReturn(singletonList(new Mapping("testJurisdiction", "testService", "testService")));
-
         when(envelopeRepository.findByJurisdictionAndStatus("testJurisdiction", PROCESSED))
             .thenThrow(DataRetrievalFailureException.class);
-
-        EnvelopeRetrieverService envelopeRetrieverService = getRetrieverService();
 
         Throwable throwable = catchThrowable(() ->
             envelopeRetrieverService.getProcessedEnvelopesByJurisdiction("testService"));
 
         assertThat(throwable).isInstanceOf(DataRetrievalFailureException.class);
-    }
-
-    private EnvelopeRetrieverService getRetrieverService() {
-        return new EnvelopeRetrieverService(envelopeRepository, new EnvelopeAccessService(envelopeAccess));
     }
 }


### PR DESCRIPTION
### Change description ###

Envelope access related code was used in envelope retriever service. This piece of functionality got separate implementation since #63 

Summary:

- Reducing access config property inclusion down to single place
- Reformatting code indentation as short variable names where unnecessary put to knew line making consequent lines extra indented
- Made code by reference easier to apply/read rather than _trivial_ lambda function
- Fix unit tests using mocks of config properties

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
