### PR TITLE
[PREVIEW] Pass sensitive information to tests using Azure Key Vault

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -25,6 +25,11 @@ List<LinkedHashMap<String, Object>> apiTestSecrets = [
   secret('test-subscription-key', 'TEST_SUBSCRIPTION_KEY')
 ]
 
+List<LinkedHashMap<String, Object>> commonSecrets = [
+  secret('test-storage-account-key', 'TEST_STORAGE_ACCOUNT_KEY'),
+  secret('test-s2s-secret', 'TEST_S2S_SECRET'),
+]
+
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   [ $class: 'AzureKeyVaultSecret',
     secretType: 'Secret',
@@ -45,7 +50,11 @@ withPipeline(type, product, component) {
   enableApiGatewayTest()
   enableDockerBuild()
 
+  onPR() {
+    loadVaultSecrets(commonSecrets)
+  }
+
   onNonPR() {
-    loadVaultSecrets(apiTestSecrets)
+    loadVaultSecrets(commonSecrets + apiTestSecrets)
   }
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -19,6 +19,11 @@ List<LinkedHashMap<String, Object>> apiTestSecrets = [
   secret('test-subscription-key', 'TEST_SUBSCRIPTION_KEY')
 ]
 
+List<LinkedHashMap<String, Object>> commonSecrets = [
+  secret('test-storage-account-key', 'TEST_STORAGE_ACCOUNT_KEY'),
+  secret('test-s2s-secret', 'TEST_S2S_SECRET'),
+]
+
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   [ $class: 'AzureKeyVaultSecret',
     secretType: 'Secret',
@@ -45,7 +50,11 @@ withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.E
   enableSlackNotifications(channel)
   enableApiGatewayTest()
 
+  onPR() {
+    loadVaultSecrets(commonSecrets)
+  }
+
   onNonPR() {
-    loadVaultSecrets(apiTestSecrets)
+    loadVaultSecrets(commonSecrets + apiTestSecrets)
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -181,11 +181,6 @@ data "azurerm_key_vault_secret" "s2s_secret" {
   vault_uri = "${local.s2s_vault_url}"
 }
 
-data "azurerm_key_vault_secret" "s2s_secret_test" {
-  name = "microservicekey-bulk-scan-processor-tests"
-  vault_uri = "${local.s2s_vault_url}"
-}
-
 # region API (gateway)
 
 data "template_file" "api_template" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -27,11 +27,6 @@ output "TEST_STORAGE_ACCOUNT_NAME" {
   value     = "${azurerm_storage_account.provider.name}"
 }
 
-output "TEST_STORAGE_ACCOUNT_KEY" {
-  sensitive = true
-  value     = "${azurerm_storage_account.provider.primary_access_key}"
-}
-
 output "TEST_S2S_URL" {
   value = "${local.s2s_url}"
 }
@@ -39,11 +34,6 @@ output "TEST_S2S_URL" {
 output "TEST_S2S_NAME" {
   sensitive = true
   value     = "${var.test_s2s_name}"
-}
-
-output "TEST_S2S_SECRET" {
-  sensitive = true
-  value     = "${data.azurerm_key_vault_secret.s2s_secret_test.value}"
 }
 
 # this variable will be accessible to tests as API_GATEWAY_URL environment variable

--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -1,0 +1,16 @@
+resource "azurerm_key_vault_secret" "test_storage_account_key" {
+  name = "test-storage-account-key"
+  value = "${azurerm_storage_account.provider.primary_access_key}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "source_test_s2s_secret" {
+  name = "microservicekey-bulk-scan-processor-tests"
+  vault_uri = "${local.s2s_vault_url}"
+}
+
+resource "azurerm_key_vault_secret" "test_s2s_secret" {
+  name = "test-s2s-secret"
+  value = "${data.azurerm_key_vault_secret.source_test_s2s_secret.value}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Pass sensitive information to tests using Azure Key Vault. Values of sensitive outputs can still end up in logs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
