### PR TITLE
Zip file processing result

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessingResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessingResult.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
+
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
+
+import java.util.List;
+
+public class ZipFileProcessingResult {
+
+    private final byte[] metadata;
+    private final List<Pdf> pdfs;
+    private Envelope envelope; // TODO: make final
+
+    public ZipFileProcessingResult(byte[] metadata, List<Pdf> pdfs) {
+        this.metadata = metadata;
+        this.pdfs = pdfs;
+    }
+
+    public byte[] getMetadata() {
+        return metadata;
+    }
+
+    public List<Pdf> getPdfs() {
+        return pdfs;
+    }
+
+    public Envelope getEnvelope() {
+        return envelope;
+    }
+
+    public void setEnvelope(Envelope envelope) {
+        this.envelope = envelope;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.NonPdfFileFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
 
@@ -20,23 +19,18 @@ public class ZipFileProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(ZipFileProcessor.class);
 
-    // TODO: remove
-    private Envelope envelope;
-
-    private List<Pdf> pdfs = new ArrayList<>();
-
-    private byte[] metadata;
-
     public ZipFileProcessor() {
     }
 
-    // TODO: make it return processing result instead of setting fields on itself
-    public void process(
+    public ZipFileProcessingResult process(
         ZipVerifiers.ZipStreamWithSignature signedZip,
         Function<ZipVerifiers.ZipStreamWithSignature, ZipInputStream> preprocessor
     ) throws IOException {
         ZipInputStream zis = preprocessor.apply(signedZip);
         ZipEntry zipEntry;
+
+        List<Pdf> pdfs = new ArrayList<>();
+        byte[] metadata = null;
 
         while ((zipEntry = zis.getNextEntry()) != null) {
             switch (FilenameUtils.getExtension(zipEntry.getName())) {
@@ -55,21 +49,7 @@ public class ZipFileProcessor {
         }
 
         log.info("PDFs found in {}: {}", signedZip.zipFileName, pdfs.size());
-    }
 
-    public byte[] getMetadata() {
-        return metadata;
-    }
-
-    public List<Pdf> getPdfs() {
-        return pdfs;
-    }
-
-    public Envelope getEnvelope() {
-        return envelope;
-    }
-
-    public void setEnvelope(Envelope envelope) {
-        this.envelope = envelope;
+        return new ZipFileProcessingResult(metadata, pdfs);
     }
 }


### PR DESCRIPTION
Continuing refactoring started in https://github.com/hmcts/bulk-scan-processor/pull/232/files

The `process` method on `ZipFileProcessor` now returns a result instead of void setting fields on itself.

More cleanup coming in future PRs.