### PR TITLE
Download zip files summary in csv file format

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.controllers;
 
 import io.swagger.annotations.ApiOperation;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -79,7 +80,7 @@ public class ReportsController {
         );
     }
 
-    @GetMapping(path = "/zip-files-summary-csv", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @GetMapping(path = "/zip-files-summary", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     @ApiOperation("Retrieves zip files summary report in csv format for the given date and jurisdiction")
     public ResponseEntity downloadZipFilesSummary(
         @RequestParam(name = "date") @DateTimeFormat(iso = DATE) LocalDate date,
@@ -87,12 +88,10 @@ public class ReportsController {
     ) throws IOException {
         List<ZipFileSummaryResponse> summary = this.reportsService.getZipFilesSummary(date, jurisdiction);
 
-        String fileName = String.format("Zipfiles-summary-%s", date.toString());
-        File csvFile = CsvWriter.writeZipFilesSummaryToCsv(fileName, summary);
-
+        File csvFile = CsvWriter.writeZipFilesSummaryToCsv(summary);
         return ResponseEntity
             .ok()
-            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=zip-files-summary.csv")
             .body(Files.readAllBytes(csvFile.toPath()));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
@@ -13,7 +13,7 @@ import java.util.List;
 public final class CsvWriter {
 
     private static final String[] ZIP_FILES_SUMMARY_CSV_HEADERS = {
-        "Zip File Name", "Date Received", "Time Received", "Date Processed", "Time Processed", "Jurisdiction", "Status"
+        "Jurisdiction", "Zip File Name", "Date Received", "Time Received", "Date Processed", "Time Processed", "Status"
     };
 
     private CsvWriter() {
@@ -32,12 +32,12 @@ public final class CsvWriter {
         try (CSVPrinter printer = new CSVPrinter(fileWriter, csvFileHeader)) {
             for (ZipFileSummaryResponse summary : CollectionUtils.emptyIfNull(data)) {
                 printer.printRecord(
+                    summary.jurisdiction,
                     summary.fileName,
                     summary.dateReceived,
                     summary.timeReceived,
                     summary.dateProcessed,
                     summary.timeProcessed,
-                    summary.jurisdiction,
                     summary.status
                 );
             }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
@@ -21,10 +21,9 @@ public final class CsvWriter {
     }
 
     public static File writeZipFilesSummaryToCsv(
-        String fileName,
         List<ZipFileSummaryResponse> data
     ) throws IOException {
-        File csvFile = File.createTempFile(fileName, ".csv");
+        File csvFile = File.createTempFile("Zipfiles-summary-", ".csv");
 
         CSVFormat csvFileHeader = CSVFormat.DEFAULT.withHeader(ZIP_FILES_SUMMARY_CSV_HEADERS);
         FileWriter fileWriter = new FileWriter(csvFile);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -114,8 +114,8 @@ public class ReportsControllerTest {
             .willReturn(singletonList(zipFileSummaryResponse));
 
         String expectedContent = String.format(
-            "Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Jurisdiction,Status\r\n"
-                + "test.zip,%s,%s,%s,%s,BULKSCAN,CONSUMED\r\n",
+            "Jurisdiction,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Status\r\n"
+                + "BULKSCAN,test.zip,%s,%s,%s,%s,CONSUMED\r\n",
             localDate.toString(), localTime.toString(),
             localDate.toString(), localTime.plusHours(1).toString()
         );
@@ -139,7 +139,7 @@ public class ReportsControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
             .andExpect(content().string(
-                "Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Jurisdiction,Status\r\n"
+                "Jurisdiction,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Status\r\n"
             ));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -22,6 +23,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CONSUMED;
@@ -121,8 +123,10 @@ public class ReportsControllerTest {
         );
 
         mockMvc
-            .perform(get("/reports/zip-files-summary-csv?date=2019-01-14&jurisdiction=BULKSCAN"))
+            .perform(get("/reports/zip-files-summary?date=2019-01-14&jurisdiction=BULKSCAN")
+                .accept(MediaType.APPLICATION_OCTET_STREAM))
             .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=zip-files-summary.csv"))
             .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
             .andExpect(content().string(expectedContent));
     }
@@ -135,8 +139,10 @@ public class ReportsControllerTest {
             .willReturn(emptyList());
 
         mockMvc
-            .perform(get("/reports/zip-files-summary-csv?date=2019-01-14"))
+            .perform(get("/reports/zip-files-summary?date=2019-01-14")
+                .accept(MediaType.APPLICATION_OCTET_STREAM))
             .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=zip-files-summary.csv"))
             .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
             .andExpect(content().string(
                 "Jurisdiction,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Status\r\n"

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -50,30 +50,30 @@ public class CsvWriterTest {
             )
             .containsExactly(
                 tuple(
+                    "Jurisdiction",
                     "Zip File Name",
                     "Date Received",
                     "Time Received",
                     "Date Processed",
                     "Time Processed",
-                    "Jurisdiction",
                     "Status"
                 ),
                 tuple(
+                    "BULKSCAN",
                     "test1.zip",
                     date.toString(),
                     time.toString(),
                     date.toString(),
                     time.toString(),
-                    "BULKSCAN",
                     DOC_PROCESSED.toString()
                 ),
                 tuple(
+                    "BULKSCAN",
                     "test2.zip",
                     date.toString(),
                     time.toString(),
                     date.toString(),
                     time.toString(),
-                    "BULKSCAN",
                     DOC_PROCESSED.toString()
                 )
             );
@@ -95,12 +95,12 @@ public class CsvWriterTest {
             )
             .containsExactly(
                 tuple(
+                    "Jurisdiction",
                     "Zip File Name",
                     "Date Received",
                     "Time Received",
                     "Date Processed",
                     "Time Processed",
-                    "Jurisdiction",
                     "Status"
                 )
             );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.util;
 
 import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
@@ -9,7 +8,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResp
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Arrays;
@@ -37,7 +35,7 @@ public class CsvWriterTest {
         );
 
         //when
-        File summaryToCsv = CsvWriter.writeZipFilesSummaryToCsv("zipfilesummary.csv", csvData);
+        File summaryToCsv = CsvWriter.writeZipFilesSummaryToCsv(csvData);
 
         //then
         List<CSVRecord> csvRecordList = readCsv(summaryToCsv);
@@ -82,7 +80,7 @@ public class CsvWriterTest {
     @Test
     public void should_return_csv_file_with_only_headers_when_the_data_is_null() throws IOException {
         //when
-        File summaryToCsv = CsvWriter.writeZipFilesSummaryToCsv("zipfilesummary.csv", null);
+        File summaryToCsv = CsvWriter.writeZipFilesSummaryToCsv(null);
 
         //then
         List<CSVRecord> csvRecordList = readCsv(summaryToCsv);
@@ -107,9 +105,6 @@ public class CsvWriterTest {
     }
 
     private List<CSVRecord> readCsv(File summaryToCsv) throws IOException {
-        Reader fileReader = new FileReader(summaryToCsv);
-        CSVParser csvParser = CSVFormat.DEFAULT.parse(fileReader);
-
-        return csvParser.getRecords();
+        return CSVFormat.DEFAULT.parse(new FileReader(summaryToCsv)).getRecords();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-514


### Change description ###
At the moment, zip file summary report endpoint is returning 
the zip files summary file without `csv` extension. 
Added a response header to download the file in `csv` format.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
