### PR TITLE
Add helper to add 'zero' rows to report

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/JurisdictionsConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/JurisdictionsConfig.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
+
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+@Configuration
+public class JurisdictionsConfig {
+
+    private final EnvelopeAccessProperties envelopeAccessProperties;
+
+    public JurisdictionsConfig(EnvelopeAccessProperties envelopeAccessProperties) {
+        this.envelopeAccessProperties = envelopeAccessProperties;
+    }
+
+    @Bean(name = "jurisdictions")
+    public Set<String> getKnownJurisdictions() {
+        return envelopeAccessProperties
+            .getMappings()
+            .stream()
+            .map(Mapping::getJurisdiction)
+            .collect(toSet());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFiller.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFiller.java
@@ -24,9 +24,14 @@ public class ZeroRowFiller {
     public List<EnvelopeCountSummary> fill(List<EnvelopeCountSummary> listToFill, LocalDate date) {
         return Stream.concat(
             listToFill.stream(),
-            Sets.difference(jurisdictions, listToFill.stream().map(res -> res.jurisdiction).collect(toSet()))
-                .stream()
-                .map(jur -> new EnvelopeCountSummary(0, 0, jur, date))
+            missingJurisdictions(listToFill).stream().map(jur -> new EnvelopeCountSummary(0, 0, jur, date))
         ).collect(toList());
+    }
+
+    private Set<String> missingJurisdictions(List<EnvelopeCountSummary> listToFill) {
+        return Sets.difference(
+            this.jurisdictions,
+            listToFill.stream().map(res -> res.jurisdiction).collect(toSet())
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFiller.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFiller.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+
+import com.google.common.collect.Sets;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+@Component
+public class ZeroRowFiller {
+
+    private final Set<String> jurisdictions;
+
+    public ZeroRowFiller(@Qualifier("jurisdictions") Set<String> jurisdictions) {
+        this.jurisdictions = jurisdictions;
+    }
+
+    public List<EnvelopeCountSummary> fill(List<EnvelopeCountSummary> listToFill, LocalDate date) {
+        return Stream.concat(
+            listToFill.stream(),
+            Sets.difference(jurisdictions, listToFill.stream().map(res -> res.jurisdiction).collect(toSet()))
+                .stream()
+                .map(jur -> new EnvelopeCountSummary(0, 0, jur, date))
+        ).collect(toList());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 
-
 import org.junit.Test;
 
 import java.util.List;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.time.LocalDate.now;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.internal.util.collections.Sets.newSet;
+
+public class ZeroRowFillerTest {
+
+    @Test
+    public void should_add_missing_zero_row_when_needed() {
+        // given
+        ZeroRowFiller filler = new ZeroRowFiller(newSet("A", "B", "C"));
+
+        List<EnvelopeCountSummary> listToFill = asList(
+            new EnvelopeCountSummary(100, 101, "A", now()),
+            new EnvelopeCountSummary(200, 201, "B", now())
+        );
+
+        // when
+        List<EnvelopeCountSummary> result = filler.fill(listToFill, now());
+
+        // then
+        assertThat(result)
+            .usingFieldByFieldElementComparator()
+            .containsExactly(
+                new EnvelopeCountSummary(100, 101, "A", now()),
+                new EnvelopeCountSummary(200, 201, "B", now()),
+                new EnvelopeCountSummary(0, 0, "C", now())
+            );
+    }
+
+    @Test
+    public void should_not_change_input_list_if_all_jurisdictions_are_present() {
+        // given
+        ZeroRowFiller filler = new ZeroRowFiller(newSet("A", "B"));
+
+        List<EnvelopeCountSummary> listToFill = asList(
+            new EnvelopeCountSummary(100, 101, "A", now()),
+            new EnvelopeCountSummary(200, 201, "B", now())
+        );
+
+        // when
+        List<EnvelopeCountSummary> result = filler.fill(listToFill, now());
+
+        // then
+        assertThat(result)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyElementsOf(listToFill);
+    }
+}


### PR DESCRIPTION
There's a new requirement, that there should be a row for every existing jurisdiction, even if there were no envelopes in DB for given day and jurisdiction.

I'll plug this helper to the service layer in next PR.