### PR TITLE
Small changes to the processing of failed documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -62,7 +62,7 @@ public class ReuploadFailedEnvelopeTask {
         CompletionService<Void> completionService = new ExecutorCompletionService<>(executorService);
 
         accessMapping
-            .parallelStream()
+            .stream()
             .map(Mapping::getJurisdiction)
             .forEach(jurisdiction -> {
                 FailedDocUploadProcessor processor = getProcessor();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTask.java
@@ -57,7 +57,7 @@ public class ReuploadFailedEnvelopeTask {
     public void processUploadFailures() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(
             accessMapping.size(),
-            r -> new Thread(r, "BSP-REUPLOAD-%d")
+            r -> new Thread(r, "BSP-REUPLOAD")
         );
         CompletionService<Void> completionService = new ExecutorCompletionService<>(executorService);
 


### PR DESCRIPTION
### Change description ###

Small changes to the processing of failed documents:
- Submit the processing of failed documents per jurisdiction in sequence, not in parallel. Submission is cheap and the number of jurisdictions is very small.
- Remove a placeholder for number from thread name - it's treated literally

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
