### PR TITLE
Add an event to process logs when zipfile is picked up by processor

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -149,13 +149,6 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
         //This verifies only pdf included in the zip with metadata was processed
         verify(documentManagementService).uploadDocuments(ImmutableList.of(okPdf));
 
-        // Verify if event registered for zipfile processing event
-        List<ProcessEvent> processEvents = processEventRepository.findAll();
-        assertThat(processEvents.stream().map(ProcessEvent::getEvent).collect(toList()))
-            .contains(
-                ZIPFILE_PROCESSING_STARTED
-            );
-
         //Verify first pdf file was never processed
         byte[] pdfFromBadZip = toByteArray(getResource("zipcontents/missing_metadata/1111001.pdf"));
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -41,6 +41,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDi
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_PROCESSED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOADED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOAD_FAILURE;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -107,6 +108,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
         List<ProcessEvent> processEvents = processEventRepository.findAll();
         assertThat(processEvents.stream().map(ProcessEvent::getEvent).collect(toList()))
             .containsExactlyInAnyOrder(
+                ZIPFILE_PROCESSING_STARTED,
                 DOC_UPLOADED,
                 DOC_PROCESSED
             );
@@ -147,6 +149,13 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
         //This verifies only pdf included in the zip with metadata was processed
         verify(documentManagementService).uploadDocuments(ImmutableList.of(okPdf));
 
+        // Verify if event registered for zipfile processing event
+        List<ProcessEvent> processEvents = processEventRepository.findAll();
+        assertThat(processEvents.stream().map(ProcessEvent::getEvent).collect(toList()))
+            .contains(
+                ZIPFILE_PROCESSING_STARTED
+            );
+
         //Verify first pdf file was never processed
         byte[] pdfFromBadZip = toByteArray(getResource("zipcontents/missing_metadata/1111001.pdf"));
 
@@ -185,7 +194,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
             .map(ProcessEvent::getEvent)
             .collect(toList());
 
-        assertThat(actualEvents).containsOnly(DOC_UPLOADED, DOC_PROCESSED);
+        assertThat(actualEvents).containsOnly(ZIPFILE_PROCESSING_STARTED, DOC_UPLOADED, DOC_PROCESSED);
     }
 
     @Test
@@ -216,7 +225,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
             .map(ProcessEvent::getEvent)
             .collect(toList());
 
-        assertThat(actualEvents).containsOnly(DOC_UPLOAD_FAILURE);
+        assertThat(actualEvents).containsOnly(ZIPFILE_PROCESSING_STARTED, DOC_UPLOAD_FAILURE);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -30,6 +30,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipAn
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOAD_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALIDATION_FAILURE;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -256,7 +257,18 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         List<ProcessEvent> processEvents = processEventRepository.findAll();
         assertThat(processEvents).hasSize(2);
 
+        // Verify that Zip file processing event is created
         assertThat(processEvents)
