### PR TITLE
Move integration test helpers to test module

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -30,7 +30,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItemRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
-import uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper;
+import uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.DocumentManagementService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.wrapper.ErrorHandlingWrapper;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -44,8 +44,8 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_UPLOADED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_UPLOAD_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.NOTIFICATION_SENT;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOAD_FAILURE;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper.zipAndSignDir;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipAndSignDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -24,8 +24,8 @@ import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_UPLOAD_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOAD_FAILURE;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper.zipAndSignDir;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipAndSignDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/EnvelopeProcessorValidationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/EnvelopeProcessorValidationTest.java
@@ -15,7 +15,7 @@ import java.util.zip.ZipInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 
 /**
  * This is unit test. Falls under integration to make use of existing zip file resources.

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -26,7 +26,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_UPLOADED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_UPLOAD_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.PROCESSED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOAD_FAILURE;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/DirectoryZipper.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/DirectoryZipper.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanprocessor.helpers;
+package uk.gov.hmcts.reform.bulkscanprocessor.helper;
 
 import com.google.common.io.Files;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipVerifiers;
@@ -15,7 +15,7 @@ import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helpers.SigningHelper.signWithSha256Rsa;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.SigningHelper.signWithSha256Rsa;
 
 public final class DirectoryZipper {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/SigningHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/SigningHelper.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanprocessor.helpers;
+package uk.gov.hmcts.reform.bulkscanprocessor.helper;
 
 import java.security.KeyFactory;
 import java.security.Signature;


### PR DESCRIPTION
The `DirZipper` and `SigningHelper` will be needed in unit tests module to create signed zip files in memory.