### PR TITLE
Add description for waits in tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -63,7 +63,8 @@ public class BlobProcessorTest {
 
         testHelper.uploadZipFile(testContainer, files, metadataFile, destZipFilename); // valid zip file
 
-        await()
+        await("file should be deleted")
+            .with()
             .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
             .until(() -> testHelper.storageHasFile(testContainer, destZipFilename), is(false));
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -59,10 +59,11 @@ public class EnvelopeDeletionTest {
         testHelper.uploadZipFile(testContainer, files, metadataFile, destZipFilename); // valid zip file
         filesToDeleteAfterTest.add(destZipFilename);
 
-        await()
+        await("file should be deleted")
             .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
             .pollInterval(1, TimeUnit.SECONDS)
             .until(() -> testHelper.storageHasFile(testContainer, destZipFilename), is(false));
+
         assertThat(testHelper.storageHasFile(testContainer, destZipFilename)).isFalse();
     }
 
@@ -74,13 +75,13 @@ public class EnvelopeDeletionTest {
         testHelper.uploadZipFile(testContainer, srcZipFilename, destZipFilename); // invalid due to missing json file
         filesToDeleteAfterTest.add(destZipFilename);
 
-        await()
+        await("file should not be deleted")
             .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
             .pollDelay(scanDelay * 2, TimeUnit.MILLISECONDS)
             .until(() -> testHelper.storageHasFile(testContainer, destZipFilename), is(true));
 
         testContainer.getBlockBlobReference(destZipFilename).delete();
+
         assertThat(testHelper.storageHasFile(testContainer, destZipFilename)).isFalse();
     }
-
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
@@ -63,7 +63,7 @@ public class UpdateStatusTest {
             destZipFilename
         );
 
-        await()
+        await("file should be deleted")
             .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
             .until(() -> testHelper.storageHasFile(testContainer, destZipFilename), is(false));
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -156,7 +156,9 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
 
         //Check blob is deleted
         CloudBlockBlob blob = testContainer.getBlockBlobReference(zipFile);
-        await().atMost(2, SECONDS).until(blob::exists, is(false));
+        await("file should be deleted")
+            .atMost(2, SECONDS)
+            .until(blob::exists, is(false));
 
         // Verify envelope status is updated to PROCESSED
         assertThat(envelopeRepository.findAll())
@@ -188,7 +190,9 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
         processor.processBlobs();
 
         CloudBlockBlob blob = testContainer.getBlockBlobReference(zipFile);
-        await().timeout(2, SECONDS).until(blob::exists, is(true));
+        await("file should not be deleted")
+            .timeout(2, SECONDS)
+            .until(blob::exists, is(true));
 
         // Verify envelope status is updated to UPLOAD_FAILED
         assertThat(envelopeRepository.findAll())


### PR DESCRIPTION
For test failure messages more clear than:
```
uk.gov.hmcts.reform.bulkscanprocessor.controllers.BlobProcessorTest: expected <false> but was <true> within 19000 milliseconds.
```