### PR TITLE
Set default document type for old db data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/DocumentTypeConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/DocumentTypeConverter.java
@@ -1,8 +1,13 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.persistence.AttributeConverter;
 
 public class DocumentTypeConverter implements AttributeConverter<DocumentType, String> {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentTypeConverter.class);
 
     @Override
     public String convertToDatabaseColumn(DocumentType attribute) {
@@ -11,6 +16,13 @@ public class DocumentTypeConverter implements AttributeConverter<DocumentType, S
 
     @Override
     public DocumentType convertToEntityAttribute(String dbData) {
-        return DocumentType.valueOf(dbData.toUpperCase());
+        try {
+            return DocumentType.valueOf(dbData.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            // for backwards compatibility due to a lot of incorrect data in db
+            log.warn("Invalid document type found in DB: '{}'", dbData, exception);
+
+            return DocumentType.OTHER;
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/DocumentTypeConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/DocumentTypeConverterTest.java
@@ -32,7 +32,7 @@ public class DocumentTypeConverterTest {
     }
 
     @Test
-    public void should_not_fail_and_return_OTHER_for_invalid_document_type_found_in_db() {
+    public void should_not_fail_and_return_other_for_invalid_document_type_found_in_db() {
         assertThat(CONVERTER.convertToEntityAttribute("not valid")).isEqualTo(OTHER);
 
         assertThat(capture.toString()).containsSequence("Invalid document type found in DB: 'not valid'");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/DocumentTypeConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/DocumentTypeConverterTest.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.entity;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.DocumentType.CHERISHED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.DocumentType.OTHER;
+
+public class DocumentTypeConverterTest {
+
+    private static final DocumentTypeConverter CONVERTER = new DocumentTypeConverter();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    @After
+    public void cleanUp() {
+        capture.flush();
+    }
+
+    @Test
+    public void should_convert_to_lower_case_for_db_entry() {
+        assertThat(CONVERTER.convertToDatabaseColumn(OTHER)).isEqualTo(OTHER.name().toLowerCase());
+    }
+
+    @Test
+    public void should_get_cherished_document_type_from_correct_db_entry() {
+        assertThat(CONVERTER.convertToEntityAttribute("cherished")).isEqualTo(CHERISHED);
+    }
+
+    @Test
+    public void should_not_fail_and_return_OTHER_for_invalid_document_type_found_in_db() {
+        assertThat(CONVERTER.convertToEntityAttribute("not valid")).isEqualTo(OTHER);
+
+        assertThat(capture.toString()).containsSequence("Invalid document type found in DB: 'not valid'");
+    }
+}


### PR DESCRIPTION
### Change description ###

As there are a lot of invalid data in other testing environments present (check #298), this needs to be manually updated or just returned as OTHER disregarding the value. Latter option is most sensible

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
