### PR TITLE
Check if blob exists before trying to process it

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -140,7 +140,7 @@ public class BlobProcessorTask extends Processor {
         try {
             processZipFileIfEligible(container, zipFilename);
         } catch (Exception ex) {
-            log.error("Failed to process file {} from container {}", ex);
+            log.error("Failed to process file {} from container {}", zipFilename, container.getName(), ex);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -108,7 +108,7 @@ public class BlobProcessorTask extends Processor {
     }
 
     @Scheduled(fixedDelayString = "${scheduling.task.scan.delay}")
-    public void processBlobs() throws IOException, StorageException, URISyntaxException {
+    public void processBlobs() {
         log.info("Started blob processing job");
 
         for (CloudBlobContainer container : blobManager.listInputContainers()) {
@@ -118,8 +118,7 @@ public class BlobProcessorTask extends Processor {
         log.info("Finished blob processing job");
     }
 
-    private void processZipFiles(CloudBlobContainer container)
-        throws IOException, StorageException, URISyntaxException {
+    private void processZipFiles(CloudBlobContainer container) {
         log.info("Processing blobs for container {}", container.getName());
 
         // Randomise iteration order to minimise lease acquire contention
@@ -131,41 +130,50 @@ public class BlobProcessorTask extends Processor {
         );
         Collections.shuffle(zipFilenames);
         for (String zipFilename : zipFilenames) {
-            processZipFile(container, zipFilename);
+            tryProcessZipFile(container, zipFilename);
         }
 
         log.info("Finished processing blobs for container {}", container.getName());
     }
 
-    private void processZipFile(CloudBlobContainer container, String zipFilename)
+    private void tryProcessZipFile(CloudBlobContainer container, String zipFilename) {
+        try {
+            processZipFileIfEligible(container, zipFilename);
+        } catch (Exception ex) {
+            log.error("Failed to process file {} from container {}", ex);
+        }
+    }
+
+    private void processZipFileIfEligible(CloudBlobContainer container, String zipFilename)
         throws IOException, StorageException, URISyntaxException {
         log.info("Processing zip file {} from container {}", zipFilename, container.getName());
+
         CloudBlockBlob cloudBlockBlob = container.getBlockBlobReference(zipFilename);
-        cloudBlockBlob.downloadAttributes();
-
-        if (!isReadyToBeProcessed(cloudBlockBlob)) {
-            log.info(
-                "Aborted processing of zip file {} from container {} - not ready yet.",
-                zipFilename,
-                container.getName()
-            );
-
-            return;
-        }
 
         Envelope existingEnvelope =
             envelopeProcessor.getEnvelopeByFileAndContainer(container.getName(), zipFilename);
+
         if (existingEnvelope != null) {
-            log.warn(
-                "Envelope for zip file {} (container {}) already exists. Aborting its processing.",
-                zipFilename,
-                container.getName()
-            );
-
+            logAbortedProcessingFilePresentInDb(zipFilename, container.getName());
             deleteIfProcessed(cloudBlockBlob, existingEnvelope, container.getName());
-            return;
-        }
+        } else if (!cloudBlockBlob.exists()) {
+            logAbortedProcessingNonExistingFile(zipFilename, container.getName());
+        } else {
+            cloudBlockBlob.downloadAttributes();
 
+            if (!isReadyToBeProcessed(cloudBlockBlob)) {
+                logAbortedProcessingNotReadyFile(zipFilename, container.getName());
+            } else {
+                processZipFile(container, cloudBlockBlob, zipFilename);
+            }
+        }
+    }
+
+    private void processZipFile(
+        CloudBlobContainer container,
+        CloudBlockBlob cloudBlockBlob,
+        String zipFilename
+    ) throws StorageException, IOException {
         Optional<String> leaseId = blobManager.acquireLease(cloudBlockBlob, container.getName(), zipFilename);
 
         if (leaseId.isPresent()) {
@@ -321,6 +329,30 @@ public class BlobProcessorTask extends Processor {
             zipFilename,
             containerName,
             messageId
+        );
+    }
+
+    private void logAbortedProcessingNotReadyFile(String zipFilename, String containerName) {
+        log.info(
+            "Aborted processing of zip file {} from container {} - not ready yet.",
+            zipFilename,
+            containerName
+        );
+    }
+
+    private void logAbortedProcessingNonExistingFile(String zipFilename, String containerName) {
+        log.info(
+            "Aborted processing of zip file {} from container {} - doesn't exist anymore.",
+            zipFilename,
+            containerName
+        );
+    }
+
+    private void logAbortedProcessingFilePresentInDb(String containerName, String zipFilename) {
+        log.warn(
+            "Envelope for zip file {} (container {}) already exists. Aborting its processing.",
+            zipFilename,
+            containerName
         );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-497

### Change description ###

Check if blob exists before trying to process it. Also, prevent failure of the whole job when the processing of a single file fails (i.e. keep processing files). 

Backstory: multiple jobs run at the same time, each doing the following:
- retrieve all blobs from given container
- process the blobs in random order

This can (and does) lead to situations when two jobs retrieve blob lists containing the same blob and by the time one job has got to the file, the other job has already processed and deleted it. There are two problems related with this:
1. Processing fails because file doesn't exist and we're polluting logs with this kind of errors
2. The whole job fails, i.e. no other files are processed

This PR addresses both issues.

Unit tests don't exist for `BlobProcessorTask`, only integration tests. There's a story to introduce them (https://tools.hmcts.net/jira/browse/BPS-489), but it's a bigger piece of work, as the code will need to be reformatted in order to allow for proper testing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