+            .filteredOn(e -> e.getEvent().equals(ZIPFILE_PROCESSING_STARTED))
+            .hasOnlyOneElementSatisfying(e -> {
+                assertThat(e.getContainer()).isEqualTo(testContainer.getName());
+                assertThat(e.getEvent()).isEqualTo(event);
+                assertThat(e.getId()).isNotNull();
+                assertThat(e.getReason()).isNull();
+            });
+
+        assertThat(processEvents)
+            .filteredOn(e -> e.getEvent().equals(event))
             .hasOnlyOneElementSatisfying(e -> {
                 assertThat(e.getContainer()).isEqualTo(testContainer.getName());
                 assertThat(e.getEvent()).isEqualTo(event);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -59,7 +59,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         assertThat(actualEnvelope.getScannableItems()).allMatch(item -> item.getDocumentUrl() == null);
 
         // and
-        eventWasCreated(DOC_UPLOAD_FAILURE);
+        eventsCreated(DOC_UPLOAD_FAILURE);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         assertThat(actualEnvelope.getScannableItems()).allMatch(item -> ObjectUtils.isEmpty(item.getDocumentUrl()));
 
         // and
-        eventWasCreated(DOC_UPLOAD_FAILURE);
+        eventsCreated(DOC_UPLOAD_FAILURE);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         assertThat(actualEnvelope.getScannableItems()).allMatch(e -> ObjectUtils.isEmpty(e.getDocumentUrl()));
 
         // and
-        eventWasCreated(DOC_UPLOAD_FAILURE);
+        eventsCreated(DOC_UPLOAD_FAILURE);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(FILE_VALIDATION_FAILURE);
+        eventsCreated(FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_ZIP_PROCESSING_FAILED);
     }
 
@@ -136,7 +136,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(FILE_VALIDATION_FAILURE);
+        eventsCreated(FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -150,7 +150,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(FILE_VALIDATION_FAILURE);
+        eventsCreated(FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -164,7 +164,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(FILE_VALIDATION_FAILURE);
+        eventsCreated(FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -178,7 +178,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(FILE_VALIDATION_FAILURE);
+        eventsCreated(FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -192,7 +192,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(FILE_VALIDATION_FAILURE);
+        eventsCreated(FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_ZIP_PROCESSING_FAILED);
     }
 
@@ -206,7 +206,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(FILE_VALIDATION_FAILURE);
+        eventsCreated(FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -229,51 +229,30 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventWasCreated(Event.DOC_SIGNATURE_FAILURE);
+        eventsCreated(Event.DOC_SIGNATURE_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_SIG_VERIFY_FAILED);
     }
 
-    @Test
-    public void should_record_zipfile_processing_event_when_processing_zipfile_fails() throws Exception {
-        // given
-        uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/missing_metadata"));
-
-        // when
-        processor.processBlobs();
-
-        // then
-        envelopeWasNotCreated();
-
-        assertThat(processEventRepository.findAll())
-            .hasOnlyOneElementSatisfying(e -> {
-                assertThat(e.getContainer()).isEqualTo(testContainer.getName());
-                assertThat(e.getEvent()).isEqualTo(Event.ZIPFILE_PROCESSING_STARTED);
-                assertThat(e.getId()).isNotNull();
-                assertThat(e.getReason()).isNull();
-            });
-    }
-
-    private void eventWasCreated(Event event) {
+    private void eventsCreated(Event event) {
         List<ProcessEvent> processEvents = processEventRepository.findAll();
-        assertThat(processEvents).hasSize(2);
 
         // Verify that Zip file processing event is created
         assertThat(processEvents)
-            .filteredOn(e -> e.getEvent().equals(ZIPFILE_PROCESSING_STARTED))
-            .hasOnlyOneElementSatisfying(e -> {
-                assertThat(e.getContainer()).isEqualTo(testContainer.getName());
-                assertThat(e.getEvent()).isEqualTo(event);
-                assertThat(e.getId()).isNotNull();
-                assertThat(e.getReason()).isNull();
+            .filteredOn(processEvent -> processEvent.getEvent().equals(Event.ZIPFILE_PROCESSING_STARTED))
+            .hasOnlyOneElementSatisfying(processEvent -> {
+                assertThat(processEvent.getContainer()).isEqualTo(testContainer.getName());
+                assertThat(processEvent.getEvent()).isEqualTo(ZIPFILE_PROCESSING_STARTED);
+                assertThat(processEvent.getId()).isNotNull();
+                assertThat(processEvent.getReason()).isNull();
             });
 
         assertThat(processEvents)
-            .filteredOn(e -> e.getEvent().equals(event))
-            .hasOnlyOneElementSatisfying(e -> {
-                assertThat(e.getContainer()).isEqualTo(testContainer.getName());
-                assertThat(e.getEvent()).isEqualTo(event);
-                assertThat(e.getId()).isNotNull();
-                assertThat(e.getReason()).isNotBlank();
+            .filteredOn(processEvent -> processEvent.getEvent().equals(event))
+            .hasOnlyOneElementSatisfying(processEvent -> {
+                assertThat(processEvent.getContainer()).isEqualTo(testContainer.getName());
+                assertThat(processEvent.getEvent()).isEqualTo(event);
+                assertThat(processEvent.getId()).isNotNull();
+                assertThat(processEvent.getReason()).isNotBlank();
             });
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.ObjectUtils;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
-import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnableToUploadDocumentException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
@@ -21,6 +20,7 @@ import static com.jayway.awaitility.Awaitility.await;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOAD_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipAndSignDir;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_SIGNATURE_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOAD_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALIDATION_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
@@ -59,7 +60,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         assertThat(actualEnvelope.getScannableItems()).allMatch(item -> item.getDocumentUrl() == null);
 
         // and
-        eventsCreated(DOC_UPLOAD_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, DOC_UPLOAD_FAILURE);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         assertThat(actualEnvelope.getScannableItems()).allMatch(item -> ObjectUtils.isEmpty(item.getDocumentUrl()));
 
         // and
-        eventsCreated(DOC_UPLOAD_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, DOC_UPLOAD_FAILURE);
     }
 
     @Test
@@ -109,7 +110,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         assertThat(actualEnvelope.getScannableItems()).allMatch(e -> ObjectUtils.isEmpty(e.getDocumentUrl()));
 
         // and
-        eventsCreated(DOC_UPLOAD_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, DOC_UPLOAD_FAILURE);
     }
 
     @Test
@@ -122,7 +123,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(FILE_VALIDATION_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_ZIP_PROCESSING_FAILED);
     }
 
@@ -136,7 +137,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(FILE_VALIDATION_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -150,7 +151,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(FILE_VALIDATION_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -164,7 +165,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(FILE_VALIDATION_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -178,7 +179,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(FILE_VALIDATION_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -192,7 +193,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(FILE_VALIDATION_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_ZIP_PROCESSING_FAILED);
     }
 
@@ -206,7 +207,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(FILE_VALIDATION_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -229,31 +230,18 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
 
         // then
         envelopeWasNotCreated();
-        eventsCreated(Event.DOC_SIGNATURE_FAILURE);
+        eventsWereCreated(ZIPFILE_PROCESSING_STARTED, DOC_SIGNATURE_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_SIG_VERIFY_FAILED);
     }
 
-    private void eventsCreated(Event event) {
-        List<ProcessEvent> processEvents = processEventRepository.findAll();
-
-        // Verify that Zip file processing event is created
-        assertThat(processEvents)
-            .filteredOn(processEvent -> processEvent.getEvent().equals(Event.ZIPFILE_PROCESSING_STARTED))
-            .hasOnlyOneElementSatisfying(processEvent -> {
-                assertThat(processEvent.getContainer()).isEqualTo(testContainer.getName());
-                assertThat(processEvent.getEvent()).isEqualTo(ZIPFILE_PROCESSING_STARTED);
-                assertThat(processEvent.getId()).isNotNull();
-                assertThat(processEvent.getReason()).isNull();
-            });
-
-        assertThat(processEvents)
-            .filteredOn(processEvent -> processEvent.getEvent().equals(event))
-            .hasOnlyOneElementSatisfying(processEvent -> {
-                assertThat(processEvent.getContainer()).isEqualTo(testContainer.getName());
-                assertThat(processEvent.getEvent()).isEqualTo(event);
-                assertThat(processEvent.getId()).isNotNull();
-                assertThat(processEvent.getReason()).isNotBlank();
-            });
+    private void eventsWereCreated(Event event1, Event event2) {
+        assertThat(processEventRepository.findAll())
+            .hasSize(2)
+            .extracting(e -> tuple(e.getContainer(), e.getEvent()))
+            .containsExactlyInAnyOrder(
+                tuple(testContainer.getName(), event1),
+                tuple(testContainer.getName(), event2)
+            );
     }
 
     private void errorWasSent(String zipFileName, ErrorCode code) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -78,7 +78,7 @@ public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<Bl
         assertThat(processEvents)
             .extracting(event -> event.getEvent())
             .containsExactlyInAnyOrder(
-                Event.DOC_UPLOADED, Event.DOC_PROCESSED
+                Event.ZIPFILE_PROCESSING_STARTED, Event.DOC_UPLOADED, Event.DOC_PROCESSED
             );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -25,6 +25,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDi
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_PROCESSED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOADED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOAD_FAILURE;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -85,7 +86,8 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
 
         assertThat(processEventRepository.findAll())
             .extracting(e -> tuple(e.getContainer(), e.getZipFileName(), e.getEvent(), e.getReason()))
-            .containsOnly(
+            .containsExactlyInAnyOrder(
+                tuple(testContainer.getName(), zipFileName, ZIPFILE_PROCESSING_STARTED, null),
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOAD_FAILURE, failureReason),
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOADED, null),
                 tuple(testContainer.getName(), zipFileName, DOC_PROCESSED, null)
@@ -117,9 +119,10 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
         String failureReason = "Error retrieving urls for uploaded files: 1111002.pdf";
 
         assertThat(processEventRepository.findAll())
-            .hasSize(2)
+            .hasSize(3)
             .extracting(e -> tuple(e.getContainer(), e.getZipFileName(), e.getEvent(), e.getReason()))
             .containsOnly(
+                tuple(testContainer.getName(), zipFileName, ZIPFILE_PROCESSING_STARTED, null),
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOAD_FAILURE, failureReason),
                 tuple(testContainer.getName(), zipFileName, DOC_UPLOAD_FAILURE, "oh no")
             );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.model.common;
 // TODO: separate envelope state and events.
 public enum Event {
 
+    ZIPFILE_PROCESSING_STARTED, // when processor starts processing zipfile from blob
     DOC_FAILURE, // generic failure while processing zip file. before uploading to document management
     FILE_VALIDATION_FAILURE,
     DOC_SIGNATURE_FAILURE, // Signature verification failure while processing zip file

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -173,7 +173,6 @@ public class BlobProcessorTask extends Processor {
             if (!isReadyToBeProcessed(cloudBlockBlob)) {
                 logAbortedProcessingNotReadyFile(zipFilename, container.getName());
             } else {
-                registerEvent(ZIPFILE_PROCESSING_STARTED, container.getName(), zipFilename, null);
                 processZipFile(container, cloudBlockBlob, zipFilename);
             }
         }
@@ -191,6 +190,8 @@ public class BlobProcessorTask extends Processor {
 
             // Zip file will include metadata.json and collection of pdf documents
             try (ZipInputStream zis = new ZipInputStream(blobInputStream)) {
+                registerEvent(ZIPFILE_PROCESSING_STARTED, container.getName(), zipFilename, null);
+
                 ZipFileProcessingResult processingResult =
                     processZipFileContent(zis, zipFilename, container.getName(), leaseId.get());
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.zip.ZipInputStream;
 
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.mapper.EnvelopeMapper.toDbEnvelope;
 
 /**
@@ -172,6 +173,7 @@ public class BlobProcessorTask extends Processor {
             if (!isReadyToBeProcessed(cloudBlockBlob)) {
                 logAbortedProcessingNotReadyFile(zipFilename, container.getName());
             } else {
+                registerEvent(ZIPFILE_PROCESSING_STARTED, container.getName(), zipFilename, null);
                 processZipFile(container, cloudBlockBlob, zipFilename);
             }
         }


### PR DESCRIPTION
### Change description ###
Added a new event to log in process_events when the zip file is picked up by the processor.
This event should be registered before validating the zip file contents, 
so it should be created for every zip file read by the processor.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
