### PR TITLE
Run nightly builds later

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,7 @@
 
 properties([
   // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-  pipelineTriggers([cron('H 05 * * *')])
+  pipelineTriggers([cron('H 07 * * *')])
 ])
 
 @Library("Infrastructure")


### PR DESCRIPTION
The 'fresher' the dependency check results the better.