### PR TITLE
Make the document types in queue messages all lowercase

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -157,7 +157,7 @@ public class ServiceBusHelperTest {
     private void checkScannableItem(JsonNode jsonNode, ScannableItem scannableItem) throws IOException {
         assertThat(jsonNode.get("file_name").asText()).isEqualTo(scannableItem.getFileName());
         assertThat(jsonNode.get("control_number").asText()).isEqualTo(scannableItem.getDocumentControlNumber());
-        assertThat(jsonNode.get("type").asText()).isEqualTo(scannableItem.getDocumentType().toString());
+        assertThat(jsonNode.get("type").asText()).isEqualTo(scannableItem.getDocumentType().toLowerCase());
         assertThat(jsonNode.get("url").asText()).isEqualTo(scannableItem.getDocumentUrl());
 
         Map<String, String> ocrData =

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -68,9 +68,9 @@ public class Document {
     // takes place when putting the message on the queue.
     private static String mapDocumentType(String documentType) {
         if (DOCUMENT_TYPES.contains(documentType)) {
-            return documentType;
+            return documentType.toLowerCase();
         } else {
-            return DOCUMENT_TYPE_OTHER;
+            return DOCUMENT_TYPE_OTHER.toLowerCase();
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -14,7 +14,10 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Document.fromS
 public class DocumentTest {
 
     private static final String DOCUMENT_TYPE_CHERISHED = "Cherished";
+    private static final String CCD_DOCUMENT_TYPE_CHERISHED = "cherished";
+
     private static final String DOCUMENT_TYPE_OTHER = "Other";
+    private static final String CCD_DOCUMENT_TYPE_OTHER = "other";
 
     @Test
     public void fromScannableItem_maps_to_document_correctly() {
@@ -25,7 +28,7 @@ public class DocumentTest {
         assertThat(document.fileName).isEqualTo(scannableItem.getFileName());
         assertThat(document.ocrData).isEqualTo(scannableItem.getOcrData());
         assertThat(document.scannedAt).isEqualTo(scannableItem.getScanningDate().toInstant());
-        assertThat(document.type).isEqualTo(scannableItem.getDocumentType());
+        assertThat(document.type).isEqualTo(CCD_DOCUMENT_TYPE_CHERISHED);
         assertThat(document.url).isEqualTo(scannableItem.getDocumentUrl());
     }
 
@@ -35,9 +38,9 @@ public class DocumentTest {
         ScannableItem otherScannableItem = scannableItem(DOCUMENT_TYPE_OTHER);
         ScannableItem sscs1ScannableItem = scannableItem("SSCS1");
 
-        assertThat(fromScannableItem(cherishedScannableItem).type).isEqualTo(DOCUMENT_TYPE_CHERISHED);
-        assertThat(fromScannableItem(otherScannableItem).type).isEqualTo(DOCUMENT_TYPE_OTHER);
-        assertThat(fromScannableItem(sscs1ScannableItem).type).isEqualTo(DOCUMENT_TYPE_OTHER);
+        assertThat(fromScannableItem(cherishedScannableItem).type).isEqualTo(CCD_DOCUMENT_TYPE_CHERISHED);
+        assertThat(fromScannableItem(otherScannableItem).type).isEqualTo(CCD_DOCUMENT_TYPE_OTHER);
+        assertThat(fromScannableItem(sscs1ScannableItem).type).isEqualTo(CCD_DOCUMENT_TYPE_OTHER);
     }
 
     private ScannableItem scannableItem(String documentType) {


### PR DESCRIPTION
### Change description ###

Make the document types in queue messages all lowercase, in order to make them consistent with CCD schema.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
