### PR TITLE
Adjust pmd ruleset

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -38,7 +38,9 @@
     <exclude name="CommentRequired"/>
     <exclude name="CommentSize"/>
   </rule>
-  <rule ref="category/java/errorprone.xml"/>
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="BeanMembersShouldSerialize"/>
+  </rule>
   <rule ref="category/java/multithreading.xml"/>
   <rule ref="category/java/performance.xml"/>
   <rule ref="category/java/security.xml"/>


### PR DESCRIPTION
Exclude the following rule:
https://pmd.github.io/pmd-6.5.0/pmd_rules_java_errorprone.html#beanmembersshouldserialize

This is especially a pain in tests, it requires adding `transient` keyword for all class fields....

Will reduce number of issues on Codacy quite a bit.