### PR TITLE
Map document types to the set used in CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -1,12 +1,19 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 
 public class Document {
+
+    private static final String DOCUMENT_TYPE_CHERISHED = "Cherished";
+    private static final String DOCUMENT_TYPE_OTHER = "Other";
+    private static final Set<String> DOCUMENT_TYPES =
+        ImmutableSet.of(DOCUMENT_TYPE_CHERISHED, DOCUMENT_TYPE_OTHER);
 
     @JsonProperty("file_name")
     public final String fileName;
@@ -48,10 +55,22 @@ public class Document {
         return new Document(
             item.getFileName(),
             item.getDocumentControlNumber(),
-            item.getDocumentType().toString(),
+            mapDocumentType(item.getDocumentType()),
             item.getScanningDate().toInstant(),
             item.getDocumentUrl(),
             item.getOcrData()
         );
+    }
+
+    // This mapping will eventually be done during the creation of DB envelope, when
+    // document subtype is introduced by the team. Until that happens, we need to store
+    // original values in the DB, so that no information is lost. That's why the mapping
+    // takes place when putting the message on the queue.
+    private static String mapDocumentType(String documentType) {
+        if (DOCUMENT_TYPES.contains(documentType)) {
+            return documentType;
+        } else {
+            return DOCUMENT_TYPE_OTHER;
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Document.fromScannableItem;
+
+public class DocumentTest {
+
+    private static final String DOCUMENT_TYPE_CHERISHED = "Cherished";
+    private static final String DOCUMENT_TYPE_OTHER = "Other";
+
+    @Test
+    public void fromScannableItem_maps_to_document_correctly() {
+        ScannableItem scannableItem = scannableItem(DOCUMENT_TYPE_CHERISHED);
+        Document document = fromScannableItem(scannableItem);
+
+        assertThat(document.controlNumber).isEqualTo(scannableItem.getDocumentControlNumber());
+        assertThat(document.fileName).isEqualTo(scannableItem.getFileName());
+        assertThat(document.ocrData).isEqualTo(scannableItem.getOcrData());
+        assertThat(document.scannedAt).isEqualTo(scannableItem.getScanningDate().toInstant());
+        assertThat(document.type).isEqualTo(scannableItem.getDocumentType());
+        assertThat(document.url).isEqualTo(scannableItem.getDocumentUrl());
+    }
+
+    @Test
+    public void fromScannableItem_maps_document_type_correctly() {
+        ScannableItem cherishedScannableItem = scannableItem(DOCUMENT_TYPE_CHERISHED);
+        ScannableItem otherScannableItem = scannableItem(DOCUMENT_TYPE_OTHER);
+        ScannableItem sscs1ScannableItem = scannableItem("SSCS1");
+
+        assertThat(fromScannableItem(cherishedScannableItem).type).isEqualTo(DOCUMENT_TYPE_CHERISHED);
+        assertThat(fromScannableItem(otherScannableItem).type).isEqualTo(DOCUMENT_TYPE_OTHER);
+        assertThat(fromScannableItem(sscs1ScannableItem).type).isEqualTo(DOCUMENT_TYPE_OTHER);
+    }
+
+    private ScannableItem scannableItem(String documentType) {
+        ScannableItem scannableItem = new ScannableItem(
+            "1111001",
+            Timestamp.from(Instant.now()),
+            "ocrAccuracy1",
+            "manualIntervention1",
+            "nextAction1",
+            Timestamp.from(Instant.now().plus(1, DAYS)),
+            ImmutableMap.of("ocr", "data1"),
+            "fileName1.pdf",
+            "notes 1",
+            documentType
+        );
+
+        scannableItem.setDocumentUrl("http://document-url.example.com");
+        return scannableItem;
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-253

### Change description ###

Map document types to the set used in CCD, i.e. translate service-specific document types to "Other".

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
