### PR TITLE
Allow filtering out test jurisdiction from envelope count report

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -31,9 +31,10 @@ public class ReportsController {
     @GetMapping(path = "/count-summary")
     @ApiOperation("Retrieves envelope count summary report")
     public EnvelopeCountSummaryReportListResponse getCountSummary(
-        @RequestParam(name = "date") @DateTimeFormat(iso = DATE) LocalDate date
+        @RequestParam(name = "date") @DateTimeFormat(iso = DATE) LocalDate date,
+        @RequestParam(name = "include-test", defaultValue = "false", required = false) boolean includeTestJurisdiction
     ) {
-        List<EnvelopeCountSummary> result = this.reportsService.getCountFor(date);
+        List<EnvelopeCountSummary> result = this.reportsService.getCountFor(date, includeTestJurisdiction);
         return new EnvelopeCountSummaryReportListResponse(
             result
                 .stream()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
@@ -5,11 +5,14 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummary
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
 @Service
 public class ReportsService {
+
+    public static final String TEST_JURISDICTION = "BULKSCAN";
 
     private final EnvelopeCountSummaryRepository repo;
 
@@ -17,10 +20,11 @@ public class ReportsService {
         this.repo = repo;
     }
 
-    public List<EnvelopeCountSummary> getCountFor(LocalDate date) {
+    public List<EnvelopeCountSummary> getCountFor(LocalDate date, boolean includeTestJurisdiction) {
         return repo
             .getReportFor(date)
             .stream()
+            .filter(it -> includeTestJurisdiction || !Objects.equals(it.getJurisdiction(), TEST_JURISDICTION))
             .map(it -> new EnvelopeCountSummary(
                 it.getReceived(),
                 it.getRejected(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -64,6 +64,13 @@ public class ReportsControllerTest {
     }
 
     @Test
+    public void should_not_include_test_jurisdiction_if_exlicitly_not_requested_by_the_client() throws Exception {
+        mockMvc.perform(get("/reports/count-summary?date=2019-01-14&include-test=false"));
+
+        verify(reportsService).getCountFor(LocalDate.of(2019, 1, 14), false);
+    }
+
+    @Test
     public void should_return_400_if_date_is_invalid() throws Exception {
         final String invalidDate = "2019-14-14";
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -35,7 +36,7 @@ public class ReportsControllerTest {
             100, 11, "hello", LocalDate.of(2019, 1, 14)
         );
 
-        given(reportsService.getCountFor(countSummary.date))
+        given(reportsService.getCountFor(countSummary.date, false))
             .willReturn(singletonList(countSummary));
 
         mockMvc
@@ -46,6 +47,20 @@ public class ReportsControllerTest {
             .andExpect(jsonPath("$.data[0].rejected").value(countSummary.rejected))
             .andExpect(jsonPath("$.data[0].jurisdiction").value(countSummary.jurisdiction))
             .andExpect(jsonPath("$.data[0].date").value(countSummary.date.toString()));
+    }
+
+    @Test
+    public void should_not_include_test_jurisdiction_by_default() throws Exception {
+        mockMvc.perform(get("/reports/count-summary?date=2019-01-14"));
+
+        verify(reportsService).getCountFor(LocalDate.of(2019, 1, 14), false);
+    }
+
+    @Test
+    public void should_include_test_jurisdiction_if_requested_by_the_client() throws Exception {
+        mockMvc.perform(get("/reports/count-summary?date=2019-01-14&include-test=true"));
+
+        verify(reportsService).getCountFor(LocalDate.of(2019, 1, 14), true);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -15,6 +15,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService.TEST_JURISDICTION;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReportsServiceTest {
@@ -38,7 +39,7 @@ public class ReportsServiceTest {
             ));
 
         // when
-        List<EnvelopeCountSummary> result = service.getCountFor(now());
+        List<EnvelopeCountSummary> result = service.getCountFor(now(), false);
 
         // then
         assertThat(result)
@@ -50,12 +51,29 @@ public class ReportsServiceTest {
     }
 
     @Test
+    public void should_filter_out_test_jurisdiction_when_requested() {
+        given(repo.getReportFor(now()))
+            .willReturn(asList(
+                new Item(now(), TEST_JURISDICTION, 100, 1),
+                new Item(now(), "SOME_OTHER_JURISDICTION", 10, 0)
+            ));
+
+        // when
+        List<EnvelopeCountSummary> resultWithoutTestJurisdiction = service.getCountFor(now(), false);
+        List<EnvelopeCountSummary> resultWithTestJurisdiction = service.getCountFor(now(), true);
+
+        // then
+        assertThat(resultWithoutTestJurisdiction).hasSize(1);
+        assertThat(resultWithTestJurisdiction).hasSize(2);
+    }
+
+    @Test
     public void should_map_empty_list_from_repo() {
         given(repo.getReportFor(now()))
             .willReturn(emptyList());
 
         // when
-        List<EnvelopeCountSummary> result = service.getCountFor(now());
+        List<EnvelopeCountSummary> result = service.getCountFor(now(), false);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -64,6 +64,8 @@ public class ReportsServiceTest {
 
         // then
         assertThat(resultWithoutTestJurisdiction).hasSize(1);
+        assertThat(resultWithoutTestJurisdiction.get(0).jurisdiction).isEqualTo("SOME_OTHER_JURISDICTION");
+
         assertThat(resultWithTestJurisdiction).hasSize(2);
     }
 


### PR DESCRIPTION
By default `BULKSCAN` envelopes are now excluded from the report, but it is possible to add extra query parameter to include them (for testing purposes).