### PR TITLE
Update log message to include more information

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
@@ -190,7 +190,13 @@ public abstract class Processor {
             envelopeProcessor.handleEvent(envelope, event);
             return Boolean.TRUE;
         } catch (Exception exception) {
-            log.error(exception.getMessage(), exception);
+            log.error(
+                "Failed to update database for the event: {} zip file: {} jurisdiction: {}",
+                event.name(),
+                envelope.getZipFileName(),
+                envelope.getJurisdiction(),
+                exception
+            );
             return Boolean.FALSE;
         }
     }


### PR DESCRIPTION
Probate files are not being processed in the demo environment. 
Added zip file name and jurisdiction information to log message for debugging purpose.