### PR TITLE
Check if invalid file gets removed in tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -124,6 +124,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_ZIP_PROCESSING_FAILED);
     }
 
@@ -138,6 +139,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -152,6 +154,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -166,6 +169,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -180,6 +184,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -194,6 +199,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_ZIP_PROCESSING_FAILED);
     }
 
@@ -208,6 +214,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
     }
 
@@ -231,6 +238,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         // then
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, DOC_SIGNATURE_FAILURE);
+        fileWasDeleted(SAMPLE_ZIP_FILE_NAME);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_SIG_VERIFY_FAILED);
     }
 
@@ -260,4 +268,8 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         assertThat(envelopesInDb).isEmpty();
     }
 
+    private void fileWasDeleted(String fileName) throws Exception {
+        CloudBlockBlob blob = testContainer.getBlockBlobReference(fileName);
+        await("file should be deleted").timeout(2, SECONDS).until(blob::exists, is(false));
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -43,6 +43,7 @@ public abstract class ProcessorTestSuite<T extends Processor> {
     protected static final String DEFAULT_PUBLIC_KEY_BASE64 = null;
 
     protected static final String CONTAINER_NAME = "bulkscan";
+    protected static final String REJECTED_CONTAINER_NAME = "bulkscan-rejected";
 
     protected T processor;
 
@@ -80,6 +81,7 @@ public abstract class ProcessorTestSuite<T extends Processor> {
     protected ServiceBusHelper serviceBusHelper;
 
     protected CloudBlobContainer testContainer;
+    protected CloudBlobContainer rejectedContainer;
 
     private static DockerComposeContainer dockerComposeContainer;
 
@@ -117,13 +119,16 @@ public abstract class ProcessorTestSuite<T extends Processor> {
         processor = spy(p);
 
         testContainer = cloudBlobClient.getContainerReference(CONTAINER_NAME);
-
         testContainer.createIfNotExists();
+
+        rejectedContainer = cloudBlobClient.getContainerReference(REJECTED_CONTAINER_NAME);
+        rejectedContainer.createIfNotExists();
     }
 
     @After
     public void cleanUp() throws Exception {
         testContainer.deleteIfExists();
+        rejectedContainer.deleteIfExists();
         envelopeRepository.deleteAll();
         processEventRepository.deleteAll();
     }


### PR DESCRIPTION
I was adding a test handling corrupted zip files (https://github.com/hmcts/bulk-scan-processor/pull/515) and realised we never check if file gets moved to rejected container.