### PR TITLE
Simplify queue error model.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
@@ -13,7 +13,6 @@ public class ErrorMsg implements Msg {
     public final String documentControlNumber;
     public final ErrorCode errorCode;
     public final String errorDescription;
-    public final boolean testOnly;
 
     // region constructors
     @SuppressWarnings("squid:S00107") // number of params
@@ -25,8 +24,7 @@ public class ErrorMsg implements Msg {
         String poBox,
         String documentControlNumber,
         ErrorCode errorCode,
-        String errorDescription,
-        boolean testOnly
+        String errorDescription
     ) {
         this.id = id;
         this.eventId = eventId;
@@ -36,7 +34,6 @@ public class ErrorMsg implements Msg {
         this.documentControlNumber = documentControlNumber;
         this.errorCode = errorCode;
         this.errorDescription = errorDescription;
-        this.testOnly = testOnly;
     }
     // endregion
 
@@ -48,7 +45,7 @@ public class ErrorMsg implements Msg {
 
     @Override
     public boolean isTestOnly() {
-        return this.testOnly;
+        return false;
     }
     // endregion
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -262,8 +262,7 @@ public class BlobProcessorTask extends Processor {
                             null,
                             null,
                             errorCode,
-                            cause.getMessage(),
-                            false
+                            cause.getMessage()
                         )
                     );
                 } catch (Exception exc) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -16,6 +16,10 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.errors.ErrorNotificationR
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
 
+import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -55,8 +59,7 @@ public class ErrorNotificationServiceTest {
             "po box",
             "document control number",
             ErrorCode.ERR_AV_FAILED,
-            "antivirus flag",
-            true
+            "antivirus flag"
         );
         ErrorNotificationResponse response = new ErrorNotificationResponse("notify id");
         given(client.notify(requestCaptor.capture())).willReturn(response);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -16,10 +16,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.errors.ErrorNotificationR
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
 
-import java.util.function.BinaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 


### PR DESCRIPTION
Always use `false` for `isTestOnly`.
A test endpoint will be used on testing environments, so the scheduled job can always do what it's supposed to do.
