### PR TITLE
Fix failing integration tests depending on run order

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -293,11 +292,4 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
         existingEnvelope.setZipDeleted(false);
         envelopeRepository.save(existingEnvelope);
     }
-
-    @After
-    public void cleanUp() {
-        envelopeRepository.deleteAll();
-        processEventRepository.deleteAll();
-    }
-
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -28,6 +28,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDi
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<BlobProcessorTask> {
+
     @Rule
     public OutputCapture outputCapture = new OutputCapture();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -37,7 +37,8 @@ public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<Bl
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
+        super.cleanUp();
         outputCapture.flush();
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DelayedFileProcessingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DelayedFileProcessingTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,11 +38,5 @@ public class DelayedFileProcessingTest extends ProcessorTestSuite<BlobProcessorT
 
         // then
         assertThat(envelopeRepository.findAll()).hasSize(1); // file processed -> envelope created
-    }
-
-    @After
-    public void cleanUp() {
-        envelopeRepository.deleteAll();
-        processEventRepository.deleteAll();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,12 +46,6 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
             SIGNATURE_ALGORITHM,
             DEFAULT_PUBLIC_KEY_BASE64
         );
-    }
-
-    @After
-    public void tearDown() {
-        envelopeRepository.deleteAll();
-        processEventRepository.deleteAll();
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

Inspected intermittent-like behaviour while running pipeline for #373. One test was overriding the parent clean up task causing not clean DB for following tests which check record amounts

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
