### PR TITLE
Make the processor crash on failed message handler registration

### DIFF
--- a/charts/bulk-scan-processor/values.template.yaml
+++ b/charts/bulk-scan-processor/values.template.yaml
@@ -20,7 +20,6 @@ java:
       secretRef: storage-secret-${SERVICE_NAME}
       key: accessKey
   environment:
-    FAIL_ON_MESSAGE_HANDLER_REGISTRATION_ERROR: "false"
     POSTGRES_USER: bulkscanner
     POSTGRES_PASSWORD: bsppassword
     POSTGRES_DB: bulk_scan


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-445

### Change description ###

Make the processor crash on failed message handler registration. Before this change, it would catch the exception and log the failure on preview, causing functional tests within the same build to fail.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
