### PR TITLE
disable persistent storage in Helm chart

### DIFF
--- a/charts/bulk-scan-processor/values.template.yaml
+++ b/charts/bulk-scan-processor/values.template.yaml
@@ -58,6 +58,8 @@ postgresql:
   postgresqlDatabase: bulk_scan
   service:
     port: 5432
+  persistence:
+    enabled: false
 
 servicebus:
   resourceGroup: bulk-scan-aks


### PR DESCRIPTION
### Change description ###

Turn off persistent storage in helm chart - it creates a lot of unnecessary persistent volumes which aren't needed for PR testing. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
