### PR TITLE
[PREVIEW]Use test containers docker compose instead of palantir docker compose rule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,10 +157,6 @@ repositories {
   jcenter()
 
   maven {
-    url 'https://dl.bintray.com/palantir/releases' // docker-compose-rule is published on bintray
-  }
-
-  maven {
     url "https://dl.bintray.com/hmcts/hmcts-maven"
   }
 }
@@ -203,8 +199,7 @@ dependencies {
   compile group: 'commons-io', name: 'commons-io', version: '2.6'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
-  testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4', version: '0.34.0'
-
+  testCompile group: 'com.jayway.awaitility', name: 'awaitility', version: '1.7.0'
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
@@ -2,10 +2,9 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.palantir.docker.compose.DockerComposeRule;
-import com.palantir.docker.compose.connection.waiting.HealthChecks;
 import org.junit.After;
-import org.junit.ClassRule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,8 +16,10 @@ import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.context.annotation.Bean;
 import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.DockerComposeContainer;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 
+import java.io.File;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 
@@ -32,12 +33,22 @@ import static org.mockito.BDDMockito.given;
 @RunWith(SpringRunner.class)
 public class ReuploadFailedEnvelopeTaskTest {
 
-    @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
-        .file("src/integrationTest/resources/docker-compose.yml")
-        .waitingForService("azure-storage", HealthChecks.toHaveAllPortsOpen())
-        .waitingForService("azure-storage", HealthChecks.toRespondOverHttp(10000, (port) -> port.inFormat("http://$HOST:$EXTERNAL_PORT/devstoreaccount1?comp=list")))
-        .build();
+    private static DockerComposeContainer dockerComposeContainer;
+
+    @BeforeClass
+    public static void initialize() {
+        File dockerComposeFile = new File("src/integrationTest/resources/docker-compose.yml");
+
+        dockerComposeContainer = new DockerComposeContainer(dockerComposeFile)
+            .withExposedService("azure-storage", 10000);
+
+        dockerComposeContainer.start();
+    }
+
+    @AfterClass
+    public static void tearDownContainer() {
+        dockerComposeContainer.stop();
+    }
 
     @Rule
     public OutputCapture outputCapture = new OutputCapture();

--- a/src/integrationTest/resources/docker-compose.yml
+++ b/src/integrationTest/resources/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 services:
   azure-storage:
     image: arafato/azurite:2.6.5


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-640

### Change description ###

- Used test containers docker compose containers instead of existing palantir docker compose rule as it was not tearing down containing properly.

- Can't use `@ClassRule` to automatically start and stop the container due to issue
https://github.com/testcontainers/testcontainers-java/issues/765

- Test containers compatible with version 2 of docker compose hence version needs to updated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
