### PR TITLE
Revert "Delete client certificate thumbprint for aat"

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -5,3 +5,4 @@ reupload_enabled = true
 scan_delay = "4000"
 scan_enabled = true
 api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"
+allowed_client_certificate_thumbprints = ["4AF638E82FBD9959A5B8286C673360AC2C2E7053"]


### PR DESCRIPTION
Reverts hmcts/bulk-scan-processor#139

Verified as not the cause of the API problem.