### PR TITLE
Bump service bus dependency to v1.2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ dependencies {
   compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '1.0.0'
   compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '1.0.0'
   compile group: 'com.microsoft.azure', name: 'azure-storage', version: '8.0.0'
-  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.7', withoutJsonSmart
+  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.8', withoutJsonSmart
 
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot


### PR DESCRIPTION
### Change description ###

Fix for thread starvation. [More details](https://github.com/Azure/azure-service-bus-java/releases/tag/1.2.8) in release description

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
