### PR TITLE
Create a base class for exceptions related with validation failures

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/FileNameIrregularitiesException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/FileNameIrregularitiesException.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
-public class FileNameIrregularitiesException extends RuntimeException {
+public class FileNameIrregularitiesException extends InvalidEnvelopeException {
 
     public FileNameIrregularitiesException(String message) {
         super(message);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/InvalidEnvelopeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/InvalidEnvelopeException.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+/**
+ * Base class for all exceptions that represent invalid envelope situation.
+ */
+public abstract class InvalidEnvelopeException extends RuntimeException {
+
+    public InvalidEnvelopeException(String message) {
+        super(message);
+    }
+
+    public InvalidEnvelopeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/InvalidEnvelopeSchemaException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/InvalidEnvelopeSchemaException.java
@@ -6,7 +6,7 @@ import com.github.fge.jsonschema.core.report.ProcessingReport;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class InvalidEnvelopeSchemaException extends RuntimeException {
+public class InvalidEnvelopeSchemaException extends InvalidEnvelopeException {
 
     public InvalidEnvelopeSchemaException(ProcessingReport report, String zipFileName) {
         super(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/MetadataNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/MetadataNotFoundException.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
-public class MetadataNotFoundException extends RuntimeException {
+public class MetadataNotFoundException extends InvalidEnvelopeException {
     private static final long serialVersionUID = 1395897001657755898L;
 
     public MetadataNotFoundException(String message) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/NonPdfFileFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/NonPdfFileFoundException.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
-public class NonPdfFileFoundException extends RuntimeException {
+public class NonPdfFileFoundException extends InvalidEnvelopeException {
 
     private static final long serialVersionUID = 9143161748679833084L;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataNotFoundException.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
-public class OcrDataNotFoundException extends RuntimeException {
+public class OcrDataNotFoundException extends InvalidEnvelopeException {
 
     public OcrDataNotFoundException(String message) {
         super(message);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataParseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataParseException.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
-public class OcrDataParseException extends RuntimeException {
+public class OcrDataParseException extends InvalidEnvelopeException {
 
     public OcrDataParseException(String message, Throwable cause) {
         super(message, cause);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -17,12 +17,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocSignatureFailureException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.FileNameIrregularitiesException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidEnvelopeSchemaException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.MetadataNotFoundException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.NonPdfFileFoundException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataNotFoundException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataParseException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidEnvelopeException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.PreviouslyFailedToUploadException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
@@ -248,13 +243,7 @@ public class BlobProcessorTask extends Processor {
             result.setEnvelope(envelopeProcessor.saveEnvelope(toDbEnvelope(envelope, containerName)));
 
             return result;
-        } catch (InvalidEnvelopeSchemaException
-            | OcrDataNotFoundException
-            | FileNameIrregularitiesException
-            | NonPdfFileFoundException
-            | OcrDataParseException
-            | MetadataNotFoundException ex
-        ) {
+        } catch (InvalidEnvelopeException ex) {
             log.warn("Rejected file {} from container {} - invalid", zipFilename, containerName, ex);
             handleInvalidFileError(Event.FILE_VALIDATION_FAILURE, containerName, zipFilename, leaseId, ex);
             return null;


### PR DESCRIPTION
### Change description ###

This PR is a proposal and can be rejected if you don't like it.

Create a base class for exceptions related with validation failures. This makes the handling slightly simpler.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
