### PR TITLE
Hotfix access level for entity constructor

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEvent.java
@@ -30,7 +30,7 @@ public class ProcessEvent {
     private Event event;
     private String reason;
 
-    private ProcessEvent() {
+    public ProcessEvent() {
         // For use by hibernate.
     }
 


### PR DESCRIPTION
### Change description ###

For basic JPA interactions private access is fine. Since we do not want to get the entity just create a reference while generating notifications to providers, hibernate requires this entity to be publicly accessible

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
