### PR TITLE
Extract base functional test class

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controllers;
+
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
+import com.microsoft.azure.storage.StorageUri;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import java.net.URI;
+
+public abstract class BaseFunctionalTest {
+
+    protected String testUrl;
+    protected long scanDelay;
+    protected String s2sUrl;
+    protected String s2sName;
+    protected String s2sSecret;
+    protected String testPrivateKeyDer;
+    protected CloudBlobContainer inputContainer;
+    protected CloudBlobContainer rejectedContainer;
+    protected TestHelper testHelper = new TestHelper();
+    protected Config config;
+
+    public void setUp() throws Exception {
+        this.config = ConfigFactory.load();
+        this.testUrl = config.getString("test-url");
+        this.scanDelay = Long.parseLong(config.getString("test-scan-delay"));
+        this.s2sUrl = config.getString("test-s2s-url");
+        this.s2sName = config.getString("test-s2s-name");
+        this.s2sSecret = config.getString("test-s2s-secret");
+        this.testPrivateKeyDer = config.getString("test-private-key-der");
+
+        StorageCredentialsAccountAndKey storageCredentials =
+            new StorageCredentialsAccountAndKey(
+                config.getString("test-storage-account-name"),
+                config.getString("test-storage-account-key")
+            );
+
+        CloudBlobClient cloudBlobClient = new CloudStorageAccount(
+            storageCredentials,
+            new StorageUri(new URI(config.getString("test-storage-account-url")), null),
+            null,
+            null
+        )
+            .createCloudBlobClient();
+
+        String inputContainerName = config.getString("test-storage-container-name");
+        String rejectedContainerName = inputContainerName + "-rejected";
+
+        inputContainer = cloudBlobClient.getContainerReference(inputContainerName);
+        rejectedContainer = cloudBlobClient.getContainerReference(rejectedContainerName);
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -1,18 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.controllers;
 
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
-import com.microsoft.azure.storage.StorageUri;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.assertj.core.util.Strings;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -20,44 +13,11 @@ import java.util.concurrent.TimeUnit;
 import static com.jayway.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BlobProcessorTest {
-
-    private String testUrl;
-    private long scanDelay;
-    private String s2sUrl;
-    private String s2sName;
-    private String s2sSecret;
-    private String testPrivateKeyDer;
-    private CloudBlobContainer testContainer;
-    private TestHelper testHelper;
+public class BlobProcessorTest extends BaseFunctionalTest {
 
     @Before
     public void setUp() throws Exception {
-        Config conf = ConfigFactory.load();
-
-        this.testUrl = conf.getString("test-url");
-        this.scanDelay = Long.parseLong(conf.getString("test-scan-delay"));
-        this.s2sUrl = conf.getString("test-s2s-url");
-        this.s2sName = conf.getString("test-s2s-name");
-        this.s2sSecret = conf.getString("test-s2s-secret");
-        this.testPrivateKeyDer = conf.getString("test-private-key-der");
-
-        this.testHelper = new TestHelper();
-
-        StorageCredentialsAccountAndKey storageCredentials =
-            new StorageCredentialsAccountAndKey(
-                conf.getString("test-storage-account-name"),
-                conf.getString("test-storage-account-key")
-            );
-
-        testContainer = new CloudStorageAccount(
-            storageCredentials,
-            new StorageUri(new URI(conf.getString("test-storage-account-url")), null),
-            null,
-            null
-        )
-            .createCloudBlobClient()
-            .getContainerReference(conf.getString("test-storage-container-name"));
+        super.setUp();
     }
 
     @Test
@@ -67,7 +27,7 @@ public class BlobProcessorTest {
         String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
 
         // valid zip file
-        testHelper.uploadZipFile(testContainer, files, metadataFile, destZipFilename, testPrivateKeyDer);
+        testHelper.uploadZipFile(inputContainer, files, metadataFile, destZipFilename, testPrivateKeyDer);
 
 
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -1,18 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.controllers;
 
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.StorageUri;
-import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -22,42 +14,13 @@ import static com.jayway.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class EnvelopeDeletionTest {
+public class EnvelopeDeletionTest extends BaseFunctionalTest {
 
-    private long scanDelay;
-    private CloudBlobContainer inputContainer;
-    private CloudBlobContainer rejectedContainer;
     private List<String> filesToDeleteAfterTest = new ArrayList<>();
-    private TestHelper testHelper;
-    private String testPrivateKeyDer;
 
     @Before
     public void setUp() throws Exception {
-        Config conf = ConfigFactory.load();
-        this.scanDelay = Long.parseLong(conf.getString("test-scan-delay"));
-        this.testPrivateKeyDer = conf.getString("test-private-key-der");
-
-        StorageCredentialsAccountAndKey storageCredentials =
-            new StorageCredentialsAccountAndKey(
-                conf.getString("test-storage-account-name"),
-                conf.getString("test-storage-account-key")
-            );
-
-        CloudBlobClient cloudBlobClient = new CloudStorageAccount(
-            storageCredentials,
-            new StorageUri(new URI(conf.getString("test-storage-account-url")), null),
-            null,
-            null
-        )
-            .createCloudBlobClient();
-
-        String inputContainerName = conf.getString("test-storage-container-name");
-        String rejectedContainerName = inputContainerName + "-rejected";
-
-        inputContainer = cloudBlobClient.getContainerReference(inputContainerName);
-        rejectedContainer = cloudBlobClient.getContainerReference(rejectedContainerName);
-
-        testHelper = new TestHelper();
+        super.setUp();
     }
 
     @After

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
@@ -1,17 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.controllers;
 
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
-import com.microsoft.azure.storage.StorageUri;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -19,43 +12,11 @@ import java.util.concurrent.TimeUnit;
 import static com.jayway.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UpdateStatusTest {
-
-    private String testUrl;
-    private long scanDelay;
-    private String s2sUrl;
-    private String s2sName;
-    private String s2sSecret;
-    private String testPrivateKeyDer;
-    private CloudBlobContainer testContainer;
-
-    private TestHelper testHelper = new TestHelper();
+public class UpdateStatusTest extends BaseFunctionalTest {
 
     @Before
     public void setUp() throws Exception {
-        Config conf = ConfigFactory.load();
-
-        this.testUrl = conf.getString("test-url");
-        this.scanDelay = Long.parseLong(conf.getString("test-scan-delay"));
-        this.s2sUrl = conf.getString("test-s2s-url");
-        this.s2sName = conf.getString("test-s2s-name");
-        this.s2sSecret = conf.getString("test-s2s-secret");
-        this.testPrivateKeyDer = conf.getString("test-private-key-der");
-
-        StorageCredentialsAccountAndKey storageCredentials =
-            new StorageCredentialsAccountAndKey(
-                conf.getString("test-storage-account-name"),
-                conf.getString("test-storage-account-key")
-            );
-
-        testContainer = new CloudStorageAccount(
-            storageCredentials,
-            new StorageUri(new URI(conf.getString("test-storage-account-url")), null),
-            null,
-            null
-        )
-            .createCloudBlobClient()
-            .getContainerReference(conf.getString("test-storage-container-name"));
+        super.setUp();
     }
 
     @Test
@@ -63,7 +24,7 @@ public class UpdateStatusTest {
         String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
 
         testHelper.uploadZipFile(
-            testContainer,
+            inputContainer,
             Arrays.asList("1111006.pdf", "1111002.pdf"),
             "1111006_2.metadata.json",
             destZipFilename,


### PR DESCRIPTION
### Change description ###

Create a base class for functional tests, in order to remove duplication. There's a lot of setup-related code duplication among functional tests and after adding another test (for handling processed-envelopes queue) there would be even more. This PR is here to extract some common logic into a base class.

This is a proposal. Alternative ideas are welcome.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
