### PR TITLE
Feature: failed upload task

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -37,4 +37,12 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
         @Param("zip") String zipFileName,
         @Param("status") Status status
     );
+
+    /**
+     * Finds first 20 envelopes for a given status.
+     *
+     * @param status to filter upon
+     * @return A list of envelopes
+     */
+    List<Envelope> findFirst20ByStatus(Status status);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
@@ -24,7 +24,7 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
      * @param container from where container originated
      * @param zipFileName of envelope
      * @param status of envelope
-     * @return Optional envelope
+     * @return A singleton list of envelope
      */
     @Query("select e from Envelope e"
         + " where e.container = :container"
@@ -32,10 +32,11 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
         + "   and e.status = :status"
         + " order by e.createdAt desc"
     )
-    Optional<Envelope> checkLastEnvelopeStatus(
+    List<Envelope> checkLastEnvelopeStatus(
         @Param("container") String container,
         @Param("zip") String zipFileName,
-        @Param("status") Status status
+        @Param("status") Status status,
+        Pageable pageable
     );
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -60,7 +60,7 @@ public class BlobProcessorTask {
     }
 
     @SchedulerLock(name = "blobProcessor")
-    @Scheduled(fixedDelayString = "${scan.delay}")
+    @Scheduled(fixedDelayString = "${scheduling.task.scan.delay}")
     public void processBlobs() throws IOException, StorageException, URISyntaxException {
         for (CloudBlobContainer container : cloudBlobClient.listContainers()) {
             processZipFiles(container);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import net.javacrumbs.shedlock.core.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.wrapper.ErrorHandlingWrapper;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This class is a task executed by Scheduler as per configured interval.
+ * It will read all the blobs from Azure Blob storage and will do below things
+ * 1. Reads Blob from container.
+ * 2. Extract Zip file(Blob)
+ * 3. Transform metadata json to DB entities.
+ * 4. Save PDF files in document storage.
+ * 5. Update status and doc urls in DB.
+ */
+@Component
+@ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
+public class ReuploadFailedEnvelopeTask {
+
+    private static final Logger log = LoggerFactory.getLogger(ReuploadFailedEnvelopeTask.class);
+
+    private final CloudBlobClient cloudBlobClient;
+    private final DocumentProcessor documentProcessor;
+    private final EnvelopeProcessor envelopeProcessor;
+    private final ErrorHandlingWrapper errorWrapper;
+
+    public ReuploadFailedEnvelopeTask(
+        CloudBlobClient cloudBlobClient,
+        DocumentProcessor documentProcessor,
+        EnvelopeProcessor envelopeProcessor,
+        ErrorHandlingWrapper errorWrapper
+    ) {
+        this.cloudBlobClient = cloudBlobClient;
+        this.documentProcessor = documentProcessor;
+        this.envelopeProcessor = envelopeProcessor;
+        this.errorWrapper = errorWrapper;
+    }
+
+    @SchedulerLock(name = "re-upload-failures")
+    @Scheduled(fixedDelayString = "${scheduling.task.reupload.delay}")
+    public void processUploadFailures() {
+        Map<String, List<Envelope>> envelopes = envelopeProcessor.getFailedToUploadEnvelopes()
+            .stream()
+            .collect(Collectors.groupingBy(Envelope::getContainer));
+
+        envelopes.forEach(this::processEnvelopes);
+    }
+
+    private void processEnvelopes(String containerName, List<Envelope> envelopes) {
+        log.info("Processing {} failed documents for container {}", envelopes.size(), containerName);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.util.EntityParser;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -64,6 +65,10 @@ public class EnvelopeProcessor {
         );
 
         return dbEnvelope;
+    }
+
+    public List<Envelope> getFailedToUploadEnvelopes() {
+        return envelopeRepository.findFirst20ByStatus(UPLOAD_FAILURE);
     }
 
     public void markAsUploaded(Envelope envelope) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,9 +65,9 @@ scheduling:
   enabled: ${SCHEDULING_ENABLED:false}
   pool: ${SCHEDULING_POOL:10}
   lock_at_most_for: ${SCHEDULING_LOCK_AT_MOST_FOR:PT10M} # 10 minutes in ISO-8601
-
-scan:
-  delay: ${SCAN_DELAY:30000} # In milliseconds
+  task:
+    scan:
+      delay: ${SCAN_DELAY:30000} # In milliseconds
 
 envelope-access:
   mappings:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,8 @@ scheduling:
   task:
     scan:
       delay: ${SCAN_DELAY:30000} # In milliseconds
+    reupload:
+      delay: ${REUPLOAD_DELAY:1800000} # In milliseconds, 30min
 
 envelope-access:
   mappings:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.rule.OutputCapture;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.wrapper.ErrorHandlingWrapper;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReuploadFailedEnvelopeTaskTest {
+
+    @Rule
+    public OutputCapture outputCapture = new OutputCapture();
+
+    @Mock
+    private DocumentProcessor documentProcessor;
+
+    @Mock
+    private EnvelopeProcessor envelopeProcessor;
+
+    @Mock
+    private ErrorHandlingWrapper errorWrapper;
+
+    private ReuploadFailedEnvelopeTask task;
+
+    @Before
+    public void setUp() {
+        task = new ReuploadFailedEnvelopeTask(
+            null,
+            documentProcessor,
+            envelopeProcessor,
+            errorWrapper
+        );
+    }
+
+    @After
+    public void tearDown() {
+        outputCapture.flush();
+    }
+
+    @Test
+    public void should_log_how_many_envelopes_processing_for_which_container() throws Exception {
+        // given
+        Envelope testEnvelope = EnvelopeCreator.envelope();
+        testEnvelope.setContainer("test");
+        Envelope dummyEnvelope = EnvelopeCreator.envelope();
+        dummyEnvelope.setContainer("dummy");
+
+        // and
+        List<Envelope> envelopes = Stream.concat(
+            Collections.nCopies(3, testEnvelope).stream(),
+            Collections.nCopies(2, dummyEnvelope).stream()
+        ).collect(Collectors.toList());
+
+        given(envelopeProcessor.getFailedToUploadEnvelopes()).willReturn(envelopes);
+
+        // when
+        task.processUploadFailures();
+
+        // then
+        assertThat(outputCapture.toString())
+            .containsPattern("Processing 3 failed documents for container test")
+            .containsPattern("Processing 2 failed documents for container dummy");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automated exception handling for failed documents](https://tools.hmcts.net/jira/browse/RPE-562)

### Change description ###

Getting first 20 failed envelopes and processing them in batches grouped by container for easier implementation.

Bonus: as per discussion with @luigibk, [Apply limit to the query](https://github.com/hmcts/bulk-scan-processor/commit/c67832f9e28985532ff547ce86be8cb2670b1aa3) contains desired improvement which did not work out in previous #93 as `Optional<>` does not apply limit. Even with `Pageable`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
