### PR TITLE
Move read permission checks to single service

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverTest.java
@@ -8,8 +8,6 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
-import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
@@ -17,7 +15,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
 
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
@@ -27,13 +24,13 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envel
 public class EnvelopeRetrieverTest {
 
     @Autowired private EnvelopeRepository envelopeRepo;
-    @Mock EnvelopeAccessProperties accessProperties;
+    @Mock EnvelopeAccessService accessService;
 
     private EnvelopeRetrieverService service;
 
     @Before
     public void setUp() throws Exception {
-        this.service = new EnvelopeRetrieverService(envelopeRepo, accessProperties);
+        this.service = new EnvelopeRetrieverService(envelopeRepo, accessService);
     }
 
     @Test
@@ -115,7 +112,7 @@ public class EnvelopeRetrieverTest {
     }
 
     private void serviceCanReadFromJurisdiction(String serviceName, String jurisdiction) {
-        given(this.accessProperties.getMappings())
-            .willReturn(singletonList(new Mapping(jurisdiction, serviceName, serviceName)));
+        given(this.accessService.getReadJurisdictionForService(serviceName))
+            .willReturn(jurisdiction);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 
 import java.util.Objects;
 
@@ -38,5 +39,22 @@ public class EnvelopeAccessService {
                 "Service " + serviceName + " cannot update envelopes in jurisdiction " + envelopeJurisdiction
             );
         }
+    }
+
+    /**
+     * Returns the name of jurisdiction from which given service can read envelopes.
+     */
+    public String getReadJurisdictionForService(String serviceName) {
+        return access
+            .getMappings()
+            .stream()
+            .filter(m -> Objects.equals(m.getReadService(), serviceName))
+            .findFirst()
+            .map(m -> m.getJurisdiction())
+            .orElseThrow(() ->
+                new ServiceJuridictionConfigNotFoundException(
+                    "No configuration mapping found for service " + serviceName
+                )
+            );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverService.java
@@ -7,12 +7,10 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.mapper.EnvelopeResponseMapper;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
 
 import java.util.List;
-import java.util.Objects;
 
 @Service
 @EnableConfigurationProperties(EnvelopeAccessProperties.class)
@@ -21,42 +19,28 @@ public class EnvelopeRetrieverService {
     private static final Logger log = LoggerFactory.getLogger(EnvelopeRetrieverService.class);
 
     private final EnvelopeRepository envelopeRepository;
-    private final EnvelopeAccessProperties envelopeAccessProperties;
+    private final EnvelopeAccessService envelopeAccessService;
     private final EnvelopeResponseMapper envelopeResponseMapper;
 
     public EnvelopeRetrieverService(
         EnvelopeRepository envelopeRepository,
-        EnvelopeAccessProperties envelopeAccessProperties
+        EnvelopeAccessService envelopeAccessService
     ) {
         this.envelopeRepository = envelopeRepository;
-        this.envelopeAccessProperties = envelopeAccessProperties;
+        this.envelopeAccessService = envelopeAccessService;
         this.envelopeResponseMapper = new EnvelopeResponseMapper();
     }
 
     public List<EnvelopeResponse> findByServiceAndStatus(String serviceName, Status status) {
         log.info("Fetch requested for envelopes for service {} and status {}", serviceName, status);
 
-        String jurisdiction = getJurisdictionByServiceName(serviceName);
+        String jurisdiction = envelopeAccessService.getReadJurisdictionForService(serviceName);
 
         return envelopeResponseMapper.toEnvelopesResponse(
             status == null
             ? envelopeRepository.findByJurisdiction(jurisdiction)
             : envelopeRepository.findByJurisdictionAndStatus(jurisdiction, status)
         );
-    }
-
-    private String getJurisdictionByServiceName(String serviceName) {
-        return envelopeAccessProperties
-            .getMappings()
-            .stream()
-            .filter(m -> Objects.equals(m.getReadService(), serviceName))
-            .findFirst()
-            .map(m -> m.getJurisdiction())
-            .orElseThrow(() ->
-                new ServiceJuridictionConfigNotFoundException(
-                    "No configuration mapping found for service " + serviceName
-                )
-            );
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
@@ -10,11 +10,14 @@ import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@SuppressWarnings("checkstyle:LineLength")
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeAccessServiceTest {
 
@@ -58,5 +61,19 @@ public class EnvelopeAccessServiceTest {
     public void assertCanUpdate_should_not_throw_an_exception_if_service_can_update_envelopes_in_given_jurisdiction() {
         assertThatCode(() -> service.assertCanUpdate("jur_A", "update_A"))
             .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void getReadJurisdictionForService_should_return_name_of_then_jurisdiction_from_which_service_can_read() {
+        String jurisdiction = service.getReadJurisdictionForService("read_A");
+
+        assertThat(jurisdiction).isEqualTo("jur_A");
+    }
+
+    @Test
+    public void getReadJurisdictionForService_should_throw_an_exception_if_there_is_no_jurisdiction_that_the_service_can_read_from() {
+        assertThatThrownBy(() -> service.getReadJurisdictionForService("update_A"))
+            .isInstanceOf(ServiceJuridictionConfigNotFoundException.class)
+            .hasMessageContaining("update_A");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
@@ -6,8 +6,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.dao.DataRetrievalFailureException;
-import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
-import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
@@ -17,7 +15,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.mockito.BDDMockito.given;
@@ -35,7 +32,7 @@ public class EnvelopeRetrieverServiceTest {
     private EnvelopeRetrieverService envelopeRetrieverService;
 
     @Mock
-    private EnvelopeAccessProperties envelopeAccess;
+    private EnvelopeAccessService envelopeAccess;
 
     private EnvelopeResponseMapper envelopeResponseMapper = new EnvelopeResponseMapper();
 
@@ -49,8 +46,8 @@ public class EnvelopeRetrieverServiceTest {
         List<Envelope> envelopes = EnvelopeCreator.envelopes();
         List<EnvelopeResponse> envelopesResponse = envelopeResponseMapper.toEnvelopesResponse(envelopes);
 
-        when(envelopeAccess.getMappings())
-            .thenReturn(singletonList(new Mapping("testJurisdiction", "testService", "testService")));
+        when(envelopeAccess.getReadJurisdictionForService("testService"))
+            .thenReturn("testJurisdiction");
 
         when(envelopeRepository.findByJurisdictionAndStatus("testJurisdiction", PROCESSED))
             .thenReturn(envelopes);
@@ -77,8 +74,8 @@ public class EnvelopeRetrieverServiceTest {
 
         List<EnvelopeResponse> envelopesResponse = envelopeResponseMapper.toEnvelopesResponse(envelopes);
 
-        given(envelopeAccess.getMappings())
-            .willReturn(singletonList(new Mapping("testJurisdiction", "testService", "testService")));
+        given(envelopeAccess.getReadJurisdictionForService("testService"))
+            .willReturn("testJurisdiction");
 
         given(envelopeRepository.findByJurisdiction("testJurisdiction"))
             .willReturn(envelopes);
@@ -94,8 +91,8 @@ public class EnvelopeRetrieverServiceTest {
 
     @Test
     public void should_throw_data_retrieval_failure_exception_when_repository_fails_to_retrieve_envelopes() {
-        when(envelopeAccess.getMappings())
-            .thenReturn(singletonList(new Mapping("testJurisdiction", "testService", "testService")));
+        when(envelopeAccess.getReadJurisdictionForService("testService"))
+            .thenReturn("testJurisdiction");
 
         when(envelopeRepository.findByJurisdictionAndStatus("testJurisdiction", PROCESSED))
             .thenThrow(DataRetrievalFailureException.class);


### PR DESCRIPTION
Extracted what seemed to be the main change in https://github.com/hmcts/bulk-scan-processor/pull/88/files which diverted quite a bit from master in the meantime.