### PR TITLE
Use safer assertJ's `extracting`

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/WhenRunningTheApplicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/WhenRunningTheApplicationTest.java
@@ -41,7 +41,7 @@ public class WhenRunningTheApplicationTest {
         ArgumentCaptor<LockConfiguration> configCaptor = ArgumentCaptor.forClass(LockConfiguration.class);
         verify(lockProvider, atLeastOnce()).lock(configCaptor.capture());
         assertThat(configCaptor.getAllValues())
-            .extracting("name")
+            .extracting(lc -> lc.getName())
             .containsOnly(
                 "re-upload-failures",
                 "send-orchestrator-notification"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -96,7 +96,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
         );
         assertThat(actualEnvelope.getStatus()).isEqualTo(PROCESSED);
         assertThat(actualEnvelope.getScannableItems())
-            .extracting("documentUrl")
+            .extracting(item -> item.getDocumentUrl())
             .hasSameElementsAs(ImmutableList.of(DOCUMENT_URL2));
         assertThat(actualEnvelope.isZipDeleted()).isTrue();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -105,7 +105,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         Envelope actualEnvelope = envelopeRepository.findAll().get(0);
 
         assertThat(actualEnvelope.getStatus()).isEqualTo(UPLOAD_FAILURE);
-        assertThat(actualEnvelope.getScannableItems()).extracting("documentUrl").allMatch(ObjectUtils::isEmpty);
+        assertThat(actualEnvelope.getScannableItems()).allMatch(e -> ObjectUtils.isEmpty(e.getDocumentUrl()));
 
         // and
         eventWasCreated(DOC_UPLOAD_FAILURE);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -83,7 +83,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         Envelope actualEnvelope = getSingleEnvelopeFromDb();
 
         assertThat(actualEnvelope.getStatus()).isEqualTo(UPLOAD_FAILURE);
-        assertThat(actualEnvelope.getScannableItems()).extracting("documentUrl").allMatch(ObjectUtils::isEmpty);
+        assertThat(actualEnvelope.getScannableItems()).allMatch(item -> ObjectUtils.isEmpty(item.getDocumentUrl()));
 
         // and
         eventWasCreated(DOC_UPLOAD_FAILURE);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -76,7 +76,7 @@ public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<Bl
         // and
         List<ProcessEvent> processEvents = processEventRepository.findAll();
         assertThat(processEvents)
-            .extracting("event")
+            .extracting(event -> event.getEvent())
             .containsExactlyInAnyOrder(
                 Event.DOC_UPLOADED, Event.DOC_PROCESSED
             );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -84,7 +84,7 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
         String failureReason = "Error retrieving urls for uploaded files: 1111002.pdf";
 
         assertThat(processEventRepository.findAll())
-            .extracting("container", "zipFileName", "event", "reason")
+            .extracting(e -> tuple(e.getContainer(), e.getZipFileName(), e.getEvent(), e.getReason()))
             .containsOnly(
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOAD_FAILURE, failureReason),
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOADED, null),
@@ -118,7 +118,7 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
 
         assertThat(processEventRepository.findAll())
             .hasSize(2)
-            .extracting("container", "zipFileName", "event", "reason")
+            .extracting(e -> tuple(e.getContainer(), e.getZipFileName(), e.getEvent(), e.getReason()))
             .containsOnly(
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOAD_FAILURE, failureReason),
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOAD_FAILURE, "oh no")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -74,10 +74,10 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
 
         assertThat(dbEnvelopes)
             .hasSize(1)
-            .extracting("status")
+            .extracting(envelope -> envelope.getStatus())
             .containsOnlyOnce(PROCESSED);
         assertThat(dbEnvelopes.get(0).getScannableItems())
-            .extracting("documentUrl")
+            .extracting(item -> item.getDocumentUrl())
             .hasSameElementsAs(ImmutableList.of(DOCUMENT_URL2));
 
         // and
@@ -110,7 +110,7 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
         // then
         assertThat(envelopeRepository.findAll())
             .hasSize(1)
-            .extracting("status")
+            .extracting(envelope -> envelope.getStatus())
             .containsOnlyOnce(UPLOAD_FAILURE);
 
         // and

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTest.java
@@ -34,7 +34,7 @@ public class MetafileJsonValidatorTest {
         assertThat(envelope.caseNumber).isEqualTo("1111222233334446");
         assertThat(envelope.classification).isEqualTo(Classification.NEW_APPLICATION);
         assertThat(envelope.scannableItems)
-            .extracting("documentType")
+            .extracting(item -> item.documentType)
             .containsExactlyInAnyOrder(
                 InputDocumentType.CHERISHED,
                 InputDocumentType.OTHER,


### PR DESCRIPTION
no magic strings