### PR TITLE
Move OCR data to envelope level in queue message

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -100,6 +100,7 @@ public class ServiceBusHelperTest {
         assertThat(busMessage.getLabel()).isNullOrEmpty();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void should_send_message_with_envelope_data() throws Exception {
 
@@ -125,6 +126,14 @@ public class ServiceBusHelperTest {
         assertThat(docs.size()).isEqualTo(2);
         checkScannableItem(docs.get(0), scannableItem1);
         checkScannableItem(docs.get(1), scannableItem2);
+
+        assertThat(jsonNode.hasNonNull("ocr_data")).isTrue();
+
+        Map<String, String> ocrData =
+            objectMapper.readValue(jsonNode.get("ocr_data").toString(), Map.class);
+
+        ScannableItem scannableItemWithOcrData = envelope.getScannableItems().get(0);
+        assertThat(ocrData).isEqualTo(scannableItemWithOcrData.getOcrData());
     }
 
     private void mockEnvelopeData() {
@@ -159,12 +168,6 @@ public class ServiceBusHelperTest {
         assertThat(jsonNode.get("control_number").asText()).isEqualTo(scannableItem.getDocumentControlNumber());
         assertThat(jsonNode.get("type").asText()).isEqualTo(scannableItem.getDocumentType().toLowerCase());
         assertThat(jsonNode.get("url").asText()).isEqualTo(scannableItem.getDocumentUrl());
-
-        Map<String, String> ocrData =
-            objectMapper.readValue(jsonNode.get("ocr_data").toString(), Map.class);
-
-        assertThat(ocrData).isEqualTo(scannableItem.getOcrData());
-
         assertDateField(jsonNode, "scanned_at", scannableItem.getScanningDate().toInstant());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 
 import java.time.Instant;
-import java.util.Map;
 import java.util.Set;
 
 public class Document {
@@ -30,24 +29,19 @@ public class Document {
     @JsonProperty("url")
     public final String url;
 
-    @JsonProperty("ocr_data")
-    public final Map<String, String> ocrData;
-
     // region constructor
     private Document(
         String fileName,
         String controlNumber,
         String type,
         Instant scannedAt,
-        String url,
-        Map<String, String> ocrData
+        String url
     ) {
         this.fileName = fileName;
         this.controlNumber = controlNumber;
         this.type = type;
         this.scannedAt = scannedAt;
         this.url = url;
-        this.ocrData = ocrData;
     }
     // endregion
 
@@ -57,8 +51,7 @@ public class Document {
             item.getDocumentControlNumber(),
             mapDocumentType(item.getDocumentType()),
             item.getScanningDate().toInstant(),
-            item.getDocumentUrl(),
-            item.getOcrData()
+            item.getDocumentUrl()
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
@@ -3,10 +3,12 @@ package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
@@ -40,6 +42,9 @@ public class EnvelopeMsg implements Msg {
     @JsonProperty("documents")
     private final List<Document> documents;
 
+    @JsonProperty("ocr_data")
+    private final Map<String, String> ocrData;
+
     private final boolean testOnly;
 
     public EnvelopeMsg(Envelope envelope) {
@@ -57,6 +62,8 @@ public class EnvelopeMsg implements Msg {
             .stream()
             .map(Document::fromScannableItem)
             .collect(Collectors.toList());
+
+        this.ocrData = getOcrData(envelope);
     }
 
     @Override
@@ -112,4 +119,13 @@ public class EnvelopeMsg implements Msg {
             + "}";
     }
 
+    private Map<String, String> getOcrData(Envelope envelope) {
+        return envelope
+            .getScannableItems()
+            .stream()
+            .filter(si -> si.getOcrData() != null)
+            .map(ScannableItem::getOcrData)
+            .findFirst()
+            .orElse(null);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -26,7 +26,6 @@ public class DocumentTest {
 
         assertThat(document.controlNumber).isEqualTo(scannableItem.getDocumentControlNumber());
         assertThat(document.fileName).isEqualTo(scannableItem.getFileName());
-        assertThat(document.ocrData).isEqualTo(scannableItem.getOcrData());
         assertThat(document.scannedAt).isEqualTo(scannableItem.getScanningDate().toInstant());
         assertThat(document.type).isEqualTo(CCD_DOCUMENT_TYPE_CHERISHED);
         assertThat(document.url).isEqualTo(scannableItem.getDocumentUrl());


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-253

### Change description ###

Move OCR data from document to envelope in queue message. Before this change, OCR data was kept in documents, but CCD schema defines it as a top-level field and the change aligns with it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
