### PR TITLE
Add service for deleting old rejected files

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -60,13 +60,13 @@ public class CleanUpRejectedFilesTaskTest {
     @Test
     public void should_delete_old_files() throws Exception {
         // given
-        upload("foo.zip");
-        upload("bar.zip");
+        // there are two files in rejected container
+        rejectedContainer.getBlockBlobReference("foo.zip").uploadText("some content");
+        rejectedContainer.getBlockBlobReference("bar.zip").uploadText("some content");
 
-        // sanity check
-        assertThat(rejectedContainer.listBlobs()).hasSize(2);
+        assertThat(rejectedContainer.listBlobs()).hasSize(2); // sanity check
 
-        // add snapshot to one of the files
+        // one of them has a snapshot
         rejectedContainer
             .getBlockBlobReference("bar.zip")
             .createSnapshot();
@@ -76,11 +76,5 @@ public class CleanUpRejectedFilesTaskTest {
 
         // then
         assertThat(rejectedContainer.listBlobs()).isEmpty();
-    }
-
-    private void upload(String fileName) throws Exception {
-        rejectedContainer
-            .getBlockBlobReference(fileName)
-            .uploadText("some content");
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -61,7 +61,6 @@ public class CleanUpRejectedFilesTaskTest {
     public void should_delete_old_files() throws Exception {
         // given
         Duration deleteDelay = Duration.ZERO; // delete immediately
-        CleanUpRejectedFilesTask sut = new CleanUpRejectedFilesTask(blobManager, deleteDelay);
 
         upload("foo.zip");
         upload("bar.zip");
@@ -75,7 +74,7 @@ public class CleanUpRejectedFilesTaskTest {
             .createSnapshot();
 
         // when
-        sut.run();
+        new CleanUpRejectedFilesTask(blobManager, deleteDelay).run();
 
         // then
         assertThat(rejectedContainer.listBlobs()).isEmpty();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -60,8 +60,6 @@ public class CleanUpRejectedFilesTaskTest {
     @Test
     public void should_delete_old_files() throws Exception {
         // given
-        Duration deleteDelay = Duration.ZERO; // delete immediately
-
         upload("foo.zip");
         upload("bar.zip");
 
@@ -74,7 +72,7 @@ public class CleanUpRejectedFilesTaskTest {
             .createSnapshot();
 
         // when
-        new CleanUpRejectedFilesTask(blobManager, deleteDelay).run();
+        new CleanUpRejectedFilesTask(blobManager, Duration.ZERO).run();
 
         // then
         assertThat(rejectedContainer.listBlobs()).isEmpty();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.DockerComposeContainer;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
+
+import java.io.File;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class CleanUpRejectedFilesTaskTest {
+
+    @Autowired
+    private BlobManagementProperties blobManagementProperties;
+
+    private CloudBlobContainer rejectedContainer;
+    private BlobManager blobManager;
+
+    private static DockerComposeContainer dockerComposeContainer;
+
+    @BeforeClass
+    public static void initialize() {
+        dockerComposeContainer =
+            new DockerComposeContainer(new File("src/integrationTest/resources/docker-compose.yml"))
+                .withExposedService("azure-storage", 10000);
+
+        dockerComposeContainer.start();
+    }
+
+    @AfterClass
+    public static void tearDownContainer() {
+        dockerComposeContainer.stop();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
+        CloudBlobClient cloudBlobClient = account.createCloudBlobClient();
+
+        this.blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
+
+        this.rejectedContainer = cloudBlobClient.getContainerReference("test-rejected");
+        this.rejectedContainer.createIfNotExists();
+    }
+
+    @Test
+    public void should_delete_old_files() throws Exception {
+        // given
+        Duration deleteDelay = Duration.ZERO; // delete immediately
+        CleanUpRejectedFilesTask sut = new CleanUpRejectedFilesTask(blobManager, deleteDelay);
+
+        upload("foo.zip");
+        upload("bar.zip");
+
+        // sanity check
+        assertThat(rejectedContainer.listBlobs()).hasSize(2);
+
+        // add snapshot to one of the files
+        rejectedContainer
+            .getBlockBlobReference("bar.zip")
+            .createSnapshot();
+
+        // when
+        sut.run();
+
+        // then
+        assertThat(rejectedContainer.listBlobs()).isEmpty();
+    }
+
+    private void upload(String fileName) throws Exception {
+        rejectedContainer
+            .getBlockBlobReference(fileName)
+            .uploadText("some content");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
+
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.EnumSet;
+
+import static com.microsoft.azure.storage.blob.BlobListingDetails.SNAPSHOTS;
+import static com.microsoft.azure.storage.blob.DeleteSnapshotsOption.INCLUDE_SNAPSHOTS;
+
+public class CleanUpRejectedFilesTask {
+
+    private static final Logger log = LoggerFactory.getLogger(CleanUpRejectedFilesTask.class);
+
+    private final BlobManager blobManager;
+    private final Duration deleteDelay;
+
+    // region constructor
+    public CleanUpRejectedFilesTask(
+        BlobManager blobManager,
+        Duration deleteDelay
+    ) {
+        this.blobManager = blobManager;
+        this.deleteDelay = deleteDelay;
+    }
+    // endregion
+
+    public void run() {
+        blobManager
+            .listRejectedContainers()
+            .forEach(container -> {
+                log.info("Deleting old rejected files from container {}", container.getName());
+                container
+                    .listBlobs(null, true, EnumSet.of(SNAPSHOTS), null, null)
+                    .forEach(listItem -> {
+                        try {
+                            CloudBlockBlob blob = container.getBlockBlobReference(
+                                FilenameUtils.getName(listItem.getUri().toString())
+                            );
+
+                            if (canBeDeleted(blob)) {
+                                blob.delete(INCLUDE_SNAPSHOTS, null, null, null);
+                                log.info("Deleted rejected file {}", blob.getName());
+                            }
+                        } catch (URISyntaxException | StorageException exc) {
+                            log.error(
+                                "Unable to delete rejected file {} from container {}",
+                                listItem.getUri(),
+                                container.getName(),
+                                exc
+                            );
+                        }
+                    });
+            });
+    }
+
+    private boolean canBeDeleted(CloudBlockBlob blob) throws StorageException {
+        blob.downloadAttributes();
+
+        Date createdTime = blob.getProperties().getLastModified();
+        Date cutoff = Date.from(Instant.now().minus(this.deleteDelay));
+
+        return createdTime.before(cutoff);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -90,6 +90,13 @@ public class BlobManager {
             .collect(toList());
     }
 
+    public List<CloudBlobContainer> listRejectedContainers() {
+        return StreamSupport
+            .stream(cloudBlobClient.listContainers().spliterator(), false)
+            .filter(c -> c.getName().endsWith(REJECTED_CONTAINER_NAME_SUFFIX))
+            .collect(toList());
+    }
+
     public void tryMoveFileToRejectedContainer(String fileName, String inputContainerName, String leaseId) {
         String rejectedContainerName = getRejectedContainerName(inputContainerName);
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -1,0 +1,90 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.microsoft.azure.storage.blob.BlobProperties;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.microsoft.azure.storage.blob.ListBlobItem;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.EnumSet;
+
+import static com.microsoft.azure.storage.blob.BlobListingDetails.SNAPSHOTS;
+import static com.microsoft.azure.storage.blob.DeleteSnapshotsOption.INCLUDE_SNAPSHOTS;
+import static java.time.Instant.now;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CleanUpRejectedFilesTaskTest {
+
+    @Mock BlobManager blobManager;
+    @Mock CloudBlobContainer container;
+
+    @Before
+    public void setUp() throws Exception {
+        given(blobManager.listRejectedContainers()).willReturn(singletonList(container));
+    }
+
+    @Test
+    public void should_remove_only_old_files() throws Exception {
+        // given
+        Duration deleteDelay = Duration.ofHours(1);
+
+        MockBlob newFile = mockBlob("new.zip", now());
+        MockBlob oldFile = mockBlob("old.zip", now().minus(deleteDelay.plusMinutes(1)));
+
+        given(container.listBlobs(null, true, EnumSet.of(SNAPSHOTS), null, null))
+            .willReturn(asList(
+                newFile.listItem,
+                oldFile.listItem
+            ));
+
+        CleanUpRejectedFilesTask task = new CleanUpRejectedFilesTask(blobManager, deleteDelay);
+
+        // when
+        task.run();
+
+        // then
+        verify(newFile.blob, times(0)).delete(any(), any(), any(), any());
+        verify(oldFile.blob, times(1)).delete(INCLUDE_SNAPSHOTS, null, null, null);
+    }
+
+    private MockBlob mockBlob(String fileName, Instant lastModified) throws Exception {
+        ListBlobItem listItem = mock(ListBlobItem.class);
+        given(listItem.getUri()).willReturn(URI.create(fileName));
+
+        BlobProperties props = mock(BlobProperties.class);
+        given(props.getLastModified()).willReturn(Date.from(lastModified));
+
+        CloudBlockBlob blob = mock(CloudBlockBlob.class);
+        given(blob.getProperties()).willReturn(props);
+
+        given(container.getBlockBlobReference(fileName)).willReturn(blob);
+
+        return new MockBlob(listItem, blob);
+    }
+
+    private class MockBlob {
+        protected final ListBlobItem listItem;
+        protected final CloudBlockBlob blob;
+
+        protected MockBlob(ListBlobItem listItem, CloudBlockBlob blob) {
+            this.listItem = listItem;
+            this.blob = blob;
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -31,8 +31,8 @@ import static org.mockito.Mockito.verify;
 @RunWith(MockitoJUnitRunner.class)
 public class CleanUpRejectedFilesTaskTest {
 
-    @Mock BlobManager blobManager;
-    @Mock CloudBlobContainer container;
+    @Mock private BlobManager blobManager;
+    @Mock private CloudBlobContainer container;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -130,6 +130,29 @@ public class BlobManagerTest {
     }
 
     @Test
+    public void listRejectedContainers_retrieves_rejected_containers_only() {
+        // given
+        List<CloudBlobContainer> allContainers = Arrays.asList(
+            mockContainer("test1"),
+            mockContainer("test1-rejected"),
+            mockContainer("test2"),
+            mockContainer("test2-rejected")
+        );
+        given(cloudBlobClient.listContainers()).willReturn(allContainers);
+
+        // when
+        List<CloudBlobContainer> rejectedContainers = blobManager.listRejectedContainers();
+
+        // then
+        assertThat(rejectedContainers)
+            .extracting(c -> c.getName())
+            .hasSameElementsAs(Arrays.asList(
+                "test1-rejected",
+                "test2-rejected"
+            ));
+    }
+
+    @Test
     public void tryMoveFileToRejectedContainer_copies_and_deletes_original_blob() throws Exception {
         // given
         mockRejectedBlobToReturnCopyState(PENDING, SUCCESS);


### PR DESCRIPTION
This PR only adds the service and tests for it.
It is not used by the app and no scheduling is configured (to come in next PR(s))