### PR TITLE
Make document type mapping case-insensitive

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -9,8 +9,8 @@ import java.util.Set;
 
 public class Document {
 
-    private static final String DOCUMENT_TYPE_CHERISHED = "Cherished";
-    private static final String DOCUMENT_TYPE_OTHER = "Other";
+    private static final String DOCUMENT_TYPE_CHERISHED = "cherished";
+    private static final String DOCUMENT_TYPE_OTHER = "other";
     private static final Set<String> DOCUMENT_TYPES =
         ImmutableSet.of(DOCUMENT_TYPE_CHERISHED, DOCUMENT_TYPE_OTHER);
 
@@ -60,10 +60,10 @@ public class Document {
     // original values in the DB, so that no information is lost. That's why the mapping
     // takes place when putting the message on the queue.
     private static String mapDocumentType(String documentType) {
-        if (DOCUMENT_TYPES.contains(documentType)) {
+        if (DOCUMENT_TYPES.contains(documentType.toLowerCase())) {
             return documentType.toLowerCase();
         } else {
-            return DOCUMENT_TYPE_OTHER.toLowerCase();
+            return DOCUMENT_TYPE_OTHER;
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -45,16 +45,12 @@ public class DocumentTest {
         expectedTypes.put("sscs1", CCD_DOCUMENT_TYPE_OTHER);
         expectedTypes.put("Sscs1", CCD_DOCUMENT_TYPE_OTHER);
 
-
-        for (Map.Entry<String, String> entry : expectedTypes.entrySet()) {
-            String inputDocumentType = entry.getKey();
-            String expectedCcdType = entry.getValue();
-
+        expectedTypes.forEach((inputDocumentType, expectedCcdType) -> {
             ScannableItem scannableItem = scannableItem(inputDocumentType);
             assertThat(Document.fromScannableItem(scannableItem).type)
                 .as(String.format("Expected CCD document type for '%s'", inputDocumentType))
                 .isEqualTo(expectedCcdType);
-        }
+        });
     }
 
     private ScannableItem scannableItem(String documentType) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -6,8 +6,11 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Document.fromScannableItem;
 
@@ -33,13 +36,23 @@ public class DocumentTest {
 
     @Test
     public void fromScannableItem_maps_document_type_correctly() {
-        ScannableItem cherishedScannableItem = scannableItem(DOCUMENT_TYPE_CHERISHED);
-        ScannableItem otherScannableItem = scannableItem(DOCUMENT_TYPE_OTHER);
-        ScannableItem sscs1ScannableItem = scannableItem("SSCS1");
+        assertThat(documentsFromScannableItems("Cherished", "cherished", "CHERISHED"))
+            .extracting("type")
+            .containsOnly(CCD_DOCUMENT_TYPE_CHERISHED);
 
-        assertThat(fromScannableItem(cherishedScannableItem).type).isEqualTo(CCD_DOCUMENT_TYPE_CHERISHED);
-        assertThat(fromScannableItem(otherScannableItem).type).isEqualTo(CCD_DOCUMENT_TYPE_OTHER);
-        assertThat(fromScannableItem(sscs1ScannableItem).type).isEqualTo(CCD_DOCUMENT_TYPE_OTHER);
+        assertThat(documentsFromScannableItems("Other", "other", "OTHER"))
+            .extracting("type")
+            .containsOnly(CCD_DOCUMENT_TYPE_OTHER);
+
+        assertThat(documentsFromScannableItems("SSCS1", "sscs1", "Sscs1"))
+            .extracting("type")
+            .containsOnly(CCD_DOCUMENT_TYPE_OTHER);
+    }
+
+    private List<Document> documentsFromScannableItems(String... inputDocumentTypes) {
+        return Arrays.stream(inputDocumentTypes)
+            .map(type -> fromScannableItem(scannableItem(type)))
+            .collect(toList());
     }
 
     private ScannableItem scannableItem(String documentType) {
@@ -53,7 +66,8 @@ public class DocumentTest {
             ImmutableMap.of("ocr", "data1"),
             "fileName1.pdf",
             "notes 1",
-            documentType
+            documentType,
+            "sscs1"
         );
 
         scannableItem.setDocumentUrl("http://document-url.example.com");


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-402

### Change description ###

Make document type mapping (from DB to queue message) case-insensitive. This is a step towards keeping document types exactly the same as they're in CCD. Once this change has been deployed, it will be followed by a migration scrip that changes the values in db to lowercase. Eventually, this mapping will be gone (as part of current story).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
