### PR TITLE
Enable reupload job for Probate and Divorce

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -142,6 +142,12 @@ envelope-access:
      - jurisdiction: BULKSCAN
        readService: bulk_scan_processor_tests
        updateService: bulk_scan_processor_tests
+     - jurisdiction: PROBATE
+       readService: TBD
+       updateService: TBD
+     - jurisdiction: DIVORCE
+       readService: TBD
+       updateService: TBD
 
 flyway:
   noop:


### PR DESCRIPTION
### Change description ###

Enable reupload job for Probate and Divorce. This is only a quick fix - to make a proper one we'll need to use a different mapping.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
