### PR TITLE
Improve the logging around processing of failed envelopes

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ReuploadFailedEnvelopeTaskTest.java
@@ -18,6 +18,7 @@ import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.DockerComposeContainer;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.FailedDocUploadProcessor;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -81,9 +82,8 @@ public class ReuploadFailedEnvelopeTaskTest {
 
         // then
         assertThat(outputCapture.toString()).containsPattern(".+ERROR \\[.+\\] "
-            + ReuploadFailedEnvelopeTask.class.getCanonicalName()
-            + ":\\d+: "
-            + JpaObjectRetrievalFailureException.class.getCanonicalName()
+            + FailedDocUploadProcessor.class.getCanonicalName()
+            + ":\\d+: An error occurred when processing failed documents for jurisdiction SSCS\\."
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-424

### Change description ###

Improve the logging around processing of failed envelopes

This PR is based on https://github.com/hmcts/bulk-scan-processor/pull/381, which should be reviewed and merged first.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
