### PR TITLE
Bring back API gateway test for unknown certificate

### DIFF
--- a/src/apiGatewayTest/java/uk/gov/hmcts/reform/bulkscanprocessor/api/GetSasTokenTest.java
+++ b/src/apiGatewayTest/java/uk/gov/hmcts/reform/bulkscanprocessor/api/GetSasTokenTest.java
@@ -59,6 +59,7 @@ public class GetSasTokenTest {
         assertThat(response.body().asString()).contains("Access denied due to missing subscription key");
     }
 
+    @Test
     public void should_reject_request_with_unrecognised_client_certificate() throws Exception {
         Response response = callSasTokenEndpoint(
             getUnrecognisedClientKeyStore(),


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-684

### Change description ###

Bring back API gateway test for unknown certificate. This test used to fail in aat, but the API Management Service has been rebuild, which might have solved the problem.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
