### PR TITLE
Add a migration script that finalises old processed envelopes

### DIFF
--- a/src/main/resources/db/migration/V036__Finalise_old_envelopes.sql
+++ b/src/main/resources/db/migration/V036__Finalise_old_envelopes.sql
@@ -1,0 +1,16 @@
+UPDATE scannable_items
+SET ocrdata = null
+WHERE envelope_id IN
+(
+  SELECT id FROM envelopes
+  WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-26'
+);
+
+INSERT INTO process_events (container, zipfilename, createdat, event)
+SELECT container, zipFileName, now(), 'COMPLETED'
+FROM envelopes
+WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-26';
+
+UPDATE envelopes
+SET status = 'COMPLETED'
+WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-26';

--- a/src/main/resources/db/migration/V036__Finalise_old_envelopes.sql
+++ b/src/main/resources/db/migration/V036__Finalise_old_envelopes.sql
@@ -1,16 +1,27 @@
+-- This script finalises all processed envelopes created before 25th January 2019.
+-- All newer envelopes will be finalised by the service itself.
+-- In production no envelopes were created or processed between 19th and 28th Jan,
+-- so 25th Jan is a safe date. On master, the change was introduced on 24th Jan,
+-- but the script prevents duplicating events.
+
 UPDATE scannable_items
 SET ocrdata = null
 WHERE envelope_id IN
 (
   SELECT id FROM envelopes
-  WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-26'
+  WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-25'
 );
 
 INSERT INTO process_events (container, zipfilename, createdat, event)
-SELECT container, zipFileName, now(), 'COMPLETED'
+SELECT container, zipfilename, now(), 'COMPLETED'
 FROM envelopes
-WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-26';
+WHERE status = 'NOTIFICATION_SENT'
+  AND createdat < '2019-01-25'
+  AND (container, zipfilename) NOT IN (
+    SELECT container, zipfilename FROM process_events
+    WHERE event = 'COMPLETED'
+  );
 
 UPDATE envelopes
 SET status = 'COMPLETED'
-WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-26';
+WHERE status = 'NOTIFICATION_SENT' AND createdat < '2019-01-25';


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-483

### Change description ###

Add a migration script that finalises old processed envelopes, i.e. those ones that were not referenced by messages from processed_envelopes queue (as the queue was added later).

Finalising involves:
- removing OCR data from envelope's scannable items
- changing the status of processed envelopes to "COMPLETED"
- creating a "COMPLETED" event

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
