### PR TITLE
Fix service exception

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
@@ -53,12 +53,9 @@ public class ErrorNotificationService {
 
             entity.setNotificationId(response.getNotificationId());
 
-            log.info("Error notification published. ID: {}", response.getNotificationId());
-        } catch (Exception exception) {
-            log.error("Failed to publish error notification", exception);
+            log.info("Error notification for {} published. ID: {}", message.zipFileName, response.getNotificationId());
+        } finally {
+            repository.save(entity);
         }
-
-        // save the entity after everything is processed
-        repository.save(entity);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
@@ -61,7 +61,11 @@ public class ErrorNotificationHandler implements IMessageHandler {
 
     private ErrorMsg getErrorMessage(byte[] message) {
         try {
-            return mapper.readValue(message, ErrorMsg.class);
+            ErrorMsg msg = mapper.readValue(message, ErrorMsg.class);
+
+            log.info("Processing error notification for {}", msg.zipFileName);
+
+            return msg;
         } catch (IOException exception) {
             throw new InvalidMessageException("Unable to read error message", exception);
         }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -86,7 +86,7 @@ public class ErrorNotificationServiceTest {
 
         // and
         assertThat(capture.toString()).contains(
-            "Error notification published. ID: " + response.getNotificationId()
+            "Error notification for " + request.zipFileName + " published. ID: " + response.getNotificationId()
         );
         verify(repository).save(any(ErrorNotification.class));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create scheduled job for processing notifications](https://tools.hmcts.net/jira/browse/BPS-288)

### Change description ###

Since inclusion of exception handler was the most confusing part to observers I think during some jugglery of those PRs and commits to accommodate smoothness lost this bit of gotcha. Service should through an error for handler to catch it

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
