### PR TITLE
Add extra wait in test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
@@ -29,6 +29,8 @@ import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.StreamSupport;
@@ -198,6 +200,18 @@ public class TestHelper {
         assertThat(response.getStatusCode()).isEqualTo(200);
 
         return response.getBody().as(EnvelopeListResponse.class, ObjectMapperType.JACKSON_2);
+    }
+
+    public Optional<EnvelopeResponse> getEnvelopeByZipFileName(
+        String baseUrl,
+        String s2sToken,
+        String zipFileName
+    ) {
+        return getEnvelopes(baseUrl, s2sToken, null)
+            .envelopes
+            .stream()
+            .filter(env -> Objects.equals(env.getZipFileName(), zipFileName))
+            .findFirst();
     }
 
     public EnvelopeResponse getEnvelope(String baseUrl, String s2sToken, UUID id) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
@@ -68,15 +68,10 @@ public class UpdateStatusTest {
             destZipFilename
         );
 
-        await("file should be deleted")
-            .atMost(scanDelay + 40_000, TimeUnit.MILLISECONDS)
-            .pollInterval(2, TimeUnit.SECONDS)
-            .until(() -> testHelper.storageHasFile(testContainer, destZipFilename), is(false));
-
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
 
         await("processing should end")
-            .atMost(scanDelay, TimeUnit.MILLISECONDS)
+            .atMost(scanDelay + 40_000, TimeUnit.MILLISECONDS)
             .pollInterval(500, TimeUnit.MILLISECONDS)
             .until(() -> testHelper.getEnvelopeByZipFileName(testUrl, s2sToken, destZipFilename)
                 .filter(env -> env.getStatus() == Status.NOTIFICATION_SENT)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class UpdateStatusTest {
 


### PR DESCRIPTION
Sending to the queue now happens in a separate task, therefore file may be deleted from blob storage, but the envelope may not yet be on the queue....