### PR TITLE
Handle empty zip file names

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobInputStream;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import joptsimple.internal.Strings;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,8 +126,16 @@ public class BlobProcessorTask extends Processor {
         // For this purpose it's more efficient to have a collection that
         // implements RandomAccess (e.g. ArrayList)
         List<String> zipFilenames = new ArrayList<>();
-        container.listBlobs().forEach(
-            b -> zipFilenames.add(FilenameUtils.getName(b.getUri().toString()))
+        container
+            .listBlobs()
+            .forEach(b -> {
+                String fileName = FilenameUtils.getName(b.getUri().toString());
+                if (Strings.isNullOrEmpty(fileName)) {
+                    log.warn("Cannot extract filename from list blob item. URI: " + b.getUri().toString());
+                } else {
+                    zipFilenames.add(fileName);
+                }
+            }
         );
         Collections.shuffle(zipFilenames);
         for (String zipFilename : zipFilenames) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -131,7 +131,7 @@ public class BlobProcessorTask extends Processor {
             .forEach(b -> {
                 String fileName = FilenameUtils.getName(b.getUri().toString());
                 if (Strings.isNullOrEmpty(fileName)) {
-                    log.warn("Cannot extract filename from list blob item. URI: " + b.getUri().toString());
+                    log.error("Cannot extract filename from list blob item. URI: {}", b.getUri());
                 } else {
                     zipFilenames.add(fileName);
                 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -135,8 +135,7 @@ public class BlobProcessorTask extends Processor {
                 } else {
                     zipFilenames.add(fileName);
                 }
-            }
-        );
+            });
         Collections.shuffle(zipFilenames);
         for (String zipFilename : zipFilenames) {
             tryProcessZipFile(container, zipFilename);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
+import com.google.common.base.Strings;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobInputStream;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import joptsimple.internal.Strings;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
AAT gets flooded with errors caused by attempt of processing zip files when passed file name is null or empty.
>The argument must not be null or an empty string. Argument name: blobName.
>com.microsoft.azure.storage.blob.CloudBlobContainer.getBlockBlobReference

In this PR such files are skipped and their URIs are logged.

Investigation to follow based on those logs...