### PR TITLE
Provide configuration for the handler of processed-envelopes queue messages

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -96,6 +96,8 @@ withPipeline(type, product, component) {
       //Regex: Endpoint=sb:\/\/([-a-zA-Z0-9]+)\.servicebus\.windows\.net.*
       def serviceBusNamespace = serviceBusConnectionStr.substring(14).split("\\.")[0]
 
+      env.PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING = "${serviceBusConnectionStr};EntityPath=processed-envelopes"
+
       // create queue
       def queues = az "servicebus queue list --resource-group ${env.RESOURCE_GROUP} --namespace-name ${serviceBusNamespace} --query '[].name'"
       queueNames.each {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -96,8 +96,6 @@ withPipeline(type, product, component) {
       //Regex: Endpoint=sb:\/\/([-a-zA-Z0-9]+)\.servicebus\.windows\.net.*
       def serviceBusNamespace = serviceBusConnectionStr.substring(14).split("\\.")[0]
 
-      env.PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING = "${serviceBusConnectionStr};EntityPath=processed-envelopes"
-
       // create queue
       def queues = az "servicebus queue list --resource-group ${env.RESOURCE_GROUP} --namespace-name ${serviceBusNamespace} --query '[].name'"
       queueNames.each {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -127,6 +127,7 @@ module "bulk-scan" {
     QUEUE_ENVELOPE_SEND = "${data.terraform_remote_state.shared_infra.queue_primary_send_connection_string}"
     QUEUE_NOTIFICATIONS_SEND = "${data.terraform_remote_state.shared_infra.notifications_queue_primary_send_connection_string}"
     QUEUE_NOTIFICATIONS_READ = "${data.terraform_remote_state.shared_infra.notifications_queue_primary_listen_connection_string}"
+    QUEUE_PROCESSED_ENVELOPES_READ = "${data.terraform_remote_state.shared_infra.processed_envelopes_queue_primary_listen_connection_string}"
 
     // silence the "bad implementation" logs
     LOGBACK_REQUIRE_ALERT_LEVEL = "false"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -39,6 +39,10 @@ output "TEST_STORAGE_ACCOUNT_URL" {
   value = "${local.storage_account_url}"
 }
 
+output "PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING" {
+  value = "${data.terraform_remote_state.shared_infra.processed_envelopes_queue_primary_send_connection_string}"
+}
+
 output "api_gateway_url" {
   value = "https://core-api-mgmt-${var.env}.azure-api.net/${local.api_base_path}"
 }

--- a/kubernetes/deployment.template.yaml
+++ b/kubernetes/deployment.template.yaml
@@ -116,8 +116,11 @@ spec:
               value: "$(SERVICE_BUS_CONN_STRING);EntityPath=notifications"
             - name: QUEUE_PROCESSED_ENVELOPES_READ
               value: "$(SERVICE_BUS_CONN_STRING);EntityPath=processed-envelopes"
-            - name: WAIT_FOR_QUEUE_CREATION
-              value: "true"
+              # The application can't fail on message handler registration error,
+              # because the queues are created after the app has started (and showed that it's healthy).
+              # The problem will be addressed in BPS-445
+            - name: FAIL_ON_MESSAGE_HANDLER_REGISTRATION_ERROR
+              value: "false"
             - name: TEST_STORAGE_ACCOUNT_NAME
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/deployment.template.yaml
+++ b/kubernetes/deployment.template.yaml
@@ -116,6 +116,8 @@ spec:
               value: "$(SERVICE_BUS_CONN_STRING);EntityPath=notifications"
             - name: QUEUE_PROCESSED_ENVELOPES_READ
               value: "$(SERVICE_BUS_CONN_STRING);EntityPath=processed-envelopes"
+            - name: WAIT_FOR_QUEUE_CREATION
+              value: "true"
             - name: TEST_STORAGE_ACCOUNT_NAME
               valueFrom:
                 secretKeyRef:

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
@@ -1,0 +1,100 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.Message;
+import com.microsoft.azure.servicebus.QueueClient;
+import com.microsoft.azure.servicebus.ReceiveMode;
+import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.in.msg.ProcessedEnvelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
+
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProcessedEnvelopeMessageHandlingTest extends BaseFunctionalTest {
+
+    private static final long MAX_MESSAGE_PROCESSING_TIME_MILLIS = 40_000;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private String s2sToken;
+    private QueueClient queueClient;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        this.s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
+
+        this.queueClient = new QueueClient(
+            new ConnectionStringBuilder(
+                config.getString("processed-envelopes-queue-conn-string")
+            ),
+            ReceiveMode.PEEKLOCK
+        );
+    }
+
+    @Test
+    public void should_complete_envelope_referenced_by_queue_message() throws Exception {
+        // given
+        String zipFilename = uploadEnvelopeContainingOcrData();
+
+        await("Envelope should be created in the service")
+            .atMost(scanDelay + MAX_MESSAGE_PROCESSING_TIME_MILLIS, TimeUnit.MILLISECONDS)
+            .pollInterval(500, TimeUnit.MILLISECONDS)
+            .until(() -> testHelper.getEnvelopeByZipFileName(testUrl, s2sToken, zipFilename).isPresent());
+
+        UUID envelopeId = getEnvelope(zipFilename).getId();
+
+        // when
+        sendProcessedEnvelopeMessage(envelopeId);
+
+        // then
+        await("Envelope should change status to 'COMPLETED'")
+            .atMost(5000, TimeUnit.MILLISECONDS)
+            .pollInterval(500, TimeUnit.MILLISECONDS)
+            .until(() -> getEnvelope(zipFilename).getStatus() == Status.COMPLETED);
+
+        EnvelopeResponse updatedEnvelope = getEnvelope(zipFilename);
+        assertThat(updatedEnvelope.getScannableItems()).hasSize(2);
+        assertThat(updatedEnvelope.getScannableItems()).allMatch(item -> item.ocrData == null);
+        assertThat(updatedEnvelope.getStatus()).isEqualTo(Status.COMPLETED);
+    }
+
+    private String uploadEnvelopeContainingOcrData() throws Exception {
+        String zipFilename = testHelper.getRandomFilename("12-02-2019-00-00-00.test.zip");
+
+        testHelper.uploadZipFile(
+            inputContainer,
+            Arrays.asList("1111006.pdf", "1111002.pdf"),
+            "1111007.metadata-with-ocr-data.json",
+            zipFilename,
+            testPrivateKeyDer
+        );
+
+        return zipFilename;
+    }
+
+    private EnvelopeResponse getEnvelope(String zipFilename) {
+        return testHelper.getEnvelopeByZipFileName(testUrl, s2sToken, zipFilename)
+            .orElseThrow(() ->
+                new AssertionError(
+                    String.format("The envelope for file %s couldn't be found", zipFilename)
+                )
+            );
+    }
+
+    private void sendProcessedEnvelopeMessage(UUID envelopeId) throws Exception {
+        IMessage message = new Message(
+            objectMapper.writeValueAsString(new ProcessedEnvelope(envelopeId))
+        );
+
+        queueClient.send(message);
+    }
+}

--- a/src/functionalTest/resources/1111007.metadata-with-ocr-data.json
+++ b/src/functionalTest/resources/1111007.metadata-with-ocr-data.json
@@ -1,0 +1,51 @@
+{
+  "po_box": "TESTPO",
+  "jurisdiction": "BULKSCAN",
+  "delivery_date": "2018-06-23T00:00:00.000Z",
+  "opening_date": "2018-06-24T00:00:00.000Z",
+  "zip_file_createddate": "2018-02-24T00:00:00.000Z",
+  "zip_file_name": "$$zip_file_name$$",
+  "envelope_classification": "exception",
+  "scannable_items": [
+    {
+      "document_control_number": "1111006",
+      "scanning_date": "2017-02-24T00:00:00.000Z",
+      "ocr_accuracy": "string",
+      "manual_intervention": "string",
+      "next_action": "return",
+      "next_action_date": "2018-06-24T00:00:00.000Z",
+      "ocr_data": "ewogICJNZXRhZGF0YV9maWxlIjogWwogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAicmlnaHQgdG8gYXBwZWFsX01ybiIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICJGYWxzZSIgfSwKICAgICB7ICJtZXRhZGF0YV9maWVsZF9uYW1lIjogImNvbnRhaW5zX01ybiIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICJUcnVlIiB9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYmVuZWZpdFR5cGVfZGVzY3JpcHRpb24iLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiQ2l2aWwgRGl2b3JjZSBDYXNlIn0sCiAgICAgeyAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJhcHBlbGxhbnRfdGl0bGUiLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiTXIifSwKICAgICB7ICJtZXRhZGF0YV9maWVsZF9uYW1lIjogImFwcGVsbGFudF9maXJzdE5hbWUiLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiU3VkaGlyIFPMtmjMtnLMtmXMtnPMtnTMtm7MtmHMtiJ9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYXBwZWxsYW50X2xhc3ROYW1lIiwgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIlNocmVzdG5hIn0sCiAgICAgeyAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJhcHBlbGxhbnRfYWRkcmVzcyIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICIyNCBPbWVnYSBTdC4gdV9rXyBMb25kb24gVUsifSwKICAgICB7ICJtZXRhZGF0YV9maWVsZF9uYW1lIjogImFwcGVsbGFudF9wb3N0Y29kZSIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICJENDE3QlMifSwKICAgICB7ICJtZXRhZGF0YV9maWVsZF9uYW1lIjogImFwcGVsbGFudF9waG9uZSIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICIwNzg5NDQ5MTEwNiJ9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYXBwZWxsYW50X21vYmlsZSIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICIifSwKICAgICB7ICJtZXRhZGF0YV9maWVsZF9uYW1lIjogImFwcGVsbGFudF9kb2IiLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiMTEvMTAvMTk4MSJ9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYXBwZWxsYW50X25pRmFsc2UiLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiNDdCQVM3NjU0In0sCiAgICAgeyAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJpc19hcHBvaW50ZWUiLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAiVHJ1ZSJ9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYXBwb2ludGVlX3RpdGxlIiwgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIk1yIn0sCiAgICAgeyAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJhcHBvaW50ZWVfZmlyc3ROYW1lIiwgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIlNvcGhpYSJ9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYXBwb2ludGVlX2xhc3ROYW1lIiwgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIlNvbGUifSwKICAgICB7ICJtZXRhZGF0YV9maWVsZF9uYW1lIjogImFwcG9pbnRlZV9hZGRyZXNzIiwgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIk4vQSJ9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYXBwb2ludGVlX3Bvc3Rjb2RlIiwgIm1ldGFkYXRhX2ZpZWxkX3ZhbHVlIjogIkQxNzFZNyJ9LAogICAgIHsgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAiYXBwb2ludGVlX2RvYiIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICIxNC8xMC8xOTgwIn0sCiAgICAgeyAibWV0YWRhdGFfZmllbGRfbmFtZSI6ICJhcHBvaW50ZWVfbmlGYWxzZSIsICJtZXRhZGF0YV9maWVsZF92YWx1ZSI6ICI0NDE3NjU0M0IifQogIF0KfQo=",
+      "file_name": "1111006.pdf",
+      "notes": "",
+      "document_type": "Cherished"
+    },
+    {
+      "document_control_number": "1111002",
+      "scanning_date": "2017-02-24T00:00:00.000Z",
+      "manual_intervention": "string",
+      "next_action": "forward",
+      "next_action_date": "2017-02-25T00:00:00.000Z",
+      "file_name": "1111002.pdf",
+      "notes": "Cheque will be forwarded to court to bank it",
+      "document_type": "Other"
+    }
+  ],
+  "payments": [
+    {
+      "document_control_number": "1111006",
+      "method": "Cheque",
+      "amount": "100.00",
+      "currency": "GBP",
+      "payment_instrument_number": "1000000000",
+      "sort_code": "112233",
+      "account_number": "12345678"
+    }
+  ],
+  "non_scannable_items": [
+    {
+      "document_control_number": "1111002",
+      "item_type": "CD",
+      "notes": "4GB USB memory stick"
+    }
+  ]
+}

--- a/src/functionalTest/resources/application.conf
+++ b/src/functionalTest/resources/application.conf
@@ -8,3 +8,4 @@ test-s2s-name=${TEST_S2S_NAME}
 test-s2s-url=${TEST_S2S_URL}
 test-s2s-secret=${TEST_S2S_SECRET}
 test-private-key-der=${TEST_PRIVATE_KEY_DER}
+processed-envelopes-queue-conn-string=${PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/FailedToRegisterMessageHandlersExcepiton.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/FailedToRegisterMessageHandlersExcepiton.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.config;
+
+public class FailedToRegisterMessageHandlersExcepiton extends RuntimeException {
+
+    public FailedToRegisterMessageHandlersExcepiton(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/MessageHandlerConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/MessageHandlerConfig.java
@@ -1,9 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.config;
 
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.MessageHandlerOptions;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,11 +14,12 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.ProcessedEnvelopeNotification
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 
 @ServiceBusConfiguration
 public class MessageHandlerConfig {
+
+    public static final Logger log = LoggerFactory.getLogger(MessageHandlerConfig.class);
 
     private static final ExecutorService notificationsReadExecutor =
         Executors.newSingleThreadExecutor(r ->
@@ -32,8 +34,8 @@ public class MessageHandlerConfig {
     private static final MessageHandlerOptions messageHandlerOptions =
         new MessageHandlerOptions(1, false, Duration.ofMinutes(5));
 
-    @Value("${WAIT_FOR_QUEUE_CREATION:false}")
-    private boolean waitForQueueCreation;
+    @Value("${FAIL_ON_MESSAGE_HANDLER_REGISTRATION_ERROR:true}")
+    private boolean failOnMessageHandlerRegistrationError;
 
     @Autowired(required = false)
     @Qualifier("read-notifications-client")
@@ -50,18 +52,7 @@ public class MessageHandlerConfig {
     private ProcessedEnvelopeNotificationHandler processedEnvelopeNotificationHandler;
 
     @PostConstruct()
-    public void registerMessageHandlers() {
-        if (waitForQueueCreation) {
-            new Thread(() -> {
-                Uninterruptibles.sleepUninterruptibly(60L, TimeUnit.SECONDS);
-                registerHandlers();
-            }).start();
-        } else {
-            registerHandlers();
-        }
-    }
-
-    private void registerHandlers() {
+    public void registerMessageHandlers() throws InterruptedException, ServiceBusException {
         try {
             if (readNotificationsQueueClient != null) {
                 readNotificationsQueueClient.registerMessageHandler(
@@ -78,16 +69,22 @@ public class MessageHandlerConfig {
             );
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throwRegisterMessageHandlerRegistrationException(e);
+            handleMessageHandlerRegistrationError(e);
         } catch (ServiceBusException e) {
-            throwRegisterMessageHandlerRegistrationException(e);
+            handleMessageHandlerRegistrationError(e);
         }
     }
 
-    private void throwRegisterMessageHandlerRegistrationException(Exception cause) {
-        throw new FailedToRegisterMessageHandlersExcepiton(
-            "An error occurred when trying to register message handlers",
-            cause
-        );
+    private <T extends Exception> void handleMessageHandlerRegistrationError(T cause) throws T {
+        final String errorMessage = "An error occurred when trying to register message handlers";
+
+        if (failOnMessageHandlerRegistrationError) {
+            throw cause;
+        } else {
+            // The application has to keep working on Preview - otherwise the pipeline
+            // wouldn't create queues which it relies on.
+            // The problem will be addresses in BPS-445
+            log.error(errorMessage, cause);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/MessageHandlerConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/MessageHandlerConfig.java
@@ -6,6 +6,7 @@ import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.ErrorNotificationHandler;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.ProcessedEnvelopeNotificationHandler;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
@@ -15,26 +16,47 @@ import javax.annotation.PostConstruct;
 @ServiceBusConfiguration
 public class MessageHandlerConfig {
 
-    private static final ExecutorService NOTIFICATIONS_READ_EXEC =
+    private static final ExecutorService notificationsReadExecutor =
         Executors.newSingleThreadExecutor(r ->
             new Thread(r, "notifications-queue-read")
         );
+
+    private static final ExecutorService processedEnvelopesReadExecutor =
+        Executors.newSingleThreadExecutor(r ->
+            new Thread(r, "processed-envelopes-queue-read")
+        );
+
+    private static final MessageHandlerOptions messageHandlerOptions =
+        new MessageHandlerOptions(1, false, Duration.ofMinutes(5));
 
     @Autowired(required = false)
     @Qualifier("read-notifications-client")
     private IQueueClient readNotificationsQueueClient;
 
+    @Autowired
+    @Qualifier("processed-envelopes-client")
+    private IQueueClient processedEnvelopesQueueClient;
+
     @Autowired(required = false)
     private ErrorNotificationHandler errorNotificationHandler;
+
+    @Autowired
+    private ProcessedEnvelopeNotificationHandler processedEnvelopeNotificationHandler;
 
     @PostConstruct
     public void registerMessageHandlers() throws ServiceBusException, InterruptedException {
         if (readNotificationsQueueClient != null) {
             readNotificationsQueueClient.registerMessageHandler(
                 errorNotificationHandler,
-                new MessageHandlerOptions(1, false, Duration.ofMinutes(5)),
-                NOTIFICATIONS_READ_EXEC
+                messageHandlerOptions,
+                notificationsReadExecutor
             );
         }
+
+        processedEnvelopesQueueClient.registerMessageHandler(
+            processedEnvelopeNotificationHandler,
+            messageHandlerOptions,
+            processedEnvelopesReadExecutor
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/QueueClientConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/QueueClientConfig.java
@@ -20,6 +20,14 @@ public class QueueClientConfig {
         return createQueueClient(connectionString, queueName);
     }
 
+    @Bean("processed-envelopes-client")
+    public IQueueClient processedEnvelopesQueueClient(
+        @Value("${queues.processed-envelopes.connection-string}") String connectionString,
+        @Value("${queues.processed-envelopes.queue-name}") String queueName
+    ) throws InterruptedException, ServiceBusException {
+        return createQueueClient(connectionString, queueName);
+    }
+
     @Bean("notifications-client")
     public IQueueClient notificationsQueueClient(
         @Value("${queues.notifications.connection-string}") String connectionString,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceBusHelpersConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/ServiceBusHelpersConfiguration.java
@@ -39,4 +39,11 @@ public class ServiceBusHelpersConfiguration {
     ) {
         return new MessageAutoCompletor(queueClient);
     }
+
+    @Bean(name = "processed-envelopes-completor")
+    public MessageAutoCompletor processedEnvelopesMessageCompletor(
+        @Qualifier("processed-envelopes-client") IQueueClient queueClient
+    ) {
+        return new MessageAutoCompletor(queueClient);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
@@ -8,6 +8,9 @@ import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.EnvelopeNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.in.msg.ProcessedEnvelope;
@@ -26,6 +29,8 @@ import java.util.concurrent.Executors;
  * This involves removing sensitive information, status change and creation of an appropriate event.
  * </p>
  */
+@Service
+@Profile("!nosb") // only active when interaction with Service Bus isn't disabled
 public class ProcessedEnvelopeNotificationHandler implements IMessageHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ProcessedEnvelopeNotificationHandler.class);
@@ -38,7 +43,7 @@ public class ProcessedEnvelopeNotificationHandler implements IMessageHandler {
     public ProcessedEnvelopeNotificationHandler(
         EnvelopeFinaliserService envelopeFinaliserService,
         ObjectMapper objectMapper,
-        MessageAutoCompletor messageCompletor
+        @Qualifier("processed-envelopes-completor") MessageAutoCompletor messageCompletor
     ) {
         this.envelopeFinaliserService = envelopeFinaliserService;
         this.objectMapper = objectMapper;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,6 +57,9 @@ queues:
   envelopes:
     connection-string: ${QUEUE_ENVELOPE_SEND:"NO_VALUE_SUPPLIED"}
     queue-name: envelopes
+  processed-envelopes:
+    connection-string: ${QUEUE_PROCESSED_ENVELOPES_READ:"NO_VALUE_SUPPLIED"}
+    queue-name: processed-envelopes
   notifications:
     connection-string: ${QUEUE_NOTIFICATIONS_SEND:"NO_VALUE_SUPPLIED"}
     queue-name: notifications


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-452

### Change description ###

- Provide configuration for the handler of processed-envelopes queue messages
- Also, as this configuration turns on the processing, a functional test is also added for this functionality

In the next PR I'll try to use temporary message receivers to check if the required queue exists (so that the service can wait for them).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
