### PR TITLE
Fix/set default document control number for nonscannable items

### DIFF
--- a/src/main/resources/db/migration/V013__Add_new_fields.sql
+++ b/src/main/resources/db/migration/V013__Add_new_fields.sql
@@ -2,15 +2,12 @@ ALTER TABLE envelopes
   ADD COLUMN caseNumber VARCHAR(100) NULL;
 
 ALTER TABLE non_scannable_items
-  ADD COLUMN documentControlNumber VARCHAR(100) NOT NULL;
+  ADD COLUMN documentControlNumber VARCHAR(100) NULL;
 
 ALTER TABLE payments
   ADD COLUMN paymentInstrumentNumber VARCHAR(100) NULL,
   ADD COLUMN sortCode VARCHAR(10) NULL,
   ADD COLUMN accountNumber VARCHAR(50) NULL;
-
-ALTER TABLE scannable_items
-  ALTER COLUMN documentControlNumber SET NOT NULL;
 
 UPDATE payments
   SET sortCode = '112233',

--- a/src/main/resources/db/migration/V013__Add_new_fields.sql
+++ b/src/main/resources/db/migration/V013__Add_new_fields.sql
@@ -2,7 +2,7 @@ ALTER TABLE envelopes
   ADD COLUMN caseNumber VARCHAR(100) NULL;
 
 ALTER TABLE non_scannable_items
-  ADD COLUMN documentControlNumber VARCHAR(100) NULL;
+  ADD COLUMN documentControlNumber VARCHAR(100) NOT NULL DEFAULT "1111111" ;
 
 ALTER TABLE payments
   ADD COLUMN paymentInstrumentNumber VARCHAR(100) NULL,
@@ -10,6 +10,6 @@ ALTER TABLE payments
   ADD COLUMN accountNumber VARCHAR(50) NULL;
 
 UPDATE payments
-  SET sortCode = '112233',
-      accountNumber = '12345678'
+  SET sortCode = '111111',
+      accountNumber = '11111111'
   WHERE method = 'Cheque' AND sortCode IS NULL AND accountNumber IS NULL;


### PR DESCRIPTION
### Change description ###

New validation schema change is breaking the build at AAT environment.

Added default value for document control number in non-scannable items table to fix the existing data in AAT.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
