### PR TITLE
Lowercase document type

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -150,14 +150,14 @@ public class ServiceBusHelperTest {
         when(scannableItem1.getDocumentUrl()).thenReturn("documentUrl1");
         when(scannableItem1.getDocumentControlNumber()).thenReturn("doc1_control_number");
         when(scannableItem1.getFileName()).thenReturn("doc1_file_name");
-        when(scannableItem1.getDocumentType()).thenReturn("Cherished");
+        when(scannableItem1.getDocumentType()).thenReturn("cherished");
         when(scannableItem1.getScanningDate()).thenReturn(Timestamp.from(Instant.now()));
         when(scannableItem1.getOcrData()).thenReturn(ImmutableMap.of("key1", "value1"));
 
         when(scannableItem2.getDocumentUrl()).thenReturn("documentUrl2");
         when(scannableItem2.getDocumentControlNumber()).thenReturn("doc2_control_number");
         when(scannableItem2.getFileName()).thenReturn("doc2_file_name");
-        when(scannableItem2.getDocumentType()).thenReturn("Other");
+        when(scannableItem2.getDocumentType()).thenReturn("other");
         when(scannableItem2.getScanningDate()).thenReturn(Timestamp.from(Instant.now()));
         when(scannableItem2.getOcrData()).thenReturn(null);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -60,8 +60,8 @@ public class Document {
     // original values in the DB, so that no information is lost. That's why the mapping
     // takes place when putting the message on the queue.
     private static String mapDocumentType(String documentType) {
-        if (DOCUMENT_TYPES.contains(documentType.toLowerCase())) {
-            return documentType.toLowerCase();
+        if (DOCUMENT_TYPES.contains(documentType)) {
+            return documentType;
         } else {
             return DOCUMENT_TYPE_OTHER;
         }

--- a/src/main/resources/db/migration/V021__Make_document_type_lowercase.sql
+++ b/src/main/resources/db/migration/V021__Make_document_type_lowercase.sql
@@ -1,0 +1,2 @@
+UPDATE scannable_items
+SET documentType = lower(documentType);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -6,7 +6,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -15,35 +14,28 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Document.fromS
 
 public class DocumentTest {
 
-    private static final String DOCUMENT_TYPE_CHERISHED = "Cherished";
     private static final String CCD_DOCUMENT_TYPE_CHERISHED = "cherished";
-
     private static final String CCD_DOCUMENT_TYPE_OTHER = "other";
 
     @Test
     public void fromScannableItem_maps_to_document_correctly() {
-        ScannableItem scannableItem = scannableItem(DOCUMENT_TYPE_CHERISHED);
+        String documentType = "cherished";
+        ScannableItem scannableItem = scannableItem(documentType);
         Document document = fromScannableItem(scannableItem);
 
         assertThat(document.controlNumber).isEqualTo(scannableItem.getDocumentControlNumber());
         assertThat(document.fileName).isEqualTo(scannableItem.getFileName());
         assertThat(document.scannedAt).isEqualTo(scannableItem.getScanningDate().toInstant());
-        assertThat(document.type).isEqualTo(CCD_DOCUMENT_TYPE_CHERISHED);
+        assertThat(document.type).isEqualTo(documentType);
         assertThat(document.url).isEqualTo(scannableItem.getDocumentUrl());
     }
 
     @Test
     public void fromScannableItem_maps_document_type_correctly() {
-        Map<String, String> expectedTypes = new HashMap<>();
-        expectedTypes.put("Cherished", CCD_DOCUMENT_TYPE_CHERISHED);
-        expectedTypes.put("cherished", CCD_DOCUMENT_TYPE_CHERISHED);
-        expectedTypes.put("CHERISHED", CCD_DOCUMENT_TYPE_CHERISHED);
-        expectedTypes.put("Other", CCD_DOCUMENT_TYPE_OTHER);
-        expectedTypes.put("other", CCD_DOCUMENT_TYPE_OTHER);
-        expectedTypes.put("OTHER", CCD_DOCUMENT_TYPE_OTHER);
-        expectedTypes.put("SSCS1", CCD_DOCUMENT_TYPE_OTHER);
-        expectedTypes.put("sscs1", CCD_DOCUMENT_TYPE_OTHER);
-        expectedTypes.put("Sscs1", CCD_DOCUMENT_TYPE_OTHER);
+        Map<String, String> expectedTypes = ImmutableMap.of(
+            "cherished", CCD_DOCUMENT_TYPE_CHERISHED,
+            "other", CCD_DOCUMENT_TYPE_OTHER,
+            "sscs1", CCD_DOCUMENT_TYPE_OTHER);
 
         expectedTypes.forEach((inputDocumentType, expectedCcdType) -> {
             ScannableItem scannableItem = scannableItem(inputDocumentType);


### PR DESCRIPTION
### Change description ###

Create a migration script that makes all document types lowercase. Also, stop converting document types to lowercase when creating queue messages (as they're already like that).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
