### PR TITLE
Rename read endpoint methods and model

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.util.ObjectUtils;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeMetadataResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeListResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
 
 import java.util.Arrays;
@@ -85,18 +85,18 @@ public class BlobProcessorTest {
 
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
 
-        EnvelopeMetadataResponse envelopeMetadataResponse =
+        EnvelopeListResponse envelopeListResponse =
             testHelper.getAllProcessedEnvelopesMetadata(this.testUrl, s2sToken);
 
         // some test DBs are not cleaned so there will probably be more than 1
-        assertThat(envelopeMetadataResponse.envelopes.size()).isGreaterThanOrEqualTo(1);
+        assertThat(envelopeListResponse.envelopes.size()).isGreaterThanOrEqualTo(1);
 
-        assertThat(envelopeMetadataResponse.envelopes)
+        assertThat(envelopeListResponse.envelopes)
             .extracting("zipFileName", "status")
             .containsOnlyOnce(tuple(destZipFilename, Status.PROCESSED));
 
 
-        List<EnvelopeResponse> envelopes = envelopeMetadataResponse.envelopes
+        List<EnvelopeResponse> envelopes = envelopeListResponse.envelopes
             .stream()
             .filter(e -> destZipFilename.equals(e.getZipFileName()))
             .collect(Collectors.toList());

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
@@ -15,7 +15,7 @@ import io.restassured.response.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeMetadataResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeListResponse;
 import uk.gov.hmcts.reform.logging.appinsights.SyntheticHeaders;
 
 import java.io.ByteArrayOutputStream;
@@ -131,11 +131,11 @@ public class TestHelper {
         return outputStream.toByteArray();
     }
 
-    public EnvelopeMetadataResponse getAllProcessedEnvelopesMetadata(String baseUrl, String s2sToken) {
+    public EnvelopeListResponse getAllProcessedEnvelopesMetadata(String baseUrl, String s2sToken) {
         Response response = getAllProcessedEnvelopesResponse(baseUrl, s2sToken);
         assertThat(response.getStatusCode()).isEqualTo(200);
 
-        return response.getBody().as(EnvelopeMetadataResponse.class, ObjectMapperType.JACKSON_2);
+        return response.getBody().as(EnvelopeListResponse.class, ObjectMapperType.JACKSON_2);
     }
 
     public Response getAllProcessedEnvelopesResponse(String baseUrl, String s2sToken) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.in.StatusUpdate;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeMetadataResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeListResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.AuthService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeRetrieverService;
@@ -45,11 +45,11 @@ public class EnvelopeController {
 
     @GetMapping
     @ApiOperation(
-        value = "Retrieves all envelopes with processed status for a given jurisdiction",
+        value = "Retrieves all envelopes",
         notes = "Returns an empty list when no envelopes were found"
     )
-    @ApiResponse(code = 200, message = "Success", response = EnvelopeMetadataResponse.class)
-    public EnvelopeMetadataResponse getProcessedEnvelopesByJurisdiction(
+    @ApiResponse(code = 200, message = "Success", response = EnvelopeListResponse.class)
+    public EnvelopeListResponse getAll(
         @RequestHeader(name = "ServiceAuthorization", required = false) String serviceAuthHeader,
         @RequestParam(name = "status", required = false) Status status
     ) {
@@ -57,7 +57,7 @@ public class EnvelopeController {
 
         List<EnvelopeResponse> envelopes = envelopeRetrieverService.findByServiceAndStatus(serviceName, status);
 
-        return new EnvelopeMetadataResponse(envelopes);
+        return new EnvelopeListResponse(envelopes);
     }
 
     @PutMapping(path = "/{id}/status")

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/EnvelopeListResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/EnvelopeListResponse.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public class EnvelopeMetadataResponse {
+public class EnvelopeListResponse {
 
     @JsonProperty("envelopes")
     public final List<EnvelopeResponse> envelopes;
 
     @JsonCreator
-    public EnvelopeMetadataResponse(@JsonProperty("envelopes") List<EnvelopeResponse> envelopes) {
+    public EnvelopeListResponse(@JsonProperty("envelopes") List<EnvelopeResponse> envelopes) {
         this.envelopes = envelopes;
     }
 }


### PR DESCRIPTION
Follow up on recent PR making `GET /envelopes` return **all** envelopes, not just processed ones.

Changes:
- renamed controller action from `getProcessedEnvelopesByJurisdiction` to `getAll`
- renamed model from `EnvelopeMetadata` (which suggests it's single envelope) to `EnvelopeList`
- updated swagger spec description
