### PR TITLE
Shutdown thread poolwhen done

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -78,6 +78,7 @@ public class ReuploadFailedEnvelopeTask {
             });
 
         awaitCompletion(completionService);
+        executorService.shutdown();
     }
 
     private void awaitCompletion(CompletionService<Void> completionService) throws InterruptedException {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RPE-736


### Change description ###
We accumulate a large number of waiting threads from a thread pool that is not shutdown properly. This might be causing the Service Bus issue or be a separate issue. Anyway this is an attempt to solve that problem and see what happens ...


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
