### PR TITLE
Change the name of 'classification' field in metadata file

### DIFF
--- a/src/functionalTest/resources/1111006.metadata.json
+++ b/src/functionalTest/resources/1111006.metadata.json
@@ -6,7 +6,7 @@
   "opening_date": "24-06-2018 00:00:00.000000",
   "zip_file_createddate": "24-02-2018 00:00:00.000000",
   "zip_file_name": "$$zip_file_name$$",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
       {
         "document_control_number": "1111006",

--- a/src/functionalTest/resources/1111006_2.metadata.json
+++ b/src/functionalTest/resources/1111006_2.metadata.json
@@ -5,7 +5,7 @@
   "opening_date": "24-06-2018 00:00:00.000000",
   "zip_file_createddate": "24-02-2018 00:00:00.000000",
   "zip_file_name": "$$zip_file_name$$",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
       {
         "document_control_number": "1111006",

--- a/src/integrationTest/resources/zipcontents/fewer_pdfs_than_declared/metadata.json
+++ b/src/integrationTest/resources/zipcontents/fewer_pdfs_than_declared/metadata.json
@@ -5,7 +5,7 @@
   "opening_date": "24-06-2018 00:00:00.000000",
   "zip_file_createddate": "24-02-2018 00:00:00.000000",
   "zip_file_name": "1_24-06-2018-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
       {
         "document_control_number": "1111001",

--- a/src/integrationTest/resources/zipcontents/mismatching_pdfs/metadata.json
+++ b/src/integrationTest/resources/zipcontents/mismatching_pdfs/metadata.json
@@ -6,7 +6,7 @@
   "opening_date": "24-06-2018 00:00:00.000000",
   "zip_file_createddate": "24-02-2018 00:00:00.000000",
   "zip_file_name": "8_24-06-2018-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
       {
         "document_control_number": "1111005",

--- a/src/integrationTest/resources/zipcontents/more_pdfs_than_declared/metadata_4_24-06-2018-00-00-00.json
+++ b/src/integrationTest/resources/zipcontents/more_pdfs_than_declared/metadata_4_24-06-2018-00-00-00.json
@@ -5,7 +5,7 @@
   "opening_date": "24-06-2018 00:00:00.000000",
   "zip_file_createddate": "24-02-2018 00:00:00.000000",
   "zip_file_name": "9_24-06-2018-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
       {
         "document_control_number": "1111001",

--- a/src/integrationTest/resources/zipcontents/ok/metadata.json
+++ b/src/integrationTest/resources/zipcontents/ok/metadata.json
@@ -6,7 +6,7 @@
   "opening_date": "23-06-2018 00:00:00.000000",
   "zip_file_createddate": "23-06-2018 00:00:00.000000",
   "zip_file_name": "7_24-06-2018-00-00-00.zip",
-  "classification": "exception",
+  "envelope_classification": "exception",
   "scannable_items": [
       {
         "document_control_number": "1111002",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/blob/InputEnvelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/blob/InputEnvelope.java
@@ -37,7 +37,7 @@ public class InputEnvelope {
         @JsonProperty("zip_file_createddate") Timestamp zipFileCreateddate,
         @JsonProperty("zip_file_name") String zipFileName,
         @JsonProperty("case_number") String caseNumber,
-        @JsonProperty("classification") Classification classification,
+        @JsonProperty("envelope_classification") Classification classification,
         @JsonProperty("scannable_items") List<InputScannableItem> scannableItems,
         @JsonProperty("payments") List<InputPayment> payments,
         @JsonProperty("non_scannable_items") List<InputNonScannableItem> nonScannableItems

--- a/src/main/resources/metafile-schema.json
+++ b/src/main/resources/metafile-schema.json
@@ -43,8 +43,8 @@
       "title": "The name of the zip file",
       "pattern": "^\\d+_([012][0-9]|30|31)-([0][0-9]|[1][012])-[2][0][0-9][0-9]-([01][0-9]|[2][0123])-[0-5][0-9]-[0-5][0-9]\\.(test\\.)?zip$"
     },
-    "classification": {
-      "id": "#/properties/classification",
+    "envelope_classification": {
+      "id": "#/properties/envelope_classification",
       "type": "string",
       "enum": [
         "exception",
@@ -339,7 +339,7 @@
     "opening_date",
     "zip_file_createddate",
     "zip_file_name",
-    "classification",
+    "envelope_classification",
     "scannable_items"
   ]
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
@@ -53,14 +53,14 @@ public class MetafileJsonValidatorTestForInvalidFiles {
             .hasMessageStartingWith(
                 getExpectedErrorHeaderLine(SAMPLE_ZIP_FILE_NAME) + "\n\terror: object has missing required properties"
             )
-            .hasMessageContaining("classification")
+            .hasMessageContaining("envelope_classification")
             .hasMessageContaining("jurisdiction")
             .hasMessageContaining("opening_date");
     }
 
     // log as per pair review request:
     // Failed validation against schema:
-    //    object has missing required properties (["classification","jurisdiction"])
+    //    object has missing required properties (["envelope_classification","jurisdiction"])
     //    object has missing required properties (["method"])
     //    object has missing required properties (["scanning_date"])
     //    object has missing required properties (["document_type","file_name"])
@@ -78,7 +78,7 @@ public class MetafileJsonValidatorTestForInvalidFiles {
             .hasMessageStartingWith(
                 getExpectedErrorHeaderLine(SAMPLE_ZIP_FILE_NAME) + "\n\terror: object has missing required properties"
             )
-            .hasMessageContaining("classification")
+            .hasMessageContaining("envelope_classification")
             .hasMessageContaining("jurisdiction")
             .hasMessageContaining("scanning_date")
             .hasMessageContaining("document_type")
@@ -142,7 +142,7 @@ public class MetafileJsonValidatorTestForInvalidFiles {
             .hasMessageContaining("exception")
             .hasMessageContaining("new_application")
             .hasMessageContaining("supplementary_evidence")
-            .hasMessageContaining("instance: {\"pointer\":\"/classification\"}");
+            .hasMessageContaining("instance: {\"pointer\":\"/envelope_classification\"}");
     }
 
     @Test

--- a/src/test/resources/metafiles/invalid/enum-boundaries-for-clasification.json
+++ b/src/test/resources/metafiles/invalid/enum-boundaries-for-clasification.json
@@ -5,7 +5,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "NEW_application",
+  "envelope_classification": "NEW_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/enum-boundaries-for-document-type.json
+++ b/src/test/resources/metafiles/invalid/enum-boundaries-for-document-type.json
@@ -6,7 +6,7 @@
   "opening_date": "31-03-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/invalid-cheque-payment.json
+++ b/src/test/resources/metafiles/invalid/invalid-cheque-payment.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/invalid-date-format.json
+++ b/src/test/resources/metafiles/invalid/invalid-date-format.json
@@ -5,7 +5,7 @@
   "opening_date": "24-02-2017 24:00:00.010000",
   "zip_file_createddate": "24-13-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/invalid-non-scannable-items.json
+++ b/src/test/resources/metafiles/invalid/invalid-non-scannable-items.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/invalid-postal-order-payment.json
+++ b/src/test/resources/metafiles/invalid/invalid-postal-order-payment.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/invalid-scannable-items.json
+++ b/src/test/resources/metafiles/invalid/invalid-scannable-items.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/invalid-zip-file-name-format.json
+++ b/src/test/resources/metafiles/invalid/invalid-zip-file-name-format.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1a_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/no-scannables.json
+++ b/src/test/resources/metafiles/invalid/no-scannables.json
@@ -5,7 +5,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "payments": [
     {
       "document_control_number": "1111002",

--- a/src/test/resources/metafiles/invalid/non-pdf-extension.json
+++ b/src/test/resources/metafiles/invalid/non-pdf-extension.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/use-of-numeric.json
+++ b/src/test/resources/metafiles/invalid/use-of-numeric.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/cash-payment-method.json
+++ b/src/test/resources/metafiles/valid/cash-payment-method.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/cheque-payment-method.json
+++ b/src/test/resources/metafiles/valid/cheque-payment-method.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/from-spec.json
+++ b/src/test/resources/metafiles/valid/from-spec.json
@@ -6,7 +6,7 @@
   "opening_date": "31-03-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/multiple-payment-methods.json
+++ b/src/test/resources/metafiles/valid/multiple-payment-methods.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/no-case-number.json
+++ b/src/test/resources/metafiles/valid/no-case-number.json
@@ -5,7 +5,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/no-non-scannables.json
+++ b/src/test/resources/metafiles/valid/no-non-scannables.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/no-payment.json
+++ b/src/test/resources/metafiles/valid/no-payment.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/valid/postal-payment-method.json
+++ b/src/test/resources/metafiles/valid/postal-payment-method.json
@@ -6,7 +6,7 @@
   "opening_date": "24-02-2017 00:00:00.010000",
   "zip_file_createddate": "24-02-2017 00:00:00.001000",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "classification": "new_application",
+  "envelope_classification": "new_application",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/signature/sample_valid_content/metadata.json
+++ b/src/test/resources/signature/sample_valid_content/metadata.json
@@ -6,7 +6,7 @@
   "opening_date": "23-06-2018 00:00:00.000000",
   "zip_file_createddate": "23-06-2018 00:00:00.000000",
   "zip_file_name": "7_24-06-2018-00-00-00.zip",
-  "classification": "exception",
+  "envelope_classification": "exception",
   "scannable_items": [
       {
         "document_control_number": "1111002",


### PR DESCRIPTION
### Change description ###

Change the name of 'classification' field in metadata file to match the spec. The spec says `envelope_classification` and we've had `classification`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
