### PR TITLE
Delete client certificate thumbprint for aat

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -5,4 +5,3 @@ reupload_enabled = true
 scan_delay = "4000"
 scan_enabled = true
 api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"
-allowed_client_certificate_thumbprints = ["4AF638E82FBD9959A5B8286C673360AC2C2E7053"]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-637

### Change description ###

Delete client certificate thumbprint for aat. The build started failing since there (not necessarily because of this change) and we need to revert it in order to verify the cause.

The thumbprint will be brought back again once we've solved the issue.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
