### PR TITLE
Log response from error response received via Feign Client

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -193,8 +193,7 @@ public class ErrorNotificationHandlerTest {
         assertThat(output).containsPattern("INFO  \\[error-notification-handler\\] "
             + ErrorNotificationExceptionHandler.class.getCanonicalName()
             + ":\\d+: Error occurred when posting notification. "
-            + "Parsed response: doh. "
-            + "Raw response: some body"
+            + "Parsed response: doh"
         );
         assertThat(output).containsPattern("Caused by: "
             + ErrorNotificationException.class.getCanonicalName()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -33,6 +33,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.MessageAutoCompletor;
 
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -108,7 +109,7 @@ public class ErrorNotificationHandlerTest {
         given(notificationClient.notify(any(ErrorNotificationRequest.class)))
             .willThrow(new ErrorNotificationException(
                 new HttpServerErrorException(INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR.getReasonPhrase()),
-                new ErrorNotificationFailingResponse("doh")
+                null
             ));
 
         // when
@@ -132,6 +133,14 @@ public class ErrorNotificationHandlerTest {
             + MESSAGE_ID
             + "\\) after 1 delivery attempt\n"
         );
+        assertThat(output).doesNotContainPattern("INFO  \\[error-notification-handler\\] "
+            + ErrorNotificationExceptionHandler.class.getCanonicalName()
+            + ":\\d+: Error occurred when posting notification. Parsed response:"
+        );
+        assertThat(output).doesNotContainPattern("INFO  \\[error-notification-handler\\] "
+            + ErrorNotificationExceptionHandler.class.getCanonicalName()
+            + ":\\d+: Error occurred when posting notification. Raw response:"
+        );
         assertThat(output).containsPattern("Caused by: "
             + ErrorNotificationException.class.getCanonicalName()
             + ": "
@@ -149,7 +158,12 @@ public class ErrorNotificationHandlerTest {
         // and
         given(notificationClient.notify(any(ErrorNotificationRequest.class)))
             .willThrow(new ErrorNotificationException(
-                new HttpClientErrorException(BAD_REQUEST, BAD_REQUEST.getReasonPhrase()),
+                new HttpClientErrorException(
+                    BAD_REQUEST,
+                    BAD_REQUEST.getReasonPhrase(),
+                    "some body".getBytes(),
+                    StandardCharsets.UTF_8
+                ),
                 new ErrorNotificationFailingResponse("doh")
             ));
         given(queueClient.deadLetterAsync(any(UUID.class), eq("Client error"), anyString()))
@@ -175,6 +189,12 @@ public class ErrorNotificationHandlerTest {
             + ":\\d+: Client error. Dead lettering message \\(ID: "
             + MESSAGE_ID
             + "\\)\n"
+        );
+        assertThat(output).containsPattern("INFO  \\[error-notification-handler\\] "
+            + ErrorNotificationExceptionHandler.class.getCanonicalName()
+            + ":\\d+: Error occurred when posting notification. "
+            + "Parsed response: doh. "
+            + "Raw response: some body"
         );
         assertThat(output).containsPattern("Caused by: "
             + ErrorNotificationException.class.getCanonicalName()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationException.java
@@ -24,4 +24,8 @@ public class ErrorNotificationException extends RuntimeException {
     public ErrorNotificationFailingResponse getResponse() {
         return response;
     }
+
+    public String getResponseRawBody() {
+        return ((HttpStatusCodeException) getCause()).getResponseBodyAsString();
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandler.java
@@ -107,9 +107,7 @@ public class ErrorNotificationExceptionHandler {
             builder
                 .append(". Parsed response: ")
                 .append(exception.getResponse().getMessage());
-        }
-
-        if (!StringUtils.isEmpty(exception.getResponseRawBody())) {
+        } else if (!StringUtils.isEmpty(exception.getResponseRawBody())) {
             toLog = true;
             builder
                 .append(". Raw response: ")
@@ -117,7 +115,9 @@ public class ErrorNotificationExceptionHandler {
         }
 
         if (toLog) {
-            log.info(builder.toString());
+            // trying to please sonar
+            String message = builder.toString();
+            log.info(message);
         }
     }
 }


### PR DESCRIPTION
### Change description ###

Response interceptors are not supported with feign library so need to handle them separately.
Since decoder did all the work and passed info to `ErrorNotificationException` "wrapper", we just need to log it in relevant place this occurs which is exception handler. Logging as separate entry to not get chunked in case massive response comes back. Logging as info as following logs are the actual piece of information in which we suppose to pay more attention

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
