### PR TITLE
Introduce request interceptor for error notification client

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationClientTest.java
@@ -219,7 +219,7 @@ public class ErrorNotificationClientTest {
     private void assertRequestLogs(ErrorNotificationRequest request) {
         List<String> logs = Arrays.asList(capture.toString().split("\n"));
         Pattern pattern = Pattern.compile(
-            "INFO.+\\[main\\] "
+            "INFO.+\\[.+\\] "
                 + ErrorNotificationClient.class.getCanonicalName()
                 + ":\\d+: Error notification body:"
         );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationConfiguration.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.RequestInterceptor;
 import feign.auth.BasicAuthRequestInterceptor;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 
@@ -23,6 +26,16 @@ public class ErrorNotificationConfiguration {
         @Value("${error_notifications.password}") String password
     ) {
         return new BasicAuthRequestInterceptor(username, password, StandardCharsets.UTF_8);
+    }
+
+    @Bean
+    public RequestInterceptor logRequestBodyInterceptor() {
+        // let's choose client itself where request "originates"
+        Logger logger = LoggerFactory.getLogger(ErrorNotificationClient.class);
+
+        return template -> {
+            logger.info("Error notification body:\n{}", new String(template.body()));
+        };
     }
 
     @Bean


### PR DESCRIPTION
### Change description ###

Just _lambda_ injecting the interceptor in feign client configuration. Feel free to suggest any other way because to my eyes having `ErrorNotificationConfiguration` logger was not really a spot on.

Lot's of refurbishment in client test to track request body in "nicer" way

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
