### PR TITLE
Change document types and subtypes to uppercase in DB

### DIFF
--- a/src/main/resources/db/migration/V023__Update_document_types_to_uppercase.sql
+++ b/src/main/resources/db/migration/V023__Update_document_types_to_uppercase.sql
@@ -1,0 +1,5 @@
+UPDATE scannable_items
+SET documentSubtype = upper(documentSubtype) where documentSubtype IS NOT NULL;
+
+UPDATE scannable_items
+SET documentType = upper(documentType);


### PR DESCRIPTION
### Change description ###

Change document types and subtypes to uppercase in DB in order to fix the conversion to and from enums when writing to and reading from the DB.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
