### PR TITLE
Feature: exception handling for error notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationException.java
@@ -10,7 +10,7 @@ public class ErrorNotificationException extends RuntimeException {
 
     private final transient ErrorNotificationFailingResponse response;
 
-    ErrorNotificationException(HttpStatusCodeException cause, ErrorNotificationFailingResponse response) {
+    public ErrorNotificationException(HttpStatusCodeException cause, ErrorNotificationFailingResponse response) {
         super(cause);
 
         this.status = cause.getStatusCode();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
@@ -38,8 +38,11 @@ public class ErrorNotificationExceptionHandler {
 
     private IMessage handleErrorNotificationException(IMessage message, ErrorNotificationException exception) {
         if (exception.getStatus().is5xxServerError()) {
-            // instant to be decided
-            errorNotificationPushClient.scheduleMessageAsync(message, Instant.now());
+            // 10th delivery time is 6h delay
+            // Eventually it'll fail in case client is down for quite some time
+            long secondsToAdd = (long) Math.floor(Math.exp((double) message.getDeliveryCount()));
+
+            errorNotificationPushClient.scheduleMessageAsync(message, Instant.now().plusSeconds(secondsToAdd));
 
             return message;
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptionhandlers;
+
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IQueueClient;
+
+public class ErrorNotificationExceptionHandler {
+
+    private final IQueueClient errorNotificationPushClient;
+
+    public ErrorNotificationExceptionHandler(IQueueClient errorNotificationPushClient) {
+        this.errorNotificationPushClient = errorNotificationPushClient;
+    }
+
+    public IMessage handle(IMessage message, Throwable throwable) {
+        if (throwable != null) {
+            // decide whether to dead-letter (throw exc) or re-schedule the message.
+            throw (RuntimeException) throwable;
+        } else {
+            return message;
+        }
+        // return for logging part. and future requires something to be returned other than void
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
@@ -32,6 +32,8 @@ public class ErrorNotificationExceptionHandler {
 
             throw exception;
         } catch (ErrorNotificationException exception) {
+            log.error("Failed to publish error notification", exception);
+
             return handleErrorNotificationException(message, exception);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
@@ -56,9 +56,10 @@ public class ErrorNotificationService {
             log.info("Error notification published. ID: {}", response.getNotificationId());
         } catch (Exception exception) {
             log.error("Failed to publish error notification", exception);
-        }
 
-        // save the entity after everything is processed
-        repository.save(entity);
+            throw exception;
+        } finally {
+            repository.save(entity);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
@@ -54,10 +54,6 @@ public class ErrorNotificationService {
             entity.setNotificationId(response.getNotificationId());
 
             log.info("Error notification published. ID: {}", response.getNotificationId());
-        } catch (Exception exception) {
-            log.error("Failed to publish error notification", exception);
-
-            throw exception;
         } finally {
             repository.save(entity);
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.servicebus.ExceptionPhase;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageHandler;
+import com.microsoft.azure.servicebus.IQueueClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
@@ -23,6 +24,8 @@ public class ErrorNotificationHandler implements IMessageHandler {
 
     private final ObjectMapper mapper;
 
+    private final IQueueClient errorNotificationPush;
+
     private static final Executor SIMPLE_EXEC = Runnable::run;
 
     private static final Executor SERVICE_EXEC = Executors.newSingleThreadExecutor(r ->
@@ -32,10 +35,12 @@ public class ErrorNotificationHandler implements IMessageHandler {
 
     public ErrorNotificationHandler(
         ErrorNotificationService service,
-        ObjectMapper mapper
+        ObjectMapper mapper,
+        IQueueClient errorNotificationPush
     ) {
         this.service = service;
         this.mapper = mapper;
+        this.errorNotificationPush = errorNotificationPush;
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandlerTest.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptionhandlers;
+
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IQueueClient;
+import com.microsoft.azure.servicebus.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpStatusCodeException;
+import uk.gov.hmcts.reform.bulkscanprocessor.client.ErrorNotificationException;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ErrorNotificationExceptionHandlerTest {
+
+    @Mock
+    private IQueueClient queueClient;
+
+    private ErrorNotificationExceptionHandler handler;
+
+    @Before
+    public void setUp() {
+        handler = new ErrorNotificationExceptionHandler(queueClient);
+    }
+
+    @Test
+    public void should_return_same_message_in_case_no_error_to_be_handled() {
+        // given
+        Message message = new Message("content");
+
+        // when
+        IMessage handledMessage = handler.handle(message, null);
+
+        // then
+        assertThat(handledMessage).isEqualTo(message);
+    }
+
+    @Test
+    public void should_handle_non_RuntimeException_cases_by_catching_the_cast() {
+        Throwable throwable = catchThrowable(() -> handler.handle(null, new IOException("oh no")));
+
+        assertThat(throwable).isInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void should_handle_ErrorNotificationException_with_4xx_error() {
+        // given
+        ErrorNotificationException exception = new ErrorNotificationException(
+            new HttpStatusCodeException(HttpStatus.BAD_REQUEST) {},
+            null
+        );
+
+        // when
+        Throwable throwable = catchThrowable(() -> handler.handle(null, exception));
+
+        // then
+        assertThat(throwable).isEqualTo(exception);
+
+        // and
+        verify(queueClient, never()).scheduleMessageAsync(any(IMessage.class), any(Instant.class));
+    }
+
+    @Test
+    public void should_reschedule_message_in_case_ErrorNotificationException_is_with_5xx_error() {
+        // given
+        Message message = new Message("content");
+        ErrorNotificationException exception = new ErrorNotificationException(
+            new HttpStatusCodeException(HttpStatus.INTERNAL_SERVER_ERROR) {},
+            null
+        );
+
+        // when
+        IMessage handledMessage = handler.handle(message, exception);
+
+        // then
+        assertThat(handledMessage).isEqualTo(message);
+
+        // and
+        verify(queueClient).scheduleMessageAsync(eq(message), any(Instant.class));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -92,6 +92,7 @@ public class ErrorNotificationServiceTest {
         verify(repository).save(any(ErrorNotification.class));
     }
 
+    @Test
     public void should_save_to_db_and_log_the_failure_when_notification_is_attempted() {
         // given
         ErrorMsg serviceBusMessage = new ErrorMsg(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -112,7 +112,6 @@ public class ErrorNotificationServiceTest {
 
         // then
         assertThat(throwable).isInstanceOf(RuntimeException.class).hasMessage("oh no");
-        assertThat(capture.toString()).contains("Failed to publish error notification");
 
         // and
         verify(repository).save(any(ErrorNotification.class));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.Message;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,11 +34,14 @@ public class ErrorNotificationHandlerTest {
     @Mock
     private ErrorNotificationService service;
 
+    @Mock
+    private IQueueClient queueClient;
+
     private ErrorNotificationHandler handler;
 
     @Before
     public void setUp() {
-        handler = new ErrorNotificationHandler(service, MAPPER);
+        handler = new ErrorNotificationHandler(service, MAPPER, queueClient);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -51,12 +51,12 @@ public class ErrorNotificationHandlerTest {
 
         // when
         CompletableFuture<Void> future = handler.onMessageAsync(message);
+        Throwable throwable = catchThrowable(future::join);
 
         // then
         assertThat(future.isCompletedExceptionally()).isTrue();
 
         // and
-        Throwable throwable = catchThrowable(future::join);
         assertThat(throwable.getCause())
             .isInstanceOf(InvalidMessageException.class)
             .hasMessageContaining("Unable to read error message");


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create scheduled job for processing notifications](https://tools.hmcts.net/jira/browse/BPS-288)

### Change description ###

First version of exception handling. Uses built in completable future feature to custom-ly handle outcome (whether failed or not) and proceed as one wishes. We only need to make sure that in certain cases message gets re-scheduled. For simplicity, client 5xx errors are re-scheduled only as any other at the time being is more of a failure which doesn't need to be re-addressed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
