### PR TITLE
Clean up csv report generation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -17,9 +17,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -79,7 +77,7 @@ public class ReportsController {
         );
     }
 
-    @GetMapping(path = "/zip-files-summary-csv", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @GetMapping(path = "/zip-files-summary", produces = "text/csv")
     @ApiOperation("Retrieves zip files summary report in csv format for the given date and jurisdiction")
     public ResponseEntity downloadZipFilesSummary(
         @RequestParam(name = "date") @DateTimeFormat(iso = DATE) LocalDate date,
@@ -87,13 +85,11 @@ public class ReportsController {
     ) throws IOException {
         List<ZipFileSummaryResponse> summary = this.reportsService.getZipFilesSummary(date, jurisdiction);
 
-        String fileName = String.format("Zipfiles-summary-%s", date.toString());
-        File csvFile = CsvWriter.writeZipFilesSummaryToCsv(fileName, summary);
+        String csv = CsvWriter.writeZipFilesSummaryToCsv(summary);
 
         return ResponseEntity
             .ok()
-            .contentType(MediaType.APPLICATION_OCTET_STREAM)
-            .body(Files.readAllBytes(csvFile.toPath()));
+            .body(csv);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
@@ -5,8 +5,6 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 
@@ -20,16 +18,12 @@ public final class CsvWriter {
         // utility class constructor
     }
 
-    public static File writeZipFilesSummaryToCsv(
-        String fileName,
-        List<ZipFileSummaryResponse> data
-    ) throws IOException {
-        File csvFile = File.createTempFile(fileName, ".csv");
+    public static String writeZipFilesSummaryToCsv(List<ZipFileSummaryResponse> data) throws IOException {
 
         CSVFormat csvFileHeader = CSVFormat.DEFAULT.withHeader(ZIP_FILES_SUMMARY_CSV_HEADERS);
-        FileWriter fileWriter = new FileWriter(csvFile);
+        StringBuilder stringBuilder = new StringBuilder();
 
-        try (CSVPrinter printer = new CSVPrinter(fileWriter, csvFileHeader)) {
+        try (CSVPrinter printer = new CSVPrinter(stringBuilder, csvFileHeader)) {
             for (ZipFileSummaryResponse summary : CollectionUtils.emptyIfNull(data)) {
                 printer.printRecord(
                     summary.fileName,
@@ -42,6 +36,6 @@ public final class CsvWriter {
                 );
             }
         }
-        return csvFile;
+        return stringBuilder.toString();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -121,9 +121,12 @@ public class ReportsControllerTest {
         );
 
         mockMvc
-            .perform(get("/reports/zip-files-summary-csv?date=2019-01-14&jurisdiction=BULKSCAN"))
+            .perform(
+                get("/reports/zip-files-summary?date=2019-01-14&jurisdiction=BULKSCAN")
+                    .accept("text/csv")
+            )
             .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
+            .andExpect(content().contentType("text/csv;charset=UTF-8"))
             .andExpect(content().string(expectedContent));
     }
 
@@ -135,9 +138,12 @@ public class ReportsControllerTest {
             .willReturn(emptyList());
 
         mockMvc
-            .perform(get("/reports/zip-files-summary-csv?date=2019-01-14"))
+            .perform(
+                get("/reports/zip-files-summary?date=2019-01-14")
+                    .accept("text/csv")
+            )
             .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
+            .andExpect(content().contentType("text/csv;charset=UTF-8"))
             .andExpect(content().string(
                 "Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Jurisdiction,Status\r\n"
             ));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -1,15 +1,12 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.util;
 
 import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
 
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.Reader;
+import java.io.StringReader;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Arrays;
@@ -37,10 +34,10 @@ public class CsvWriterTest {
         );
 
         //when
-        File summaryToCsv = CsvWriter.writeZipFilesSummaryToCsv("zipfilesummary.csv", csvData);
+        String csv = CsvWriter.writeZipFilesSummaryToCsv(csvData);
 
         //then
-        List<CSVRecord> csvRecordList = readCsv(summaryToCsv);
+        List<CSVRecord> csvRecordList = readCsv(csv);
 
         assertThat(csvRecordList)
             .isNotEmpty()
@@ -82,10 +79,10 @@ public class CsvWriterTest {
     @Test
     public void should_return_csv_file_with_only_headers_when_the_data_is_null() throws IOException {
         //when
-        File summaryToCsv = CsvWriter.writeZipFilesSummaryToCsv("zipfilesummary.csv", null);
+        String csv = CsvWriter.writeZipFilesSummaryToCsv(null);
 
         //then
-        List<CSVRecord> csvRecordList = readCsv(summaryToCsv);
+        List<CSVRecord> csvRecordList = readCsv(csv);
 
         assertThat(csvRecordList)
             .isNotEmpty()
@@ -106,10 +103,7 @@ public class CsvWriterTest {
             );
     }
 
-    private List<CSVRecord> readCsv(File summaryToCsv) throws IOException {
-        Reader fileReader = new FileReader(summaryToCsv);
-        CSVParser csvParser = CSVFormat.DEFAULT.parse(fileReader);
-
-        return csvParser.getRecords();
+    private List<CSVRecord> readCsv(String csv) throws IOException {
+        return CSVFormat.DEFAULT.parse(new StringReader(csv)).getRecords();
     }
 }


### PR DESCRIPTION
- use single url (use Accept header to return data in appropriate format)
- return csv in response body instead of downloading a file