### PR TITLE
Feature: consume notifications

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -115,6 +115,8 @@ module "bulk-scan" {
     NOTIFICATIONS_TO_ORCHESTRATOR_TASK_ENABLED = "${var.orchestrator_notifications_task_enabled}"
     NOTIFICATIONS_TO_ORCHESTRATOR_TASK_DELAY   = "${var.orchestrator_notifications_task_delay}"
 
+    ERROR_NOTIFICATIONS_ENABLED = "${var.error_notifications_enabled}"
+
     STORAGE_BLOB_LEASE_TIMEOUT               = "${var.blob_lease_timeout}"               // In seconds
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES = "${var.blob_processing_delay_in_minutes}"
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -123,6 +123,7 @@ module "bulk-scan" {
 
     QUEUE_ENVELOPE_SEND = "${data.terraform_remote_state.shared_infra.queue_primary_send_connection_string}"
     QUEUE_NOTIFICATIONS_SEND = "${data.terraform_remote_state.shared_infra.notifications_queue_primary_send_connection_string}"
+    QUEUE_NOTIFICATIONS_READ = "${data.terraform_remote_state.shared_infra.notification_primary_listen_connection_string}"
 
     // silence the "bad implementation" logs
     LOGBACK_REQUIRE_ALERT_LEVEL = "false"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -4,3 +4,4 @@ api_gateway_test_valid_certificate_thumbprint = "3B0D23863EE7EF90290AD02B0ACFD7C
 allowed_client_certificate_thumbprints = ["4DA9F2E1E2274DF1C43D3DFCA58ACA3F4B435697"]
 
 blob_processing_delay_in_minutes = "30"
+error_notifications_enabled = "false"

--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -1,7 +1,8 @@
 api_gateway_test_valid_certificate_thumbprint = "91CB9878CD88A6B442E19C12A557B0E79D054E65"
-scan_enabled = true
-reupload_enabled = true
+scan_enabled = "true"
+reupload_enabled = "true"
 orchestrator_notifications_task_delay = "3000"
 orchestrator_notifications_task_enabled = "true"
 blob_signature_verification_key_file = "test_public_key.der"
 capacity = "2"
+error_notifications_enabled = "true"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -89,6 +89,10 @@ variable "scan_enabled" {
   default = "false"
 }
 
+variable "error_notifications_enabled" {
+  default = "true"
+}
+
 variable "orchestrator_notifications_task_enabled" {
   default = "false"
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/NotificationQueueReadDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/NotificationQueueReadDisabledTest.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.features;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+    properties = {
+        "queues.read-notifications.enabled=false"
+    }
+)
+@RunWith(SpringRunner.class)
+
+public class NotificationQueueReadDisabledTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void should_have_error_notification_bean_for_queue_reading_loaded_in_context() {
+        assertThat(context.containsBean("notifications-read")).isFalse();
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/NotificationQueueReadEnabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/NotificationQueueReadEnabledTest.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.features;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+    properties = {
+        "queues.read-notifications.enabled=true"
+    }
+)
+@RunWith(SpringRunner.class)
+
+public class NotificationQueueReadEnabledTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void should_have_error_notification_bean_for_queue_reading_loaded_in_context() {
+        assertThat(context.containsBean("notifications-read")).isTrue();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceBusConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceBusConfiguration.java
@@ -8,6 +8,7 @@ import com.microsoft.azure.servicebus.ReceiveMode;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -57,6 +58,7 @@ public class ServiceBusConfiguration {
     }
 
     @Bean(name = "notifications-read")
+    @ConditionalOnProperty(prefix = "queues.read-notifications", name = "enabled")
     public IQueueClient notificationsQueueReader(
         @Value("${queues.read-notifications.connection-string}") String connectionString,
         @Value("${queues.read-notifications.queue-name}") String queueName,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceBusConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceBusConfiguration.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.servicebus.IMessageHandler;
+import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.QueueClient;
 import com.microsoft.azure.servicebus.ReceiveMode;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
@@ -9,11 +11,20 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.ServiceBusHelper;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.ErrorNotificationHandler;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Lazy
 @Configuration
 public class ServiceBusConfiguration {
+
+    static final ExecutorService QUEUE_READ_EXEC = Executors.newSingleThreadExecutor(r ->
+        new Thread(r, "notifications-queue-read")
+    );
 
     @Bean(name = "envelopes")
     public ServiceBusHelper envelopesQueueHelper(
@@ -43,5 +54,24 @@ public class ServiceBusConfiguration {
             ),
             objectMapper
         );
+    }
+
+    @Bean(name = "notifications-read")
+    public IQueueClient notificationsQueueReader(
+        @Value("${queues.read-notifications.connection-string}") String connectionString,
+        @Value("${queues.read-notifications.queue-name}") String queueName,
+        ErrorNotificationService service,
+        ObjectMapper objectMapper
+    ) throws InterruptedException, ServiceBusException {
+        IQueueClient client = new QueueClient(
+            new ConnectionStringBuilder(connectionString, queueName),
+            ReceiveMode.PEEKLOCK
+        );
+
+        IMessageHandler messageHandler = new ErrorNotificationHandler(service, objectMapper);
+
+        client.registerMessageHandler(messageHandler, QUEUE_READ_EXEC);
+
+        return client;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Message describing an error processing an envelope.
  */
@@ -17,14 +20,14 @@ public class ErrorMsg implements Msg {
     // region constructors
     @SuppressWarnings("squid:S00107") // number of params
     public ErrorMsg(
-        String id,
-        Long eventId,
-        String zipFileName,
-        String jurisdiction,
-        String poBox,
-        String documentControlNumber,
-        ErrorCode errorCode,
-        String errorDescription
+        @JsonProperty(value = "id", required = true) String id,
+        @JsonProperty(value = "eventId", required = true) Long eventId,
+        @JsonProperty(value = "zipFileName", required = true) String zipFileName,
+        @JsonProperty("jurisdiction") String jurisdiction,
+        @JsonProperty("poBox") String poBox,
+        @JsonProperty("documentControlNumber") String documentControlNumber,
+        @JsonProperty(value = "errorCode", required = true) ErrorCode errorCode,
+        @JsonProperty(value = "errorDescription", required = true) String errorDescription
     ) {
         this.id = id;
         this.eventId = eventId;
@@ -38,11 +41,13 @@ public class ErrorMsg implements Msg {
     // endregion
 
     // region getters
+    @JsonIgnore
     @Override
     public String getMsgId() {
         return this.id;
     }
 
+    @JsonIgnore
     @Override
     public boolean isTestOnly() {
         return false;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.servicebus.ExceptionPhase;
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IMessageHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public class ErrorNotificationHandler implements IMessageHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(ErrorNotificationHandler.class);
+
+    private final ErrorNotificationService service;
+
+    private final ObjectMapper mapper;
+
+    static final Executor SIMPLE_EXEC = Runnable::run;
+
+    static final Executor SERVICE_EXEC = Executors.newSingleThreadExecutor(r ->
+        new Thread(r, "error-notification-service")
+    );
+
+
+    public ErrorNotificationHandler(
+        ErrorNotificationService service,
+        ObjectMapper mapper
+    ) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public CompletableFuture<Void> onMessageAsync(IMessage message) {
+        return CompletableFuture
+            .supplyAsync(message::getBody, SIMPLE_EXEC)
+            .thenApplyAsync(this::getErrorMessage, SIMPLE_EXEC)
+            .thenAcceptAsync(this::processMessage, SERVICE_EXEC)
+            .thenRunAsync(() -> log.debug("Error notification consumed. ID {}", message.getMessageId()), SIMPLE_EXEC);
+    }
+
+    private ErrorMsg getErrorMessage(byte[] message) {
+        try {
+            return mapper.readValue(message, ErrorMsg.class);
+        } catch (IOException exception) {
+            throw new InvalidMessageException(
+                "Unable to read error message. Message: " + exception.getMessage(),
+                exception
+            );
+        }
+    }
+
+    private void processMessage(ErrorMsg message) {
+        service.processServiceBusMessage(message);
+    }
+
+    @Override
+    public void notifyException(Throwable exception, ExceptionPhase phase) {
+        log.error(
+            "Exception occurred in phase {}. Message: {}",
+            phase,
+            exception.getMessage(),
+            exception
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,6 +57,9 @@ queues:
   notifications:
     connection-string: ${QUEUE_NOTIFICATIONS_SEND:"NO_VALUE_SUPPLIED"}
     queue-name: notifications
+  read-notifications:
+    connection-string: ${QUEUE_NOTIFICATIONS_READ:"NO_VALUE_SUPPLIED"}
+    queue-name: notifications
 
 accesstoken:
   serviceConfig:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,6 +60,7 @@ queues:
   read-notifications:
     connection-string: ${QUEUE_NOTIFICATIONS_READ:"NO_VALUE_SUPPLIED"}
     queue-name: notifications
+    enabled: ${ERROR_NOTIFICATIONS_ENABLED:false}
 
 accesstoken:
   serviceConfig:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -1,0 +1,120 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willThrow;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ErrorNotificationHandlerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Mock
+    private ErrorNotificationService service;
+
+    private ErrorNotificationHandler handler;
+
+    @Before
+    public void setUp() {
+        handler = new ErrorNotificationHandler(service, MAPPER);
+    }
+
+    @Test
+    public void should_fail_exceptionally_when_trying_parse_the_message_body() {
+        // given
+        IMessage message = getSampleMessage("{}".getBytes());
+
+        // when
+        CompletableFuture<Void> future = handler.onMessageAsync(message);
+
+        // then
+        assertThat(future.isCompletedExceptionally()).isTrue();
+
+        // and
+        Throwable throwable = catchThrowable(future::join);
+        assertThat(throwable.getCause())
+            .isInstanceOf(InvalidMessageException.class)
+            .hasMessageContaining("Unable to read error message. Message: Missing required creator property 'id'");
+
+        // and
+        verify(service, never()).processServiceBusMessage(any(ErrorMsg.class));
+    }
+
+    @Test
+    public void should_fail_exceptionally_when_service_throws_an_error() throws JsonProcessingException {
+        // given
+        ErrorMsg msg = getSampleErrorMessage();
+        IMessage message = getSampleMessage(MAPPER.writeValueAsBytes(msg));
+        willThrow(new RuntimeException("oh no")).given(service).processServiceBusMessage(any(ErrorMsg.class));
+
+        // when
+        CompletableFuture<Void> future = handler.onMessageAsync(message);
+
+        // then
+        assertThat(future.isCompletedExceptionally()).isFalse(); // because void return gets cleaned up instead
+
+        // and
+        Throwable throwable = catchThrowable(future::join);
+        assertThat(throwable.getCause())
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("oh no");
+
+        // and
+        verify(service).processServiceBusMessage(any(ErrorMsg.class));
+    }
+
+    @Test
+    public void should_complete_task_successfully() throws JsonProcessingException {
+        // given
+        ErrorMsg msg = getSampleErrorMessage();
+        IMessage message = getSampleMessage(MAPPER.writeValueAsBytes(msg));
+        doNothing().when(service).processServiceBusMessage(any(ErrorMsg.class));
+
+        // when
+        CompletableFuture<Void> future = handler.onMessageAsync(message);
+
+        // then
+        assertThat(future.isCompletedExceptionally()).isFalse();
+
+        // and
+        verify(service).processServiceBusMessage(any(ErrorMsg.class));
+    }
+
+    private ErrorMsg getSampleErrorMessage() {
+        return new ErrorMsg(
+            "id",
+            0L,
+            "zip_file_name",
+            "jurisdiction",
+            "po_box",
+            "document_control_number",
+            ErrorCode.ERR_AV_FAILED,
+            "av fail"
+        );
+    }
+
+    private IMessage getSampleMessage(byte[] body) {
+        return new Message(UUID.randomUUID().toString(), body, "content-type");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create scheduled job for processing notifications](https://tools.hmcts.net/jira/browse/BPS-288)

### Change description ###

Processing error notifications in the message handler way provided by azure service bus library. Use the benefit of java8 feature of `CompletableFuture` and separate pool as suggested - best to not use common one

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
