### PR TITLE
Handle invalid zip files

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/InvalidZipArchiveException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/InvalidZipArchiveException.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class InvalidZipArchiveException extends InvalidEnvelopeException {
+    public InvalidZipArchiveException(String message) {
+        super(message);
+    }
+
+    public InvalidZipArchiveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiers.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiers.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 import com.google.common.base.Strings;
 import com.google.common.io.Resources;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocSignatureFailureException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.SignatureValidationException;
 
 import java.io.ByteArrayInputStream;
@@ -107,7 +108,7 @@ public class ZipVerifiers {
 
             return zipEntries;
         } catch (IOException ioe) {
-            throw new SignatureValidationException(ioe);
+            throw new InvalidZipArchiveException("Error extracting zip entries", ioe);
         }
     }
 


### PR DESCRIPTION
Move file to rejected container.
Previously file was being left where it was causing the job to process it on next run (and creating error event. over and over again).