### PR TITLE
Remove (Hashicorp) Vault provider config from infrastructure code

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,9 +1,5 @@
 provider "azurerm" {}
 
-provider "vault" {
-  address = "https://vault.reform.hmcts.net:6200"
-}
-
 locals {
   is_preview            = "${(var.env == "preview" || var.env == "spreview")}"
   account_name          = "${replace("${var.product}${var.env}", "-", "")}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Remove (Hashicorp) Vault provider config from infrastructure code. We're not using Hashicorp Vault anymore.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
