### PR TITLE
[PREVIEW] Update functional test to use the new read envelopes endpoint

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -86,7 +86,7 @@ public class BlobProcessorTest {
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
 
         EnvelopeMetadataResponse envelopeMetadataResponse =
-            testHelper.getAllProcessedEnvelopesMetadata(this.testUrl, s2sToken);
+            testHelper.getEnvelopes(this.testUrl, s2sToken, Status.PROCESSED);
 
         // some test DBs are not cleaned so there will probably be more than 1
         assertThat(envelopeMetadataResponse.envelopes.size()).isGreaterThanOrEqualTo(1);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
@@ -131,23 +131,24 @@ public class TestHelper {
         return outputStream.toByteArray();
     }
 
-    public EnvelopeMetadataResponse getAllProcessedEnvelopesMetadata(String baseUrl, String s2sToken) {
-        Response response = getAllProcessedEnvelopesResponse(baseUrl, s2sToken);
+    public EnvelopeMetadataResponse getEnvelopes(String baseUrl, String s2sToken, Status status) {
+        String url = status == null ? "/envelopes" : "/envelopes?status=" + status;
+
+        Response response =
+            RestAssured
+                .given()
+                .relaxedHTTPSValidation()
+                .baseUri(baseUrl)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header("ServiceAuthorization", "Bearer " + s2sToken)
+                .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Bulk Scan Processor smoke test")
+                .when()
+                .get(url)
+                .andReturn();
+
         assertThat(response.getStatusCode()).isEqualTo(200);
 
         return response.getBody().as(EnvelopeMetadataResponse.class, ObjectMapperType.JACKSON_2);
-    }
-
-    public Response getAllProcessedEnvelopesResponse(String baseUrl, String s2sToken) {
-        return RestAssured
-            .given()
-            .relaxedHTTPSValidation()
-            .baseUri(baseUrl)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("ServiceAuthorization", "Bearer " + s2sToken)
-            .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Bulk Scan Processor smoke test")
-            .when().get("/envelopes?status=" + Status.PROCESSED)
-            .andReturn();
     }
 
     public void updateEnvelopeStatus(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +72,7 @@ public class UpdateStatusTest {
         // find our envelope
         UUID envelopeId =
             testHelper
-                .getAllProcessedEnvelopesMetadata(this.testUrl, s2sToken)
+                .getEnvelopes(this.testUrl, s2sToken, Status.PROCESSED)
                 .envelopes
                 .stream()
                 .filter(e -> Objects.equals(e.getZipFileName(), destZipFilename))
@@ -88,20 +87,19 @@ public class UpdateStatusTest {
             Status.CONSUMED
         );
 
-
-        List<Envelope> envelopesAfterUpdate =
+        // TODO: update when an endpoint for reading single envelope by ID is available.
+        Envelope envelopeAfterUpdate =
             testHelper
-                .getAllProcessedEnvelopesMetadata(this.testUrl, s2sToken)
-                .envelopes;
-
-        // currently read endpoint returns only envelopes in status 'PROCESSED'
-        // change this once we can read all envelopes (or single envelope by ID)
-        assertThat(
-            envelopesAfterUpdate.stream()
+                .getEnvelopes(this.testUrl, s2sToken, Status.CONSUMED)
+                .envelopes
+                .stream()
                 .filter(e -> e.getId() == envelopeId)
                 .findFirst()
-        )
-            .as("Envelope should no longer be on a list of PROCESSED envelopes")
-            .isEmpty();
+                .get();
+
+        assertThat(envelopeAfterUpdate.getStatus())
+            .as("Envelope should have status " + Status.CONSUMED)
+            .isEqualTo(Status.CONSUMED);
+
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
@@ -93,7 +93,7 @@ public class UpdateStatusTest {
                 .getEnvelopes(this.testUrl, s2sToken, Status.CONSUMED)
                 .envelopes
                 .stream()
-                .filter(e -> e.getId() == envelopeId)
+                .filter(e -> e.getId().equals(envelopeId))
                 .findFirst()
                 .get();
 

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscanprocessor/WhenApplicationDeployedTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscanprocessor/WhenApplicationDeployedTest.java
@@ -1,16 +1,16 @@
 package uk.gov.hmcts.reform.bulkscanprocessor;
 
 import io.restassured.RestAssured;
-import io.restassured.response.Response;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.TestHelper;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.logging.appinsights.SyntheticHeaders;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.not;
 
@@ -47,8 +47,9 @@ public class WhenApplicationDeployedTest {
         TestHelper testHelper = new TestHelper();
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
 
-        Response response = testHelper.getAllProcessedEnvelopesResponse(this.testUrl, s2sToken);
-        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThatCode(() ->
+            testHelper.getEnvelopes(this.testUrl, s2sToken, Status.PROCESSED)
+        ).doesNotThrowAnyException();
     }
 
 }


### PR DESCRIPTION
instead of just asserting envelope is no longer on the list of 'processed' envelopes we can now actually check that it is in the correct status after making an update.