### PR TITLE
[PREVIEW] Update Azure Storage dependency to v8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ def versions = [
 dependencies {
   compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '1.0.0'
   compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '1.0.0'
-  compile group: 'com.microsoft.azure', name: 'azure-storage', version: '7.0.0'
+  compile group: 'com.microsoft.azure', name: 'azure-storage', version: '8.0.0'
 
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
@@ -73,7 +73,7 @@ public class GetSasTokenTest {
         Date tokenExpiry = DateUtil.parseDatetime(queryParams.get("se")[0]);
         assertThat(tokenExpiry).isNotNull();
         assertThat(queryParams.get("sig")).isNotNull(); //this is a generated hash of the resource string
-        assertThat(queryParams.get("sv")).contains("2017-07-29"); //azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2018-03-28"); //azure api version is latest
         assertThat(queryParams.get("sp")).contains("wl"); //access permissions(write-w,list-l)
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
@@ -45,7 +45,7 @@ public class SasTokenControllerTest {
 
         assertThat(queryParams.get("sig")).isNotNull();//this is a generated hash of the resource string
         assertThat(queryParams.get("se")[0]).startsWith(currentDate);//the expiry date/time for the signature
-        assertThat(queryParams.get("sv")).contains("2017-07-29");//azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2018-03-28");//azure api version is latest
         assertThat(queryParams.get("sp")).contains("wl");//access permissions(write-w,list-l)
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
@@ -52,7 +52,7 @@ public class SasTokenGeneratorServiceTest {
 
         assertThat(queryParams.get("sig")).isNotNull();//this is a generated hash of the resource string
         assertThat(queryParams.get("se")[0]).startsWith(currentDate);//the expiry date/time for the signature
-        assertThat(queryParams.get("sv")).contains("2017-07-29");//azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2018-03-28");//azure api version is latest
         assertThat(queryParams.get("sp")).contains("wl");//access permissions(write-w,list-l)
     }
 


### PR DESCRIPTION
### Change description ###

The following update was left behind for a reason. It is most core element of the processor. By checking the release and the fact we are fast developing this service suggests it is more than safe to update it. Notes of the version jump:

- library uses java 8
- fixes internal dependency of jackson which is being constanly reported by snyk
- adds more sdk methods which we were not using anyway
- follows up latest rest specs which we not use directly anyway

Spinning up preview environment so to assure functionality is still intact

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
