### PR TITLE
Create a service for finalising processed envelopes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
@@ -135,6 +135,10 @@ public class ScannableItem implements EnvelopeAssignable {
         return ocrData;
     }
 
+    public void setOcrData(OcrData ocrData) {
+        this.ocrData = ocrData;
+    }
+
     public String getNotes() {
         return notes;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
@@ -6,14 +6,15 @@ import java.util.Optional;
 
 public enum Status {
 
-    CONSUMED, // client service handled the documents
+    CONSUMED,           // client service handled the documents
     CREATED,
-    METADATA_FAILURE, // when we are aware of envelope, but there are inconsistency among files and metadata info
-    SIGNATURE_FAILURE, // the zip archive failed signature verification
-    PROCESSED, // after storing all docs in DM
+    METADATA_FAILURE,   // when we are aware of envelope, but there are inconsistency among files and metadata info
+    SIGNATURE_FAILURE,  // the zip archive failed signature verification
+    PROCESSED,          // after storing all docs in DM
     UPLOADED,
     UPLOAD_FAILURE,
-    NOTIFICATION_SENT; // after notifying that processing is complete
+    NOTIFICATION_SENT,  // after notifying about a new envelope
+    COMPLETED;          // final state - the envelope has been successfully processed by the service
 
     public static Optional<Status> fromEvent(Event event) {
         switch (event) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/EnvelopeNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/EnvelopeNotFoundException.java
@@ -1,4 +1,12 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
 public class EnvelopeNotFoundException extends RuntimeException {
+
+    public EnvelopeNotFoundException() {
+        super();
+    }
+
+    public EnvelopeNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
@@ -13,4 +13,5 @@ public enum Event {
     BLOB_DELETE_FAILURE, // when blob is not successfully deleted after processing is complete
     DOC_PROCESSED_NOTIFICATION_SENT, // when document processed notification is posted (to servicebus queue)
     DOC_PROCESSED_NOTIFICATION_FAILURE, // when document processed notification fails
+    COMPLETED, // the processing of the envelope completed successfully
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserService.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.EnvelopeNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
+
+import java.util.UUID;
+import javax.transaction.Transactional;
+
+@Service
+public class EnvelopeFinaliserService {
+
+    private final EnvelopeRepository envelopeRepository;
+    private final ProcessEventRepository processEventRepository;
+
+    public EnvelopeFinaliserService(
+        EnvelopeRepository envelopeRepository,
+        ProcessEventRepository processEventRepository
+    ) {
+        this.envelopeRepository = envelopeRepository;
+        this.processEventRepository = processEventRepository;
+    }
+
+    @Transactional
+    public void finaliseEnvelope(UUID envelopeId) {
+        Envelope envelope = findEnvelope(envelopeId);
+
+        envelope.getScannableItems().forEach(item -> item.setOcrData(null));
+        envelope.setStatus(Status.COMPLETED);
+        envelopeRepository.save(envelope);
+
+        processEventRepository.save(
+            new ProcessEvent(envelope.getContainer(), envelope.getZipFileName(), Event.COMPLETED)
+        );
+    }
+
+    private Envelope findEnvelope(UUID envelopeId) {
+        return envelopeRepository.findById(envelopeId)
+            .orElseThrow(() ->
+                new EnvelopeNotFoundException(
+                    String.format("Envelope with ID %s couldn't be found", envelopeId)
+                )
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.Lists.newArrayList;
+
 public final class EnvelopeCreator {
 
     private static final MetafileJsonValidator validator;
@@ -187,13 +189,13 @@ public final class EnvelopeCreator {
     }
 
     private static List<NonScannableItem> nonScannableItems() {
-        return ImmutableList.of(
+        return newArrayList(
             new NonScannableItem("1111001", "CD", "4GB USB memory stick")
         );
     }
 
     private static List<Payment> payments() {
-        return ImmutableList.of(
+        return newArrayList(
             new Payment(
                 "1111002",
                 "Cheque",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
@@ -1,0 +1,157 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.EnvelopeNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.ocr.OcrData;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.ocr.OcrDataField;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EnvelopeFinaliserServiceTest {
+
+    @Mock
+    private EnvelopeRepository envelopeRepository;
+
+    @Mock
+    private ProcessEventRepository processEventRepository;
+
+    private EnvelopeFinaliserService envelopeFinaliserService;
+
+    @Before
+    public void setUp() {
+        envelopeFinaliserService = new EnvelopeFinaliserService(
+            envelopeRepository,
+            processEventRepository
+        );
+    }
+
+    @Test
+    public void finaliseEnvelope_should_update_envelope_status_clear_all_ocr_data() {
+        // given
+        UUID envelopeId = UUID.randomUUID();
+
+        Envelope envelope = envelope(
+            "JURISDICTION1",
+            Status.NOTIFICATION_SENT,
+            createScannableItemsWithOcrData(3)
+        );
+
+        given(envelopeRepository.findById(envelopeId)).willReturn(Optional.of(envelope));
+
+        // when
+        envelopeFinaliserService.finaliseEnvelope(envelopeId);
+
+        // then
+        verify(envelopeRepository).findById(envelopeId);
+        ArgumentCaptor<Envelope> envelopeCaptor = ArgumentCaptor.forClass(Envelope.class);
+        verify(envelopeRepository).save(envelopeCaptor.capture());
+        verifyNoMoreInteractions(envelopeRepository);
+
+        Envelope savedEnvelope = envelopeCaptor.getValue();
+        assertThat(savedEnvelope.getStatus()).isEqualTo(Status.COMPLETED);
+
+        assertThat(savedEnvelope.getScannableItems())
+            .extracting("ocrData")
+            .containsOnlyNulls();
+    }
+
+    @Test
+    public void finaliseEnvelope_should_create_event_of_type_completed() {
+        // given
+        Envelope envelope = envelope("JURISDICTION1", Status.NOTIFICATION_SENT, emptyList());
+
+        given(envelopeRepository.findById(any())).willReturn(Optional.of(envelope));
+
+        // when
+        envelopeFinaliserService.finaliseEnvelope(UUID.randomUUID());
+
+        // then
+        ArgumentCaptor<ProcessEvent> processEventCaptor = ArgumentCaptor.forClass(ProcessEvent.class);
+        verify(processEventRepository).save(processEventCaptor.capture());
+        verifyNoMoreInteractions(processEventRepository);
+
+        ProcessEvent savedEvent = processEventCaptor.getValue();
+        assertThat(savedEvent.getContainer()).isEqualTo(envelope.getContainer());
+        assertThat(savedEvent.getEvent()).isEqualTo(Event.COMPLETED);
+        assertThat(savedEvent.getZipFileName()).isEqualTo(envelope.getZipFileName());
+    }
+
+    @Test
+    public void finaliseEnvelope_should_throw_exception_when_envelope_is_not_found() {
+        given(envelopeRepository.findById(any())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            envelopeFinaliserService.finaliseEnvelope(
+                UUID.fromString("ef2565fd-74f5-418e-9d8c-7bf847edde80")
+            )
+        )
+            .isInstanceOf(EnvelopeNotFoundException.class)
+            .hasMessage("Envelope with ID ef2565fd-74f5-418e-9d8c-7bf847edde80 couldn't be found");
+    }
+
+    private List<ScannableItem> createScannableItemsWithOcrData(int count) {
+        return Stream.generate(() -> {
+            Timestamp timestamp = Timestamp.from(Instant.parse("2018-06-23T12:34:56.123Z"));
+
+            ScannableItem scannableItem = new ScannableItem(
+                "1111001",
+                timestamp,
+                "test",
+                "test",
+                "return",
+                timestamp,
+                createOcrData(),
+                "1111001.pdf",
+                "test",
+                DocumentType.CHERISHED,
+                null
+            );
+
+            scannableItem.setDocumentUrl("http://localhost:8080/documents/0fa1ab60-f836-43aa-8c65-b07cc9bebceb");
+            return scannableItem;
+        })
+            .limit(count)
+            .collect(toList());
+    }
+
+    private OcrData createOcrData() {
+        OcrData ocrData = new OcrData();
+        ocrData.setFields(Arrays.asList(
+            new OcrDataField(new TextNode("key1"), new TextNode("value1")),
+            new OcrDataField(new TextNode("key2"), new TextNode("value2"))
+        ));
+
+        return ocrData;
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-452

### Change description ###

**Create a service for finalising processed envelopes, by creating an appropriate event, clearing OCR data and updating envelope status.**

Next: use that service when processing messages from the 'processed-envelopes' queue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
