### PR TITLE
Remove some unnecessary S2S sign-ins from functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -58,9 +58,7 @@ public abstract class BaseFunctionalTest {
         rejectedContainer = cloudBlobClient.getContainerReference(rejectedContainerName);
     }
 
-    protected void waitForFileToBeProcessed(String fileName) {
-        String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
-
+    protected void waitForFileToBeProcessed(String fileName, String s2sToken) {
         await("processing of file " + fileName + "should end")
             .atMost(scanDelay + 40_000, TimeUnit.MILLISECONDS)
             .pollInterval(500, TimeUnit.MILLISECONDS)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -28,9 +28,9 @@ public class BlobProcessorTest extends BaseFunctionalTest {
         // valid zip file
         testHelper.uploadZipFile(inputContainer, files, metadataFile, destZipFilename, testPrivateKeyDer);
 
-        waitForFileToBeProcessed(destZipFilename);
-
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
+
+        waitForFileToBeProcessed(destZipFilename, s2sToken);
 
         EnvelopeResponse envelope = testHelper.getEnvelopeByZipFileName(testUrl, s2sToken, destZipFilename).get();
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/UpdateStatusTest.java
@@ -29,10 +29,9 @@ public class UpdateStatusTest extends BaseFunctionalTest {
             testPrivateKeyDer
         );
 
-        waitForFileToBeProcessed(destZipFilename);
-
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
 
+        waitForFileToBeProcessed(destZipFilename, s2sToken);
 
         // find our envelope
         UUID envelopeId =


### PR DESCRIPTION
### Change description ###

Remove some unnecessary S2S sign-ins from functional tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
