### PR TITLE
Output full stack trace on integration or functional test exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ tasks.withType(JavaCompile) {
 task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
   testClassesDirs = sourceSets.functionalTest.output.classesDirs
   classpath = sourceSets.functionalTest.runtimeClasspath
+
+  testLogging {
+    exceptionFormat = 'full'
+  }
 }
 
 task integration(type: Test, description: 'Runs the integration tests.', group: 'Verification') {
@@ -70,6 +74,10 @@ task integration(type: Test, description: 'Runs the integration tests.', group: 
 
   // set your environment variables here
    environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
+
+  testLogging {
+    exceptionFormat = 'full'
+  }
 }
 
 task smoke(type: Test) {
@@ -253,4 +261,3 @@ test {
     exceptionFormat = 'full'
   }
 }
-


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Output full stack trace in case of exception in integration or functional test. This should help solve issues such as intermittent docker failures in jenkins build. Currently for these failures we get only the 1st line of the stack trace.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
