### PR TITLE
Include OCR data in queue messages

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -153,6 +153,7 @@ public class ServiceBusHelperTest {
         assertThat(jsonNode.get("control_number").asText()).isEqualTo(scannableItem.getDocumentControlNumber());
         assertThat(jsonNode.get("type").asText()).isEqualTo(scannableItem.getDocumentType());
         assertThat(jsonNode.get("url").asText()).isEqualTo(scannableItem.getDocumentUrl());
+        assertThat(jsonNode.get("ocr_data").asText(null)).isEqualTo(scannableItem.getOcrData());
 
         assertDateField(jsonNode, "scanned_at", scannableItem.getScanningDate().toInstant());
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -22,19 +22,24 @@ public class Document {
     @JsonProperty("url")
     public final String url;
 
+    @JsonProperty("ocr_data")
+    public final String ocrData;
+
     // region constructor
     private Document(
         String fileName,
         String controlNumber,
         String type,
         Instant scannedAt,
-        String url
+        String url,
+        String ocrData
     ) {
         this.fileName = fileName;
         this.controlNumber = controlNumber;
         this.type = type;
         this.scannedAt = scannedAt;
         this.url = url;
+        this.ocrData = ocrData;
     }
     // endregion
 
@@ -44,7 +49,8 @@ public class Document {
             item.getDocumentControlNumber(),
             item.getDocumentType(),
             item.getScanningDate().toInstant(),
-            item.getDocumentUrl()
+            item.getDocumentUrl(),
+            item.getOcrData()
         );
     }
 }

--- a/src/test/resources/metafiles/valid/from-spec.json
+++ b/src/test/resources/metafiles/valid/from-spec.json
@@ -15,6 +15,7 @@
       "next_action": "return",
       "next_action_date": "24-02-2017 00:00:00.000010",
       "file_name": "1111001.pdf",
+      "ocr_data": "VGVzdCBvY3IgZGF0YQo=",
       "notes": "The document had ink spilled on it",
       "document_type": "Passport"
     },


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-253

### Change description ###

Include OCR data, if present in the input metadata, in messages for the orchestrator.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
