### PR TITLE
Feature: failed upload task

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,5 +1,5 @@
 vault_section = "preprod"
 capacity = "2"
 scan_delay = "4000"
-scheduling_enabled = true
+scan_enabled = true
 api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,5 +1,7 @@
 vault_section = "preprod"
 capacity = "2"
+reupload_delay = "4000"
+reupload_enabled = true
 scan_delay = "4000"
 scan_enabled = true
 api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,4 +1,5 @@
 token_validity = "5184000" #60 days in seconds
 vault_section = "preprod"
+reupload_enabled = true
 scan_enabled = true
 api_gateway_test_valid_certificate_thumbprint = "FD81389707E12B53FA723D62BDA792B4F36AEBF1"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,4 +1,4 @@
 token_validity = "5184000" #60 days in seconds
 vault_section = "preprod"
-scheduling_enabled = true
+scan_enabled = true
 api_gateway_test_valid_certificate_thumbprint = "FD81389707E12B53FA723D62BDA792B4F36AEBF1"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -91,8 +91,8 @@ module "bulk-scan" {
     S2S_NAME                      = "${var.s2s_name}"
     S2S_SECRET                    = "${data.vault_generic_secret.s2s_secret.data["value"]}"
 
-    SCHEDULING_ENABLED            = "${var.scheduling_enabled}"
     SCAN_DELAY                    = "${var.scan_delay}"
+    SCAN_ENABLED                  = "${var.scan_enabled}"
     // silence the "bad implementation" logs
     LOGBACK_REQUIRE_ALERT_LEVEL   = false
     LOGBACK_REQUIRE_ERROR_CODE    = false

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -91,6 +91,9 @@ module "bulk-scan" {
     S2S_NAME                      = "${var.s2s_name}"
     S2S_SECRET                    = "${data.vault_generic_secret.s2s_secret.data["value"]}"
 
+    REUPLOAD_BATCH                = "${var.reupload_batch}"
+    REUPLOAD_DELAY                = "${var.reupload_delay}"
+    REUPLOAD_ENABLED              = "${var.reupload_enabled}"
     SCAN_DELAY                    = "${var.scan_delay}"
     SCAN_ENABLED                  = "${var.scan_enabled}"
     // silence the "bad implementation" logs

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -14,6 +14,10 @@ output "microserviceName" {
   value = "${var.component}"
 }
 
+outpu "TEST_REUPLOAD_DELAY" {
+  value = "${var.reupload_delay}"
+}
+
 output "TEST_SCAN_DELAY" {
   value = "${var.scan_delay}"
 }

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,3 +1,5 @@
 vault_section = "preprod"
+reupload_enabled = true
+reupload_delay = "4000"
 scan_enabled = true
 scan_delay = "4000"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,3 +1,3 @@
 vault_section = "preprod"
-scheduling_enabled = true
+scan_enabled = true
 scan_delay = "4000"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -66,6 +66,18 @@ variable "common_tags" {
   type = "map"
 }
 
+variable "reupload_batch" {
+  default = "20"
+}
+
+variable "reupload_delay" {
+  default = "1800000"  # In milliseconds
+}
+
+variable "reupload_enabled" {
+  default = "false"
+}
+
 variable "scan_delay" {
   default = "30000"  # In milliseconds
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -66,12 +66,12 @@ variable "common_tags" {
   type = "map"
 }
 
-variable "scheduling_enabled" {
-  default = "false"
-}
-
 variable "scan_delay" {
   default = "30000"  # In milliseconds
+}
+
+variable "scan_enabled" {
+  default = "false"
 }
 
 # list of SSL client certificate thumbprints that are accepted by the API (gateway)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -86,6 +87,9 @@ public class EnvelopeControllerTest {
     @Autowired
     private ErrorHandlingWrapper errorWrapper;
 
+    @Value("${scheduling.task.reupload.batch}")
+    private int reUploadBatchSize;
+
     @Mock
     private DocumentManagementService documentManagementService;
 
@@ -110,7 +114,8 @@ public class EnvelopeControllerTest {
 
         envelopeProcessor = new EnvelopeProcessor(
             envelopeRepository,
-            processEventRepository
+            processEventRepository,
+            reUploadBatchSize
         );
 
         blobProcessorTask = new BlobProcessorTask(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/WhenRunningTheApplicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/WhenRunningTheApplicationTest.java
@@ -36,7 +36,10 @@ public class WhenRunningTheApplicationTest {
         waitForBlobProcessor();
         ArgumentCaptor<LockConfiguration> configCaptor = ArgumentCaptor.forClass(LockConfiguration.class);
         verify(lockProvider, atLeastOnce()).lock(configCaptor.capture());
-        assertThat(configCaptor.getValue().getName()).isEqualTo("blobProcessor");
+        assertThat(configCaptor.getAllValues()).extracting("name").containsOnly(
+            "blobProcessor",
+            "re-upload-failures"
+        );
     }
 
     private void waitForBlobProcessor() {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/WhenRunningTheApplicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/WhenRunningTheApplicationTest.java
@@ -22,7 +22,8 @@ import static org.mockito.Mockito.verify;
 
 @SpringBootTest(
     properties = {
-        "scheduling.enabled=true"
+        "scheduling.task.scan.enabled=true",
+        "scheduling.task.reupload.enabled=true"
     }
 )
 @RunWith(SpringRunner.class)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTestSuite.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItemRepository;
@@ -54,6 +55,9 @@ public abstract class BlobProcessorTestSuite {
     @Autowired
     private ScannableItemRepository scannableItemRepository;
 
+    @Value("${scheduling.task.reupload.batch}")
+    private int reUploadBatchSize;
+
     @Mock
     DocumentManagementService documentManagementService;
 
@@ -71,7 +75,8 @@ public abstract class BlobProcessorTestSuite {
 
         EnvelopeProcessor envelopeProcessor = new EnvelopeProcessor(
             envelopeRepository,
-            processEventRepository
+            processEventRepository,
+            reUploadBatchSize
         );
 
         blobProcessorTask = new BlobProcessorTask(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.palantir.docker.compose.DockerComposeRule;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +30,11 @@ import static org.mockito.BDDMockito.willThrow;
 })
 @RunWith(SpringRunner.class)
 public class ReuploadFailedEnvelopeTaskTest {
+
+    @ClassRule
+    public static DockerComposeRule docker = DockerComposeRule.builder()
+        .file("src/integrationTest/resources/docker-compose.yml")
+        .build();
 
     @Rule
     public OutputCapture outputCapture = new OutputCapture();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.FailedDocUploadProcessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+    "scheduling.task.reupload.enabled=true"
+})
+@RunWith(SpringRunner.class)
+public class ReuploadFailedEnvelopeTaskTest {
+
+    @Autowired
+    private ReuploadFailedEnvelopeTask task;
+
+    @SpyBean
+    private FailedDocUploadProcessor processor;
+
+    @Test
+    public void should_return_new_instance_of_processor_when_rerequesting_via_lookup_method() {
+        // comparing instance hashes. .hashCode() just returns same one
+        assertThat(task.getProcessor().toString()).isNotEqualTo(task.getProcessor().toString());
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
@@ -23,7 +23,7 @@ import java.security.InvalidKeyException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(properties = {
     "scheduling.task.reupload.enabled=true"
@@ -59,9 +59,8 @@ public class ReuploadFailedEnvelopeTaskTest {
     @Test
     public void should_await_for_all_futures_even_if_their_code_throw_exception() throws Exception {
         // given
-        willThrow(JpaObjectRetrievalFailureException.class)
-            .given(envelopeProcessor)
-            .getFailedToUploadEnvelopes(anyString());
+        given(envelopeProcessor.getFailedToUploadEnvelopes(anyString()))
+            .willThrow(JpaObjectRetrievalFailureException.class);
 
         // when
         task.processUploadFailures();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -43,4 +43,18 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
         @Param("status") Status status,
         Pageable pageable
     );
+
+    /**
+     * Finds first N envelopes for a given status as per defined page request.
+     *
+     * @param jurisdiction to filter upon
+     * @param status to filter upon
+     * @param pageable limit of data to be processed by consumer
+     * @return A list of envelopes
+     */
+    List<Envelope> findByJurisdictionAndStatusOrderByCreatedAtAsc(
+        String jurisdiction,
+        Status status,
+        Pageable pageable
+    );
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -58,7 +58,7 @@ public class BlobProcessorTask {
     }
 
     @SchedulerLock(name = "blobProcessor")
-    @Scheduled(fixedDelayString = "${scan.delay}")
+    @Scheduled(fixedDelayString = "${scheduling.task.scan.delay}")
     public void processBlobs() throws IOException, StorageException, URISyntaxException {
         for (CloudBlobContainer container : cloudBlobClient.listContainers()) {
             processZipFiles(container);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -27,12 +27,14 @@ import java.util.zip.ZipInputStream;
 
 /**
  * This class is a task executed by Scheduler as per configured interval.
- * It will read all the blobs from Azure Blob storage and will do below things
- * 1. Reads Blob from container.
- * 2. Extract Zip file(Blob)
- * 3. Transform metadata json to DB entities.
- * 4. Save PDF files in document storage.
- * 5. Update status and doc urls in DB.
+ * It will read all the blobs from Azure Blob storage and will do below things:
+ * <ol>
+ *     <li>Read Blob from container</li>
+ *     <li>Extract Zip file (blob)</li>
+ *     <li>Transform metadata json to DB entities</li>
+ *     <li>Save PDF files in document storage</li>
+ *     <li>Update status and doc urls in DB</li>
+ * </ol>
  */
 @Component
 @ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -37,7 +37,7 @@ import java.util.zip.ZipInputStream;
  * </ol>
  */
 @Component
-@ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "scheduling.task.scan.enabled", matchIfMissing = true)
 public class BlobProcessorTask {
 
     private static final Logger log = LoggerFactory.getLogger(BlobProcessorTask.class);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -90,7 +90,9 @@ public class ReuploadFailedEnvelopeTask {
 
                 future.cancel(true);
 
-                Thread.currentThread().interrupt();
+                if (exception instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             } finally {
                 completed++;
             }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -43,6 +43,11 @@ public class ReuploadFailedEnvelopeTask {
         this.accessMapping = accessProperties.getMappings();
     }
 
+    /**
+     * Spring overrides the {@code @Lookup} method and returns new instance of returned object.
+     *
+     * @return Instance of {@code FailedDocUploadProcessor}
+     */
     @Lookup
     public FailedDocUploadProcessor getProcessor() {
         return null;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -1,0 +1,100 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.netflix.servo.util.ThreadFactories;
+import net.javacrumbs.shedlock.core.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.FailedDocUploadProcessor;
+
+import java.util.List;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * This class is a task executed by Scheduler as per configured interval.
+ * It will retrieve failed to upload envelopes from DB and try to re-upload.
+ * <ol>
+ *     <li>Get batch of failed to upload envelopes</li>
+ *     <li>Retrieve relevant zip file from Blob Storage</li>
+ *     <li>Try to upload pdfs</li>
+ * </ol>
+ */
+@Component
+@ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(EnvelopeAccessProperties.class)
+public class ReuploadFailedEnvelopeTask {
+
+    private static final Logger log = LoggerFactory.getLogger(ReuploadFailedEnvelopeTask.class);
+
+    private final List<Mapping> accessMapping;
+
+    private final int poolSize;
+
+    public ReuploadFailedEnvelopeTask(
+        EnvelopeAccessProperties accessProperties,
+        TaskScheduler taskScheduler
+    ) {
+        this.accessMapping = accessProperties.getMappings();
+        poolSize = Math.max(((ThreadPoolTaskScheduler) taskScheduler).getPoolSize(), accessMapping.size());
+    }
+
+    @Lookup
+    public FailedDocUploadProcessor getProcessor() {
+        return null;
+    }
+
+    @SchedulerLock(name = "re-upload-failures")
+    @Scheduled(fixedDelayString = "${scheduling.task.reupload.delay}")
+    public void processUploadFailures() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(
+            poolSize,
+            ThreadFactories.withName("BSP-REUPLOAD-%d")
+        );
+        CompletionService<Void> completionService = new ExecutorCompletionService<>(executorService);
+
+        for (Mapping mapping : accessMapping) {
+            FailedDocUploadProcessor processor = getProcessor();
+
+            completionService.submit(() -> {
+                log.info("Processing failed documents for jurisdiction {}", mapping.getJurisdiction());
+
+                processor.processJurisdiction(mapping.getJurisdiction());
+
+                return null;
+            });
+        }
+
+        awaitCompletion(completionService);
+    }
+
+    private void awaitCompletion(CompletionService<Void> completionService) throws InterruptedException {
+        int completed = 0;
+
+        while (completed < accessMapping.size()) {
+            Future<Void> future = completionService.take(); // blocks if none available
+
+            try {
+                future.get(); // waits if necessary
+            } catch (InterruptedException | ExecutionException exception) {
+                log.error(exception.getMessage(), exception);
+
+                future.cancel(true);
+            } finally {
+                completed++;
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -92,6 +92,8 @@ public class ReuploadFailedEnvelopeTask {
                 log.error(exception.getMessage(), exception);
 
                 future.cancel(true);
+
+                Thread.currentThread().interrupt();
             } finally {
                 completed++;
             }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -44,7 +44,7 @@ public class ReuploadFailedEnvelopeTask {
     }
 
     /**
-     * Spring overrides the {@code @Lookup} method and returns new instance of returned object.
+     * Spring overrides the {@code @Lookup} method and returns an instance of bean.
      *
      * @return Instance of {@code FailedDocUploadProcessor}
      */

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Future;
  * </ol>
  */
 @Component
-@ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "scheduling.task.reupload.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(EnvelopeAccessProperties.class)
 public class ReuploadFailedEnvelopeTask {
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -7,9 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Lookup;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
@@ -41,14 +39,8 @@ public class ReuploadFailedEnvelopeTask {
 
     private final List<Mapping> accessMapping;
 
-    private final int poolSize;
-
-    public ReuploadFailedEnvelopeTask(
-        EnvelopeAccessProperties accessProperties,
-        TaskScheduler taskScheduler
-    ) {
+    public ReuploadFailedEnvelopeTask(EnvelopeAccessProperties accessProperties) {
         this.accessMapping = accessProperties.getMappings();
-        poolSize = Math.max(((ThreadPoolTaskScheduler) taskScheduler).getPoolSize(), accessMapping.size());
     }
 
     @Lookup
@@ -60,7 +52,7 @@ public class ReuploadFailedEnvelopeTask {
     @Scheduled(fixedDelayString = "${scheduling.task.reupload.delay}")
     public void processUploadFailures() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(
-            poolSize,
+            accessMapping.size(),
             ThreadFactories.withName("BSP-REUPLOAD-%d")
         );
         CompletionService<Void> completionService = new ExecutorCompletionService<>(executorService);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
+
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.wrapper.ErrorHandlingWrapper;
+
+import java.util.List;
+
+@Component
+public class FailedDocUploadProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(FailedDocUploadProcessor.class);
+
+    private final CloudBlobClient cloudBlobClient;
+    private final DocumentProcessor documentProcessor;
+    private final EnvelopeProcessor envelopeProcessor;
+    private final ErrorHandlingWrapper errorWrapper;
+
+    public FailedDocUploadProcessor(
+        CloudBlobClient cloudBlobClient,
+        DocumentProcessor documentProcessor,
+        EnvelopeProcessor envelopeProcessor,
+        ErrorHandlingWrapper errorWrapper
+    ) {
+        this.cloudBlobClient = cloudBlobClient;
+        this.documentProcessor = documentProcessor;
+        this.envelopeProcessor = envelopeProcessor;
+        this.errorWrapper = errorWrapper;
+    }
+
+    public void processJurisdiction(String jurisdiction) {
+        List<Envelope> envelopes = envelopeProcessor.getFailedToUploadEnvelopes(jurisdiction);
+
+        if (envelopes.size() > 0) {
+            String containerName = envelopes.get(0).getContainer();
+
+            processEnvelopes(containerName, envelopes);
+        }
+    }
+
+    private void processEnvelopes(String containerName, List<Envelope> envelopes) {
+        log.info("Processing {} failed documents for container {}", envelopes.size(), containerName);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
@@ -3,6 +3,9 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.wrapper.ErrorHandlingWrapper;
@@ -10,6 +13,10 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.wrapper.ErrorHandlingWrapp
 import java.util.List;
 
 @Component
+@Scope(
+    value = ConfigurableBeanFactory.SCOPE_PROTOTYPE, // every other call to return bean will create new instance
+    proxyMode = ScopedProxyMode.TARGET_CLASS // allows prototyping
+)
 public class FailedDocUploadProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(FailedDocUploadProcessor.class);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,9 @@ scheduling:
   task:
     scan:
       delay: ${SCAN_DELAY:30000} # In milliseconds
+    reupload:
+      delay: ${REUPLOAD_DELAY:1800000} # In milliseconds, 30min
+      batch: ${REUPLOAD_BATCH:20} # fetch 20 envelopes at once to process them. 0 for all
 
 envelope-access:
   mappings:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,15 +62,16 @@ dm:
     url: ${DOCUMENT_MANAGEMENT_URL:http://localhost:8082}
 
 scheduling:
-  enabled: ${SCHEDULING_ENABLED:false}
   pool: ${SCHEDULING_POOL:10}
   lock_at_most_for: ${SCHEDULING_LOCK_AT_MOST_FOR:PT10M} # 10 minutes in ISO-8601
   task:
     scan:
       delay: ${SCAN_DELAY:30000} # In milliseconds
+      enabled: ${SCAN_ENABLED:false}
     reupload:
-      delay: ${REUPLOAD_DELAY:1800000} # In milliseconds, 30min
       batch: ${REUPLOAD_BATCH:20} # fetch 20 envelopes at once to process them. 0 for all
+      delay: ${REUPLOAD_DELAY:1800000} # In milliseconds, 30min
+      enabled: ${REUPLOAD_ENABLED:false}
 
 envelope-access:
   mappings:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,9 +65,9 @@ scheduling:
   enabled: ${SCHEDULING_ENABLED:false}
   pool: ${SCHEDULING_POOL:10}
   lock_at_most_for: ${SCHEDULING_LOCK_AT_MOST_FOR:PT10M} # 10 minutes in ISO-8601
-
-scan:
-  delay: ${SCAN_DELAY:30000} # In milliseconds
+  task:
+    scan:
+      delay: ${SCAN_DELAY:30000} # In milliseconds
 
 envelope-access:
   mappings:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.rule.OutputCapture;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.wrapper.ErrorHandlingWrapper;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FailedDocUploadProcessorTest {
+
+    @Rule
+    public OutputCapture outputCapture = new OutputCapture();
+
+    @Mock
+    private DocumentProcessor documentProcessor;
+
+    @Mock
+    private EnvelopeProcessor envelopeProcessor;
+
+    @Mock
+    private ErrorHandlingWrapper errorWrapper;
+
+    private FailedDocUploadProcessor processor;
+
+    @Before
+    public void setUp() {
+        processor = new FailedDocUploadProcessor(
+            null,
+            documentProcessor,
+            envelopeProcessor,
+            errorWrapper
+        );
+    }
+
+    @After
+    public void tearDown() {
+        outputCapture.flush();
+    }
+
+    @Test
+    public void should_log_how_many_envelopes_processing_for_which_container() throws Exception {
+        // given
+        Envelope testEnvelope = EnvelopeCreator.envelope();
+        testEnvelope.setContainer("test");
+        List<Envelope> envelopes = Collections.nCopies(3, testEnvelope);
+
+        // and
+        given(envelopeProcessor.getFailedToUploadEnvelopes("test")).willReturn(envelopes);
+
+        // when
+        processor.processJurisdiction("test");
+
+        // then
+        assertThat(outputCapture.toString()).containsPattern("Processing 3 failed documents for container test");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automated exception handling for failed documents](https://tools.hmcts.net/jira/browse/RPE-562)

### Change description ###

Core set up of new scheduler task handling failed documents in an efficient way:

- Designate available thread pool size by choosing ~between maximum available from task scheduler and actual~ configured jurisdictions
- Instantiate processor prototype separately per jurisdiction so as per cloud blob storage.

Further implementation is coming later leaving this PR as an entry point.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
