### PR TITLE
Replace save() with saveAndFlush() when using JPA repositories

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
@@ -38,7 +38,7 @@ public class EnvelopeTest {
         Envelope envelope = EnvelopeCreator.envelope();
 
         // and
-        UUID envelopeId = repository.save(envelope).getId();
+        UUID envelopeId = repository.saveAndFlush(envelope).getId();
 
         // when
         Envelope readEnvelope = repository.getOne(envelopeId);
@@ -54,7 +54,7 @@ public class EnvelopeTest {
         envelope.setContainer(null);
 
         // when
-        Envelope dbEnvelope = repository.save(envelope);
+        Envelope dbEnvelope = repository.saveAndFlush(envelope);
 
         // then
         assertThat(capture.toString()).containsPattern(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ErrorNotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ErrorNotificationRepositoryTest.java
@@ -33,7 +33,7 @@ public class ErrorNotificationRepositoryTest {
 
     @Before
     public void setUp() {
-        eventId = eventRepository.save(
+        eventId = eventRepository.saveAndFlush(
             new ProcessEvent("container", "zip_file_name", Event.DOC_FAILURE)
         ).getId();
     }
@@ -52,7 +52,7 @@ public class ErrorNotificationRepositoryTest {
         );
 
         // when
-        long dbId = repository.save(errorNotification).getId();
+        long dbId = repository.saveAndFlush(errorNotification).getId();
 
         // then
         ErrorNotification dbItem = repository.getOne(dbId);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItemTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItemTest.java
@@ -39,7 +39,7 @@ public class ScannableItemTest {
         envelope.setContainer("container");
 
         // and
-        List<ScannableItem> items = envelopeRepository.save(envelope).getScannableItems();
+        List<ScannableItem> items = envelopeRepository.saveAndFlush(envelope).getScannableItems();
 
         // when
         scannableItemRepository.saveAll(items.stream()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
@@ -48,7 +48,7 @@ public class OcrDataSerializationJourneyTest {
             .isInstanceOf(OcrData.class);
 
         Envelope dbEnvelope = EnvelopeMapper.toDbEnvelope(inputEnvelope, "test");
-        UUID envelopeId = repository.save(dbEnvelope).getId();
+        UUID envelopeId = repository.saveAndFlush(dbEnvelope).getId();
 
         Envelope readEnvelope = repository.getOne(envelopeId);
         AssertionsForInterfaceTypes.assertThat(readEnvelope.getScannableItems().get(0).getOcrData())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverTest.java
@@ -107,7 +107,7 @@ public class EnvelopeRetrieverTest {
     @Test
     public void should_retrieve_single_envelope_by_id() throws Exception {
         // given
-        Envelope envelopeIdDb = envelopeRepo.save(envelope("X", Status.PROCESSED));
+        Envelope envelopeIdDb = envelopeRepo.saveAndFlush(envelope("X", Status.PROCESSED));
         serviceCanReadFromJurisdiction("service_X", "X");
 
         // when
@@ -120,7 +120,7 @@ public class EnvelopeRetrieverTest {
     @Test
     public void should_return_empty_optional_if_envelope_is_not_found() throws Exception {
         // given
-        envelopeRepo.save(envelope("X", Status.PROCESSED));
+        envelopeRepo.saveAndFlush(envelope("X", Status.PROCESSED));
         serviceCanReadFromJurisdiction("service_X", "X");
 
         // when
@@ -133,7 +133,7 @@ public class EnvelopeRetrieverTest {
     @Test
     public void should_throw_an_exception_if_service_cannot_read_existing_envelope() throws Exception {
         // given
-        Envelope envelopeForServiceB = envelopeRepo.save(envelope("B", Status.PROCESSED));
+        Envelope envelopeForServiceB = envelopeRepo.saveAndFlush(envelope("B", Status.PROCESSED));
         serviceCanReadFromJurisdiction("service_A", "A");
 
         // when
@@ -153,7 +153,7 @@ public class EnvelopeRetrieverTest {
 
     private void dbContains(Envelope... envelopes) {
         for (Envelope env : envelopes) {
-            envelopeRepo.save(env);
+            envelopeRepo.saveAndFlush(env);
         }
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -290,6 +290,6 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
         existingEnvelope.setZipFileName(zipFileName);
         existingEnvelope.setContainer(testContainer.getName());
         existingEnvelope.setZipDeleted(false);
-        envelopeRepository.save(existingEnvelope);
+        envelopeRepository.saveAndFlush(existingEnvelope);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTaskTest.java
@@ -47,7 +47,7 @@ public class OrchestratorNotificationTaskTest {
     @Test
     public void should_update_envelope_status_and_events_after_sending_notification() {
         // given
-        Envelope envelopeInDb = envelopeRepo.save(envelope("some_jurisdiction", Status.PROCESSED));
+        Envelope envelopeInDb = envelopeRepo.saveAndFlush(envelope("some_jurisdiction", Status.PROCESSED));
 
         // when
         task.run();
@@ -67,7 +67,7 @@ public class OrchestratorNotificationTaskTest {
     @Test
     public void should_not_update_envelope_and_create_an_event_if_sending_notification_failed() {
         // given
-        Envelope envelopeInDb = envelopeRepo.save(envelope("some_jurisdiction", Status.PROCESSED));
+        Envelope envelopeInDb = envelopeRepo.saveAndFlush(envelope("some_jurisdiction", Status.PROCESSED));
 
         doThrow(InvalidMessageException.class)
             .when(serviceBusHelper).sendMessage(any());

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateService.java
@@ -53,12 +53,12 @@ public class EnvelopeUpdateService {
         statusChangeValidator.assertCanUpdate(envelope.getStatus(), newStatus);
 
         envelope.setStatus(newStatus);
-        envelopeRepo.save(envelope);
+        envelopeRepo.saveAndFlush(envelope);
         log.info("Updated envelope {} status from {} to {}.", envelope.getId(), envelope.getStatus(), newStatus);
 
         Event event = eventForStatusChange.get(newStatus);
         if (event != null) {
-            eventRepo.save(new ProcessEvent(
+            eventRepo.saveAndFlush(new ProcessEvent(
                 envelope.getContainer(),
                 envelope.getZipFileName(),
                 event

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
@@ -55,7 +55,7 @@ public class ErrorNotificationService {
 
             log.info("Error notification for {} published. ID: {}", message.zipFileName, response.getNotificationId());
         } finally {
-            repository.save(entity);
+            repository.saveAndFlush(entity);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTask.java
@@ -87,7 +87,7 @@ public class OrchestratorNotificationTask {
     }
 
     private void createEvent(Envelope envelope, Event event) {
-        processEventRepo.save(
+        processEventRepo.saveAndFlush(
             new ProcessEvent(
                 envelope.getContainer(),
                 envelope.getZipFileName(),
@@ -98,6 +98,6 @@ public class OrchestratorNotificationTask {
 
     private void updateStatus(Envelope envelope) {
         envelope.setStatus(Status.NOTIFICATION_SENT);
-        envelopeRepo.save(envelope);
+        envelopeRepo.saveAndFlush(envelope);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
@@ -86,7 +86,7 @@ public abstract class Processor {
         );
 
         processEvent.setReason(reason);
-        long eventId = eventRepository.save(processEvent).getId();
+        long eventId = eventRepository.saveAndFlush(processEvent).getId();
 
         log.info(
             "Zip {} from {} marked as {}",
@@ -122,7 +122,7 @@ public abstract class Processor {
 
     private void incrementUploadFailureCount(Envelope envelope) {
         envelope.setUploadFailureCount(envelope.getUploadFailureCount() + 1);
-        envelopeRepository.save(envelope);
+        envelopeRepository.saveAndFlush(envelope);
     }
 
     private Boolean deleteBlob(
@@ -205,7 +205,7 @@ public abstract class Processor {
         Status.fromEvent(event).ifPresent(status -> {
             envelope.setStatus(status);
 
-            envelopeRepository.save(envelope);
+            envelopeRepository.saveAndFlush(envelope);
 
             log.info(
                 "Change envelope {} from {} and {} status to {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
@@ -102,7 +102,7 @@ public class EnvelopeProcessor {
     }
 
     public Envelope saveEnvelope(Envelope envelope) {
-        Envelope dbEnvelope = envelopeRepository.save(envelope);
+        Envelope dbEnvelope = envelopeRepository.saveAndFlush(envelope);
 
         log.info("Envelope for jurisdiction {} and zip file name {} successfully saved in database.",
             envelope.getJurisdiction(),
@@ -121,13 +121,13 @@ public class EnvelopeProcessor {
     }
 
     public void handleEvent(Envelope envelope, Event event) {
-        processEventRepository.save(
+        processEventRepository.saveAndFlush(
             new ProcessEvent(envelope.getContainer(), envelope.getZipFileName(), event)
         );
 
         Status.fromEvent(event).ifPresent(status -> {
             envelope.setStatus(status);
-            envelopeRepository.save(envelope);
+            envelopeRepository.saveAndFlush(envelope);
         });
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeUpdateServiceTest.java
@@ -69,7 +69,7 @@ public class EnvelopeUpdateServiceTest {
 
         // then status should be updated
         ArgumentCaptor<Envelope> envelopeParam = ArgumentCaptor.forClass(Envelope.class);
-        verify(envelopeRepo).save(envelopeParam.capture());
+        verify(envelopeRepo).saveAndFlush(envelopeParam.capture());
         assertThat(envelopeParam.getValue().getStatus()).isEqualTo(CONSUMED);
     }
 
@@ -83,7 +83,7 @@ public class EnvelopeUpdateServiceTest {
 
         // then
         ArgumentCaptor<ProcessEvent> eventParam = ArgumentCaptor.forClass(ProcessEvent.class);
-        verify(eventRepo).save(eventParam.capture());
+        verify(eventRepo).saveAndFlush(eventParam.capture());
         assertThat(eventParam.getValue().getEvent()).isEqualTo(Event.DOC_CONSUMED);
     }
 
@@ -96,6 +96,6 @@ public class EnvelopeUpdateServiceTest {
         service.updateStatus(randomUUID(), UPLOAD_FAILURE, "some_service");
 
         // then
-        verify(eventRepo, never()).save(any());
+        verify(eventRepo, never()).saveAndFlush(any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -88,7 +88,7 @@ public class ErrorNotificationServiceTest {
         assertThat(capture.toString()).contains(
             "Error notification for " + request.zipFileName + " published. ID: " + response.getNotificationId()
         );
-        verify(repository).save(any(ErrorNotification.class));
+        verify(repository).saveAndFlush(any(ErrorNotification.class));
     }
 
     public void should_save_to_db_and_log_the_failure_when_notification_is_attempted() {
@@ -110,6 +110,6 @@ public class ErrorNotificationServiceTest {
 
         // then
         assertThat(capture.toString()).contains("Failed to publish error notification.");
-        verify(repository).save(any(ErrorNotification.class));
+        verify(repository).saveAndFlush(any(ErrorNotification.class));
     }
 }


### PR DESCRIPTION
### Change description ###

When saving envelopes to DB, call `saveAndFlush()` method on JPA repository, instead of `save()`. This way we make sure the envelope is saved in the DB immediately and we don't leave any pending changes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
