### PR TITLE
Move rejected files to separate containers

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -55,8 +55,9 @@ withPipeline(type, product, component) {
       env.TEST_S2S_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
       env.TEST_SCAN_DELAY = '4000'
       env.RESOURCE_GROUP = 'bulk-scan-aks'
-      def testStorageAccountName = 'bulkscan'
-      env.TEST_STORAGE_CONTAINER_NAME = testStorageAccountName
+      def testInputStorageContainerName = 'bulkscan'
+      def testRejectedStorageContainerName = 'bulkscan-rejected'
+      env.TEST_STORAGE_CONTAINER_NAME = testInputStorageContainerName
 
       def az = { cmd -> return sh(script: "env AZURE_CONFIG_DIR=/opt/jenkins/.azure-${env.SUBSCRIPTION_NAME} az $cmd", returnStdout: true).trim() }
 
@@ -66,7 +67,7 @@ withPipeline(type, product, component) {
       def storageSecret = "${aksServiceName}-storage-secret"
       def serviceBusSecret = "${aksServiceName}-servicebus-secret"
       def queueName = "envelopes"
-      def storageContainers = [testStorageAccountName, "sscs"]
+      def storageContainers = [testInputStorageContainerName, testRejectedStorageContainerName, "sscs"]
 
       def namespace = aksServiceName
       def kubectl = new Kubectl(this, subscription, namespace)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -86,7 +86,6 @@ public class EnvelopeDeletionTest {
             .pollInterval(2, TimeUnit.SECONDS)
             .until(() -> testHelper.storageHasFile(inputContainer, destZipFilename), is(false));
 
-        assertThat(testHelper.storageHasFile(inputContainer, destZipFilename)).isFalse();
         assertThat(testHelper.storageHasFile(rejectedContainer, destZipFilename)).isFalse();
     }
 
@@ -105,7 +104,7 @@ public class EnvelopeDeletionTest {
 
         await("file should be deleted")
             .atMost(scanDelay + 40_000, TimeUnit.MILLISECONDS)
-            .pollDelay(scanDelay * 2, TimeUnit.MILLISECONDS)
+            .pollInterval(2, TimeUnit.SECONDS)
             .until(() -> testHelper.storageHasFile(inputContainer, destZipFilename), is(false));
 
         assertThat(testHelper.storageHasFile(rejectedContainer, destZipFilename)).isTrue();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -66,7 +66,7 @@ public class EnvelopeDeletionTest {
             } catch (StorageException e) {
                 // Do nothing as the file was not leased
             }
-            
+
             inputContainer.getBlockBlobReference(filename).deleteIfExists();
             rejectedContainer.getBlockBlobReference(filename).deleteIfExists();
         }
@@ -103,11 +103,11 @@ public class EnvelopeDeletionTest {
 
         filesToDeleteAfterTest.add(destZipFilename);
 
-        await("file should not be deleted")
-            .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
+        await("file should be deleted")
+            .atMost(scanDelay + 40_000, TimeUnit.MILLISECONDS)
             .pollDelay(scanDelay * 2, TimeUnit.MILLISECONDS)
-            .until(() -> testHelper.storageHasFile(rejectedContainer, destZipFilename), is(true));
+            .until(() -> testHelper.storageHasFile(inputContainer, destZipFilename), is(false));
 
-        assertThat(testHelper.storageHasFile(inputContainer, destZipFilename)).isFalse();
+        assertThat(testHelper.storageHasFile(rejectedContainer, destZipFilename)).isTrue();
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.StorageUri;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -23,10 +24,11 @@ import static org.hamcrest.Matchers.is;
 
 public class EnvelopeDeletionTest {
 
-    private transient long scanDelay;
-    private transient CloudBlobContainer testContainer;
+    private long scanDelay;
+    private CloudBlobContainer inputContainer;
+    private CloudBlobContainer rejectedContainer;
     private List<String> filesToDeleteAfterTest = new ArrayList<>();
-    private transient TestHelper testHelper;
+    private TestHelper testHelper;
 
     @Before
     public void setUp() throws Exception {
@@ -39,14 +41,19 @@ public class EnvelopeDeletionTest {
                 conf.getString("test-storage-account-key")
             );
 
-        testContainer = new CloudStorageAccount(
+        CloudBlobClient cloudBlobClient = new CloudStorageAccount(
             storageCredentials,
             new StorageUri(new URI(conf.getString("test-storage-account-url")), null),
             null,
             null
         )
-            .createCloudBlobClient()
-            .getContainerReference(conf.getString("test-storage-container-name"));
+            .createCloudBlobClient();
+
+        String inputContainerName = conf.getString("test-storage-container-name");
+        String rejectedContainerName = inputContainerName + "-rejected";
+
+        inputContainer = cloudBlobClient.getContainerReference(inputContainerName);
+        rejectedContainer = cloudBlobClient.getContainerReference(rejectedContainerName);
 
         testHelper = new TestHelper();
     }
@@ -55,11 +62,13 @@ public class EnvelopeDeletionTest {
     public void tearDown() throws Exception {
         for (String filename: filesToDeleteAfterTest) {
             try {
-                testContainer.getBlockBlobReference(filename).breakLease(0);
+                inputContainer.getBlockBlobReference(filename).breakLease(0);
             } catch (StorageException e) {
                 // Do nothing as the file was not leased
             }
-            testContainer.getBlockBlobReference(filename).deleteIfExists();
+            
+            inputContainer.getBlockBlobReference(filename).deleteIfExists();
+            rejectedContainer.getBlockBlobReference(filename).deleteIfExists();
         }
     }
 
@@ -69,23 +78,24 @@ public class EnvelopeDeletionTest {
         String metadataFile = "1111006.metadata.json";
         String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
 
-        testHelper.uploadZipFile(testContainer, files, metadataFile, destZipFilename); // valid zip file
+        testHelper.uploadZipFile(inputContainer, files, metadataFile, destZipFilename); // valid zip file
         filesToDeleteAfterTest.add(destZipFilename);
 
         await("file should be deleted")
             .atMost(scanDelay + 40_000, TimeUnit.MILLISECONDS)
             .pollInterval(2, TimeUnit.SECONDS)
-            .until(() -> testHelper.storageHasFile(testContainer, destZipFilename), is(false));
+            .until(() -> testHelper.storageHasFile(inputContainer, destZipFilename), is(false));
 
-        assertThat(testHelper.storageHasFile(testContainer, destZipFilename)).isFalse();
+        assertThat(testHelper.storageHasFile(inputContainer, destZipFilename)).isFalse();
+        assertThat(testHelper.storageHasFile(rejectedContainer, destZipFilename)).isFalse();
     }
 
     @Test
-    public void should_keep_zip_file_after_failed_processing() throws Exception {
+    public void should_move_invalid_zip_file_to_rejected_container() throws Exception {
         String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
 
         testHelper.uploadZipFile(
-            testContainer,
+            inputContainer,
             Arrays.asList("1111006.pdf"),
             null, // missing metadata file
             destZipFilename
@@ -96,6 +106,8 @@ public class EnvelopeDeletionTest {
         await("file should not be deleted")
             .atMost(scanDelay + 15_000, TimeUnit.MILLISECONDS)
             .pollDelay(scanDelay * 2, TimeUnit.MILLISECONDS)
-            .until(() -> testHelper.storageHasFile(testContainer, destZipFilename), is(true));
+            .until(() -> testHelper.storageHasFile(rejectedContainer, destZipFilename), is(true));
+
+        assertThat(testHelper.storageHasFile(inputContainer, destZipFilename)).isFalse();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.DOC_UPLOAD_FAILURE;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Event.FILE_VALIDATION_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOAD_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipAndSignDir;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
@@ -108,7 +108,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
     }
 
     @Test
-    public void should_record_generic_failure_when_zip_does_not_contain_metadata_json() throws Exception {
+    public void should_record_validation_failure_when_zip_does_not_contain_metadata_json() throws Exception {
         // given
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/missing_metadata"));
 
@@ -117,11 +117,11 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(DOC_FAILURE);
+        eventWasCreated(FILE_VALIDATION_FAILURE);
     }
 
     @Test
-    public void should_record_generic_failure_when_metadata_parsing_fails() throws Exception {
+    public void should_record_validation_failure_when_metadata_parsing_fails() throws Exception {
         // given
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/invalid_metadata"));
 
@@ -130,11 +130,11 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(DOC_FAILURE);
+        eventWasCreated(FILE_VALIDATION_FAILURE);
     }
 
     @Test
-    public void should_record_generic_failure_when_zip_contains_documents_not_in_pdf_format() throws Exception {
+    public void should_record_validation_failure_when_zip_contains_documents_not_in_pdf_format() throws Exception {
         // given
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/non_pdf"));
 
@@ -143,7 +143,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(Event.DOC_FAILURE);
+        eventWasCreated(FILE_VALIDATION_FAILURE);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Event.java
@@ -4,6 +4,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 public enum Event {
 
     DOC_FAILURE, // generic failure while processing zip file. before uploading to document management
+    FILE_VALIDATION_FAILURE,
     DOC_SIGNATURE_FAILURE, // Signature verification failure while processing zip file
     DOC_UPLOADED,
     DOC_UPLOAD_FAILURE,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -192,7 +192,8 @@ public class BlobProcessorTask extends Processor {
         } catch (InvalidEnvelopeSchemaException
             | FileNameIrregularitiesException
             | NonPdfFileFoundException
-            | MetadataNotFoundException ex) {
+            | MetadataNotFoundException ex
+        ) {
             handleInvalidFileError(Event.FILE_VALIDATION_FAILURE, containerName, zipFilename, ex);
         } catch (DocSignatureFailureException ex) {
             handleInvalidFileError(Event.DOC_SIGNATURE_FAILURE, containerName, zipFilename, ex);
@@ -211,9 +212,11 @@ public class BlobProcessorTask extends Processor {
     }
 
     private void handleInvalidFileError(
-        Event fileValidationFailure, String containerName, String zipFilename,
-        Exception cause) {
-
+        Event fileValidationFailure,
+        String containerName,
+        String zipFilename,
+        Exception cause
+    ) {
         handleEventRelatedError(fileValidationFailure, containerName, zipFilename, cause);
         blobManager.tryMoveFileToRejectedContainer(zipFilename, containerName);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
@@ -127,7 +127,7 @@ public class FailedDocUploadProcessor extends Processor {
             processor = zipFileProcessor;
         } catch (DocSignatureFailureException ex) {
             handleEventRelatedError(Event.DOC_SIGNATURE_FAILURE, containerName, zipFileName, ex);
-            blobManager.tryMoveFileToRejectedContainer(zipFileName, containerName);
+            blobManager.tryMoveFileToRejectedContainer(zipFileName, containerName, null);
         } catch (Exception ex) {
             handleEventRelatedError(Event.DOC_FAILURE, containerName, zipFileName, ex);
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
@@ -127,6 +127,7 @@ public class FailedDocUploadProcessor extends Processor {
             processor = zipFileProcessor;
         } catch (DocSignatureFailureException ex) {
             handleEventRelatedError(Event.DOC_SIGNATURE_FAILURE, containerName, zipFileName, ex);
+            blobManager.tryMoveFileToRejectedContainer(zipFileName, containerName);
         } catch (Exception ex) {
             handleEventRelatedError(Event.DOC_FAILURE, containerName, zipFileName, ex);
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-261

### Change description ###

Move rejected files to separate, 'rejected' containers

This PR is a copy of the already approved https://github.com/hmcts/bulk-scan-processor/pull/288. What changed here is the destination branch, which is now demo.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
