### PR TITLE
Remove the second check of envelope's status in functional test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
@@ -66,7 +66,6 @@ public class ProcessedEnvelopeMessageHandlingTest extends BaseFunctionalTest {
         EnvelopeResponse updatedEnvelope = getEnvelope(zipFilename);
         assertThat(updatedEnvelope.getScannableItems()).hasSize(2);
         assertThat(updatedEnvelope.getScannableItems()).allMatch(item -> item.ocrData == null);
-        assertThat(updatedEnvelope.getStatus()).isEqualTo(Status.COMPLETED);
     }
 
     private String uploadEnvelopeContainingOcrData() throws Exception {


### PR DESCRIPTION
### Change description ###

Remove the second check of envelope's status in a functional test. 

This additional check can cause the test to fail, because the status might still be changed by one of processor's jobs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
