### PR TITLE
Remove default Service Bus connection strings from application settings

### DIFF
--- a/charts/bulk-scan-processor/values.template.yaml
+++ b/charts/bulk-scan-processor/values.template.yaml
@@ -41,6 +41,7 @@ java:
     STORAGE_URL: "https://$(STORAGE_ACCOUNT_NAME).blob.core.windows.net"
     QUEUE_ENVELOPE_SEND: "$(SB_CONN_STRING);EntityPath=envelopes"
     QUEUE_NOTIFICATIONS_SEND: "$(SB_CONN_STRING);EntityPath=notifications"
+    QUEUE_NOTIFICATIONS_READ: "$(SB_CONN_STRING);EntityPath=notifications"
     QUEUE_PROCESSED_ENVELOPES_READ: "$(SB_CONN_STRING);EntityPath=processed-envelopes"
   keyVaults:
     "s2s":

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,16 +55,16 @@ storage:
 
 queues:
   envelopes:
-    connection-string: ${QUEUE_ENVELOPE_SEND:"NO_VALUE_SUPPLIED"}
+    connection-string: ${QUEUE_ENVELOPE_SEND}
     queue-name: envelopes
   processed-envelopes:
-    connection-string: ${QUEUE_PROCESSED_ENVELOPES_READ:"NO_VALUE_SUPPLIED"}
+    connection-string: ${QUEUE_PROCESSED_ENVELOPES_READ}
     queue-name: processed-envelopes
   notifications:
-    connection-string: ${QUEUE_NOTIFICATIONS_SEND:"NO_VALUE_SUPPLIED"}
+    connection-string: ${QUEUE_NOTIFICATIONS_SEND}
     queue-name: notifications
   read-notifications:
-    connection-string: ${QUEUE_NOTIFICATIONS_READ:"NO_VALUE_SUPPLIED"}
+    connection-string: ${QUEUE_NOTIFICATIONS_READ}
     queue-name: notifications
     enabled: ${ERROR_NOTIFICATIONS_ENABLED:false}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-445

### Change description ###

Remove default Service Bus connection strings from application settings. Those defaults prevented the application from crashing quickly, failing preview builds.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
