### PR TITLE
Feature: message handler to consume error notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Message describing an error processing an envelope.
  */
@@ -17,14 +20,14 @@ public class ErrorMsg implements Msg {
     // region constructors
     @SuppressWarnings("squid:S00107") // number of params
     public ErrorMsg(
-        String id,
-        Long eventId,
-        String zipFileName,
-        String jurisdiction,
-        String poBox,
-        String documentControlNumber,
-        ErrorCode errorCode,
-        String errorDescription
+        @JsonProperty(value = "id", required = true) String id,
+        @JsonProperty(value = "eventId", required = true) Long eventId,
+        @JsonProperty(value = "zipFileName", required = true) String zipFileName,
+        @JsonProperty("jurisdiction") String jurisdiction,
+        @JsonProperty("poBox") String poBox,
+        @JsonProperty("documentControlNumber") String documentControlNumber,
+        @JsonProperty(value = "errorCode", required = true) ErrorCode errorCode,
+        @JsonProperty(value = "errorDescription", required = true) String errorDescription
     ) {
         this.id = id;
         this.eventId = eventId;
@@ -38,11 +41,13 @@ public class ErrorMsg implements Msg {
     // endregion
 
     // region getters
+    @JsonIgnore
     @Override
     public String getMsgId() {
         return this.id;
     }
 
+    @JsonIgnore
     @Override
     public boolean isTestOnly() {
         return false;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.servicebus.ExceptionPhase;
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IMessageHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public class ErrorNotificationHandler implements IMessageHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(ErrorNotificationHandler.class);
+
+    private final ErrorNotificationService service;
+
+    private final ObjectMapper mapper;
+
+    static final Executor SIMPLE_EXEC = Runnable::run;
+
+    static final Executor SERVICE_EXEC = Executors.newSingleThreadExecutor(r ->
+        new Thread(r, "error-notification-service")
+    );
+
+
+    public ErrorNotificationHandler(
+        ErrorNotificationService service,
+        ObjectMapper mapper
+    ) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public CompletableFuture<Void> onMessageAsync(IMessage message) {
+        return CompletableFuture
+            .supplyAsync(message::getBody, SIMPLE_EXEC)
+            .thenApplyAsync(this::getErrorMessage, SIMPLE_EXEC)
+            .thenAcceptAsync(this::processMessage, SERVICE_EXEC)
+            .thenRunAsync(() -> log.debug("Error notification consumed. ID {}", message.getMessageId()), SIMPLE_EXEC);
+    }
+
+    private ErrorMsg getErrorMessage(byte[] message) {
+        try {
+            return mapper.readValue(message, ErrorMsg.class);
+        } catch (IOException exception) {
+            throw new InvalidMessageException(
+                "Unable to read error message. Message: " + exception.getMessage(),
+                exception
+            );
+        }
+    }
+
+    private void processMessage(ErrorMsg message) {
+        service.processServiceBusMessage(message);
+    }
+
+    @Override
+    public void notifyException(Throwable exception, ExceptionPhase phase) {
+        log.error(
+            "Exception occurred in phase {}. Message: {}",
+            phase,
+            exception.getMessage(),
+            exception
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
@@ -23,9 +23,9 @@ public class ErrorNotificationHandler implements IMessageHandler {
 
     private final ObjectMapper mapper;
 
-    static final Executor SIMPLE_EXEC = Runnable::run;
+    private static final Executor SIMPLE_EXEC = Runnable::run;
 
-    static final Executor SERVICE_EXEC = Executors.newSingleThreadExecutor(r ->
+    private static final Executor SERVICE_EXEC = Executors.newSingleThreadExecutor(r ->
         new Thread(r, "error-notification-service")
     );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -1,0 +1,119 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willThrow;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ErrorNotificationHandlerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Mock
+    private ErrorNotificationService service;
+
+    private ErrorNotificationHandler handler;
+
+    @Before
+    public void setUp() {
+        handler = new ErrorNotificationHandler(service, MAPPER);
+    }
+
+    @Test
+    public void should_fail_exceptionally_when_trying_parse_the_message_body() {
+        // given
+        IMessage message = getSampleMessage("{}".getBytes());
+
+        // when
+        CompletableFuture<Void> future = handler.onMessageAsync(message);
+
+        // then
+        assertThat(future.isCompletedExceptionally()).isTrue();
+
+        // and
+        Throwable throwable = catchThrowable(future::join);
+        assertThat(throwable.getCause())
+            .isInstanceOf(InvalidMessageException.class)
+            .hasMessageContaining("Unable to read error message. Message: Missing required creator property 'id'");
+
+        // and
+        verify(service, never()).processServiceBusMessage(any(ErrorMsg.class));
+    }
+
+    @Test
+    public void should_fail_exceptionally_when_service_throws_an_error() throws JsonProcessingException {
+        // given
+        ErrorMsg msg = getSampleErrorMessage();
+        IMessage message = getSampleMessage(MAPPER.writeValueAsBytes(msg));
+        willThrow(new RuntimeException("oh no")).given(service).processServiceBusMessage(any(ErrorMsg.class));
+
+        // when
+        CompletableFuture<Void> future = handler.onMessageAsync(message);
+        Throwable throwable = catchThrowable(future::join);
+
+        // then
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThat(throwable.getCause())
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("oh no");
+
+        // and
+        verify(service).processServiceBusMessage(any(ErrorMsg.class));
+    }
+
+    @Test
+    public void should_complete_task_successfully() throws JsonProcessingException {
+        // given
+        ErrorMsg msg = getSampleErrorMessage();
+        IMessage message = getSampleMessage(MAPPER.writeValueAsBytes(msg));
+        doNothing().when(service).processServiceBusMessage(any(ErrorMsg.class));
+
+        // when
+        CompletableFuture<Void> future = handler.onMessageAsync(message);
+        future.join();
+
+        // then
+        assertThat(future.isCompletedExceptionally()).isFalse();
+
+        // and
+        verify(service).processServiceBusMessage(any(ErrorMsg.class));
+    }
+
+    private ErrorMsg getSampleErrorMessage() {
+        return new ErrorMsg(
+            "id",
+            0L,
+            "zip_file_name",
+            "jurisdiction",
+            "po_box",
+            "document_control_number",
+            ErrorCode.ERR_AV_FAILED,
+            "av fail"
+        );
+    }
+
+    private IMessage getSampleMessage(byte[] body) {
+        return new Message(UUID.randomUUID().toString(), body, "content-type");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create scheduled job for processing notifications](https://tools.hmcts.net/jira/browse/BPS-288)

### Change description ###

Processing error notifications in the message handler way provided by azure service bus library. Use the benefit of java8 feature of `CompletableFuture` and separate execution pool as it is recommended - best to not use common one.

This is extract of #373 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
