### PR TITLE
Include OCR data in queue messages

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 
 import java.time.Instant;
+import java.util.Map;
 
 public class Document {
 
@@ -22,19 +23,24 @@ public class Document {
     @JsonProperty("url")
     public final String url;
 
+    @JsonProperty("ocr_data")
+    public final Map<String, String> ocrData;
+
     // region constructor
     private Document(
         String fileName,
         String controlNumber,
         String type,
         Instant scannedAt,
-        String url
+        String url,
+        Map<String, String> ocrData
     ) {
         this.fileName = fileName;
         this.controlNumber = controlNumber;
         this.type = type;
         this.scannedAt = scannedAt;
         this.url = url;
+        this.ocrData = ocrData;
     }
     // endregion
 
@@ -44,7 +50,8 @@ public class Document {
             item.getDocumentControlNumber(),
             item.getDocumentType().toString(),
             item.getScanningDate().toInstant(),
-            item.getDocumentUrl()
+            item.getDocumentUrl(),
+            item.getOcrData()
         );
     }
 }

--- a/src/test/resources/metafiles/valid/from-spec.json
+++ b/src/test/resources/metafiles/valid/from-spec.json
@@ -16,7 +16,8 @@
       "next_action_date": "24-02-2017 00:00:00.000010",
       "file_name": "1111001.pdf",
       "notes": "The document had ink spilled on it",
-      "document_type": "Cherished"
+      "document_type": "Cherished",
+      "ocr_data": "eyJNZXRhZGF0YV9maWxlIjogW3sgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAibmFtZTIiLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAidmFsdWUyIn1dfQo="
     },
     {
       "document_control_number": "1111002",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-253

### Change description ###

Include OCR data in documents contained in the messages that the processor places in the queue.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
