### PR TITLE
[PREVIEW] Remove no longer used field from queue message

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -119,12 +119,6 @@ public class ServiceBusHelperTest {
         assertDateField(jsonNode, "delivery_date", message.getDeliveryDate());
         assertDateField(jsonNode, "opening_date", message.getOpeningDate());
 
-        JsonNode docUrls = jsonNode.get("doc_urls");
-        assertThat(docUrls.isArray()).isTrue();
-        assertThat(docUrls.size()).isEqualTo(2);
-        assertThat(docUrls.get(0).asText()).isEqualTo(scannableItem1.getDocumentUrl());
-        assertThat(docUrls.get(1).asText()).isEqualTo(scannableItem2.getDocumentUrl());
-
         JsonNode docs = jsonNode.get("documents");
         assertThat(docs.isArray()).isTrue();
         assertThat(docs.size()).isEqualTo(2);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
-import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 
 import java.time.Instant;
 import java.util.List;
@@ -38,10 +37,6 @@ public class EnvelopeMsg implements Msg {
     @JsonProperty("zip_file_name")
     private String zipFileName;
 
-    // TODO: remove, after no longer used by orchestrator
-    @JsonProperty("doc_urls")
-    private List<String> documentUrls;
-
     @JsonProperty("documents")
     private List<Document> documents;
 
@@ -57,10 +52,6 @@ public class EnvelopeMsg implements Msg {
         this.openingDate = envelope.getOpeningDate().toInstant();
         this.zipFileName = envelope.getZipFileName();
         this.testOnly = envelope.isTestOnly();
-        this.documentUrls = envelope.getScannableItems()
-            .stream()
-            .map(ScannableItem::getDocumentUrl)
-            .collect(Collectors.toList());
         this.documents = envelope
             .getScannableItems()
             .stream()
@@ -88,10 +79,6 @@ public class EnvelopeMsg implements Msg {
 
     public String getJurisdiction() {
         return jurisdiction;
-    }
-
-    public List<String> getDocumentUrls() {
-        return documentUrls;
     }
 
     public Instant getDeliveryDate() {


### PR DESCRIPTION
Orchestrator is not using it:
https://github.com/hmcts/bulk-scan-orchestrator/blob/master/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Envelope.java