### PR TITLE
Introduce converters for zip file summary report

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/converters/DownloadCsvZipFileSummaryConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/converters/DownloadCsvZipFileSummaryConverter.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controllers.converters;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ReportException;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+public final class DownloadCsvZipFileSummaryConverter {
+
+    private DownloadCsvZipFileSummaryConverter() {
+        // utility class constructor
+    }
+
+    public static ResponseEntity<byte[]> convert(List<ZipFileSummaryResponse> summary) {
+        try {
+            File csvFile = CsvWriter.writeZipFilesSummaryToCsv(summary);
+
+            return ResponseEntity
+                .ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=zip-files-summary.csv")
+                .body(Files.readAllBytes(csvFile.toPath()));
+        } catch (IOException exception) {
+            throw new ReportException("Unable to generate response", exception);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/converters/JsonViewZipFileSummaryConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/converters/JsonViewZipFileSummaryConverter.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controllers.converters;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportListResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public final class JsonViewZipFileSummaryConverter {
+
+    private JsonViewZipFileSummaryConverter() {
+        // utility class constructor
+    }
+
+    public static ResponseEntity<ZipFilesSummaryReportListResponse> convert(List<ZipFileSummaryResponse> summary) {
+        ZipFilesSummaryReportListResponse response = new ZipFilesSummaryReportListResponse(
+            summary
+                .stream()
+                .map(item -> new ZipFilesSummaryReportItem(
+                    item.fileName,
+                    item.dateReceived,
+                    item.timeReceived,
+                    item.dateProcessed,
+                    item.timeProcessed,
+                    item.jurisdiction,
+                    item.status
+                ))
+                .collect(toList())
+        );
+
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .body(response);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ReportException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ReportException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class ReportException extends RuntimeException {
+
+    public ReportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/converters/DownloadCsvZipFileSummaryConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/converters/DownloadCsvZipFileSummaryConverterTest.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controller.converters;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscanprocessor.controllers.converters.DownloadCsvZipFileSummaryConverter.convert;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CONSUMED;
+
+public class DownloadCsvZipFileSummaryConverterTest {
+
+    @Test
+    public void should_return_csv_downloadable_response_entity() {
+        // given
+        LocalDate localDate = LocalDate.of(2019, 1, 14);
+        LocalTime localTime = LocalTime.of(12, 30, 10, 0);
+
+        ZipFileSummaryResponse response = new ZipFileSummaryResponse(
+            "test.zip",
+            localDate,
+            localTime,
+            localDate,
+            localTime.plusHours(1),
+            "BULKSCAN",
+            CONSUMED.toString()
+        );
+
+        // when
+        ResponseEntity<?> entity = convert(ImmutableList.of(response));
+
+        // then
+        assertThat(entity.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+
+        ContentDisposition contentDisposition = entity.getHeaders().getContentDisposition();
+        assertThat(contentDisposition.getType()).isEqualTo("attachment");
+        assertThat(contentDisposition.getFilename()).isEqualTo("zip-files-summary.csv");
+
+        assertThat(((byte[]) entity.getBody()).length).isGreaterThan(0);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/converters/JsonViewZipFileSummaryConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/converters/JsonViewZipFileSummaryConverterTest.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controller.converters;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportListResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscanprocessor.controllers.converters.JsonViewZipFileSummaryConverter.convert;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CONSUMED;
+
+public class JsonViewZipFileSummaryConverterTest {
+
+    private static final ZipFilesSummaryReportItemComparator COMPARATOR = new ZipFilesSummaryReportItemComparator();
+
+    @Test
+    public void should_return_json_response_entity() {
+        // given
+        LocalDate localDate = LocalDate.of(2019, 1, 14);
+        LocalTime localTime = LocalTime.of(12, 30, 10, 0);
+
+        ZipFileSummaryResponse response = new ZipFileSummaryResponse(
+            "test.zip",
+            localDate,
+            localTime,
+            localDate,
+            localTime.plusHours(1),
+            "BULKSCAN",
+            CONSUMED.toString()
+        );
+
+        // when
+        ResponseEntity<?> entity = convert(ImmutableList.of(response));
+
+        // then
+        assertThat(entity.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON_UTF8);
+        assertThat(((ZipFilesSummaryReportListResponse) entity.getBody()).items)
+            .usingElementComparator(COMPARATOR)
+            .contains(new ZipFilesSummaryReportItem(
+                response.fileName,
+                response.dateReceived,
+                response.timeReceived,
+                response.dateProcessed,
+                response.timeProcessed,
+                response.jurisdiction,
+                response.status
+            ));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/converters/ZipFilesSummaryReportItemComparator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/converters/ZipFilesSummaryReportItemComparator.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.controller.converters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportItem;
+
+import java.util.Comparator;
+
+class ZipFilesSummaryReportItemComparator implements Comparator<ZipFilesSummaryReportItem> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public int compare(ZipFilesSummaryReportItem o1, ZipFilesSummaryReportItem o2) {
+        try {
+            return MAPPER.writeValueAsString(o1).compareTo(MAPPER.writeValueAsString(o2));
+        } catch (JsonProcessingException exception) {
+            throw new RuntimeException("oh no. should not happened", exception);
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Report endpoint: list zip files received on given day](https://tools.hmcts.net/jira/browse/BPS-514)

### Change description ###

I believe everyone was in favour to have a single endpoint for specific report and provide ability for consumer to choose whichever output is available. To avoid boiler code juggled in controller methods it has been mimicked to decorators for easier use.

Feature of this separation is already finished in two steps:

- [x] Boilerplate code for decorators
- [ ] Use decorators in zip file summary report (local branch - not yet pushed)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
