### PR TITLE
Add service for returning zip file status

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepoTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepoTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
 @SuppressWarnings("checkstyle:LineLength")
@@ -58,6 +59,24 @@ public class EnvelopeRepoTest {
 
         // then
         assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void findByZipFileName_should_find_envelops_in_db() {
+        // given
+        dbHas(
+            envelope("A.zip", "X", Status.PROCESSED),
+            envelope("A.zip", "Y", Status.UPLOAD_FAILURE),
+            envelope("B.zip", "Z", Status.UPLOAD_FAILURE)
+        );
+
+        // when
+        List<Envelope> resultForA = repo.findByZipFileName("A.zip");
+        List<Envelope> resultForX = repo.findByZipFileName("X.zip");
+
+        // then
+        assertThat(resultForA).hasSize(2);
+        assertThat(resultForX).hasSize(0);
     }
 
     @After

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepoTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepoTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
 @SuppressWarnings("checkstyle:LineLength")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepositoryTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.entity;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+@RunWith(SpringRunner.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+public class ProcessEventRepositoryTest {
+
+    @Autowired
+    private ProcessEventRepository repo;
+
+    @Test
+    public void findByZipFileName_should_find_events_in_db() {
+        // given
+        repo.saveAll(asList(
+            new ProcessEvent("A", "hello.zip", Event.DOC_PROCESSED),
+            new ProcessEvent("B", "hello.zip", Event.DOC_PROCESSED),
+            new ProcessEvent("C", "world.zip", Event.DOC_PROCESSED)
+        ));
+
+        // when
+        List<ProcessEvent> resultForHello = repo.findByZipFileName("hello.zip");
+        List<ProcessEvent> resultForX = repo.findByZipFileName("x.zip");
+
+        // then
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(resultForHello)
+            .usingElementComparatorOnFields("container", "zipFileName", "event")
+            .containsExactlyInAnyOrder(
+                new ProcessEvent("A", "hello.zip", Event.DOC_PROCESSED),
+                new ProcessEvent("B", "hello.zip", Event.DOC_PROCESSED)
+            );
+
+        softly.assertThat(resultForX).hasSize(0);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -25,6 +25,8 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
 
     List<Envelope> findByStatus(Status status);
 
+    List<Envelope> findByZipFileName(String zipFileName);
+
     /**
      * Finds envelope with a blob not deleted for a given container and zip file name.
      *

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepository.java
@@ -2,5 +2,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProcessEventRepository extends JpaRepository<ProcessEvent, Long> {
+    List<ProcessEvent> findByZipFileName(String zipFileName);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusService.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.zipfilestatus;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.zipfilestatus.model.ZipFileStatus;
+
+@Service
+public class ZipFileStatusService {
+
+    private final ProcessEventRepository eventRepo;
+    private final EnvelopeRepository envelopeRepo;
+
+    // region constructor
+
+    public ZipFileStatusService(ProcessEventRepository eventRepo, EnvelopeRepository envelopeRepo) {
+        this.eventRepo = eventRepo;
+        this.envelopeRepo = envelopeRepo;
+    }
+
+    // endregion
+
+    public ZipFileStatus getStatusFor(String zipFileName) {
+        return new ZipFileStatus(
+            envelopeRepo.findByZipFileName(zipFileName),
+            eventRepo.findByZipFileName(zipFileName)
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/model/ZipFileStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/model/ZipFileStatus.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.zipfilestatus.model;
+
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
+
+import java.util.List;
+
+public class ZipFileStatus {
+
+    public final List<Envelope> envelopes;
+    public final List<ProcessEvent> events;
+
+    public ZipFileStatus(List<Envelope> envelopes, List<ProcessEvent> events) {
+        this.envelopes = envelopes;
+        this.events = events;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -78,6 +78,10 @@ public final class EnvelopeCreator {
     }
 
     public static Envelope envelope(String jurisdiction, Status status) {
+        return envelope(UUID.randomUUID() + ".zip", jurisdiction, status);
+    }
+
+    public static Envelope envelope(String zipFileName, String jurisdiction, Status status) {
         Timestamp timestamp = getTimestamp();
 
         Envelope envelope = new Envelope(
@@ -86,7 +90,7 @@ public final class EnvelopeCreator {
             timestamp,
             timestamp,
             timestamp,
-            UUID.randomUUID() + ".zip",
+            zipFileName,
             "1111222233334446",
             Classification.EXCEPTION,
             scannableItems(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.zipfilestatus;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.zipfilestatus.model.ZipFileStatus;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ZipFileStatusServiceTest {
+
+    @Mock private ProcessEventRepository eventRepo;
+    @Mock private EnvelopeRepository envelopeRepo;
+
+    private ZipFileStatusService service;
+
+    @Before
+    public void setUp() throws Exception {
+        this.service = new ZipFileStatusService(eventRepo, envelopeRepo);
+    }
+
+    @Test
+    public void should_return_envelopes_and_events_from_db() {
+        // given
+        List<ProcessEvent> events = asList(
+            new ProcessEvent("container_A", "hello.zip", Event.DOC_UPLOADED),
+            new ProcessEvent("container_A", "hello.zip", Event.DOC_PROCESSED),
+            new ProcessEvent("container_B", "hello.zip", Event.DOC_UPLOADED),
+            new ProcessEvent("container_B", "hello.zip", Event.DOC_PROCESSED),
+            new ProcessEvent("container_C", "hello.zip", Event.DOC_FAILURE)
+        );
+
+        List<Envelope> envelopes = asList(
+            EnvelopeCreator.envelope("container_A", Status.PROCESSED),
+            EnvelopeCreator.envelope("container_B", Status.PROCESSED)
+        );
+
+        given(envelopeRepo.findByZipFileName("hello.zip")).willReturn(envelopes);
+        given(eventRepo.findByZipFileName("hello.zip")).willReturn(events);
+
+        // when
+        ZipFileStatus result = service.getStatusFor("hello.zip");
+
+        // then
+        assertThat(result.envelopes)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrderElementsOf(envelopes);
+
+        assertThat(result.events)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrderElementsOf(events);
+    }
+
+    @Test
+    public void should_return_empty_lists_when_no_data_for_zip_file_was_found() {
+        // given
+        given(envelopeRepo.findByZipFileName("hello.zip")).willReturn(emptyList());
+        given(eventRepo.findByZipFileName("hello.zip")).willReturn(emptyList());
+
+        // when
+        ZipFileStatus result = service.getStatusFor("hello.zip");
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.envelopes).isNotNull().isEmpty();
+        assertThat(result.events).isNotNull().isEmpty();
+    }
+}


### PR DESCRIPTION
### Create end-point to return envelope status and events by zip file name
https://tools.hmcts.net/jira/browse/BPS-451

1. **Add service layer**
2. Add controller layer

In this PR I just add the service that will be called by the new endpoint.

Note that there may exist multiple envelopes with the same zip file name (in different jurisdictions).

