### PR TITLE
Serialise OCR data in queue message as a list

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
@@ -31,7 +31,6 @@ public class OcrDataSerializationJourneyTest {
     @Autowired
     private EnvelopeRepository repository;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void should_deserialize_all_ocr_fields_in_insertion_order() throws Exception {
         ObjectMapper mapper = new ObjectMapper().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.ocr.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.EnvelopeMsg;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Msg;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.MsgLabel;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.OcrField;
 
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -137,11 +138,16 @@ public class ServiceBusHelperTest {
 
         assertThat(jsonNode.hasNonNull("ocr_data")).isTrue();
 
-        OcrData ocrData =
-            objectMapper.readValue(jsonNode.get("ocr_data").toString(), OcrData.class);
+        OcrField[] actualOcrData =
+            objectMapper.readValue(jsonNode.get("ocr_data").toString(), OcrField[].class);
 
-        ScannableItem scannableItemWithOcrData = envelope.getScannableItems().get(0);
-        assertThat(ocrData).isEqualToComparingFieldByFieldRecursively(scannableItemWithOcrData.getOcrData());
+        OcrField[] expectedOcrData = {
+            new OcrField("key1", "value1")
+        };
+
+        assertThat(actualOcrData)
+            .usingFieldByFieldElementComparator()
+            .isEqualTo(expectedOcrData);
     }
 
     private void mockEnvelopeData() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/ocr/OcrDataField.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/ocr/OcrDataField.java
@@ -8,10 +8,10 @@ import com.fasterxml.jackson.databind.node.ValueNode;
 public class OcrDataField {
 
     @JsonProperty(value = "metadata_field_name")
-    private TextNode name;
+    public final TextNode name;
 
     @JsonProperty(value = "metadata_field_value")
-    private ValueNode value;
+    public final ValueNode value;
 
     @JsonCreator
     public OcrDataField(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/OcrField.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/OcrField.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OcrField {
+
+    @JsonProperty("metadata_field_name")
+    private String name;
+
+    @JsonProperty("metadata_field_value")
+    private String value;
+
+    @JsonCreator
+    public OcrField(
+        @JsonProperty("metadata_field_name") String name,
+        @JsonProperty("metadata_field_value") String value
+    ) {
+        this.name = name;
+        this.value = value;
+    }
+}


### PR DESCRIPTION
### Change description ###

Serialise OCR data in queue message as a list. Before this change, it was an object containing a list.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
