### PR TITLE
Base envelope count report on events

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEvent.java
@@ -52,6 +52,10 @@ public class ProcessEvent {
         return createdAt;
     }
 
+    public void setCreatedAt(Timestamp createdAt) {
+        this.createdAt = createdAt;
+    }
+
     public long getId() {
         return id;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/EnvelopeCountSummaryRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/EnvelopeCountSummaryRepository.java
@@ -13,14 +13,19 @@ public interface EnvelopeCountSummaryRepository extends JpaRepository<Envelope, 
 
     @Query(
         nativeQuery = true,
-        value = "SELECT "
-            + "  date(createdat) AS date, "
-            + "  jurisdiction, "
-            + "  count(*) AS received, "
-            + "  SUM(CASE WHEN status in ('METADATA_FAILURE', 'SIGNATURE_FAILURE') THEN 1 ELSE 0 END) AS rejected "
-            + "FROM envelopes "
-            + "GROUP BY date(createdat), jurisdiction "
-            + "HAVING date(createdat) = :date"
+        value = "SELECT\n" +
+            "  container as jurisdiction,\n" +
+            "  date,\n" +
+            "  count(*) AS received,\n" +
+            "  SUM(CASE WHEN event IN ('DOC_FAILURE', 'FILE_VALIDATION_FAILURE', 'DOC_SIGNATURE_FAILURE') THEN 1 ELSE 0 END) AS rejected\n" +
+            "FROM (\n" +
+            "  SELECT DISTINCT on (container, zipfilename)\n" +
+            "  container, zipfilename, date(createdat), event\n" +
+            "  FROM process_events\n" +
+            "  ORDER BY container, zipfilename, date(createdat) ASC\n" +
+            ") AS first_events\n" +
+            "GROUP BY container, date\n" +
+            "HAVING date = :date"
     )
     List<EnvelopeCountSummaryItem> getReportFor(@Param("date") LocalDate date);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/EnvelopeCountSummaryRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/EnvelopeCountSummaryRepository.java
@@ -9,23 +9,24 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@SuppressWarnings("checkstyle:LineLength")
 public interface EnvelopeCountSummaryRepository extends JpaRepository<Envelope, UUID> {
 
     @Query(
         nativeQuery = true,
-        value = "SELECT\n" +
-            "  container as jurisdiction,\n" +
-            "  date,\n" +
-            "  count(*) AS received,\n" +
-            "  SUM(CASE WHEN event IN ('DOC_FAILURE', 'FILE_VALIDATION_FAILURE', 'DOC_SIGNATURE_FAILURE') THEN 1 ELSE 0 END) AS rejected\n" +
-            "FROM (\n" +
-            "  SELECT DISTINCT on (container, zipfilename)\n" +
-            "  container, zipfilename, date(createdat), event\n" +
-            "  FROM process_events\n" +
-            "  ORDER BY container, zipfilename, date(createdat) ASC\n" +
-            ") AS first_events\n" +
-            "GROUP BY container, date\n" +
-            "HAVING date = :date"
+        value = "SELECT\n"
+            + "  container as jurisdiction,\n"
+            + "  date,\n"
+            + "  count(*) AS received,\n"
+            + "  SUM(CASE WHEN event IN ('DOC_FAILURE', 'FILE_VALIDATION_FAILURE', 'DOC_SIGNATURE_FAILURE') THEN 1 ELSE 0 END) AS rejected\n"
+            + "FROM (\n"
+            + "  SELECT DISTINCT on (container, zipfilename)\n"
+            + "  container, zipfilename, date(createdat), event\n"
+            + "  FROM process_events\n"
+            + "  ORDER BY container, zipfilename, date(createdat) ASC\n"
+            + ") AS first_events\n"
+            + "GROUP BY container, date\n"
+            + "HAVING date = :date"
     )
     List<EnvelopeCountSummaryItem> getReportFor(@Param("date") LocalDate date);
 }


### PR DESCRIPTION
As envelope is not created when zip file is rejected :/

Using `DISTINCT ON` to find the first event for each zip file.
https://zaiste.net/postgresql_distinct_on/