### PR TITLE
Remove a failure-related event from a non-failure case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
@@ -127,10 +127,7 @@ public abstract class Processor {
         try {
             // Lease needs to be broken before deleting the blob. 0 implies lease is broken immediately
             cloudBlockBlob.breakLease(0);
-            boolean deleted = cloudBlockBlob.deleteIfExists();
-            if (!deleted) {
-                handleBlobDeletionError(envelope, null);
-            }
+            cloudBlockBlob.deleteIfExists();
             envelope.setZipDeleted(true);
             envelopeProcessor.saveEnvelope(envelope);
             return Boolean.TRUE;


### PR DESCRIPTION
### Change description ###

Remove an failure-related event from a non-failure case. This event is replaced with logs in https://github.com/hmcts/bulk-scan-processor/pull/378

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
