### PR TITLE
Fix enum used in DB

### DIFF
--- a/src/main/resources/db/migration/V019__Fix_up_document_types.sql
+++ b/src/main/resources/db/migration/V019__Fix_up_document_types.sql
@@ -1,0 +1,3 @@
+UPDATE scannable_items SET documenttype = 'CHERISHED' WHERE documenttype = 'Cherished';
+
+UPDATE scannable_items SET documenttype = 'OTHER' WHERE documenttype != 'Cherished';


### PR DESCRIPTION
### Change description ###

Last PRs finally gave a conclusion to my thick skull why JPA is bad. So enums in hibernate are using names/ordinals instead of this _hacky_ customisation of method `.toString` in place which is used in `Jackson` instead. Hence the expected output published to ServiceBus is correct but DB records in test environment are not. Which brings back the question of trustworthiness of our PR pipelines when introducing such visually nonbreaking change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
