### PR TITLE
Fix rejected files cleanup job

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -9,6 +9,7 @@ orchestrator_notifications_task_enabled = "true"
 orchestrator_notifications_task_delay = "3000"
 
 delete_rejected_files_enabled = "true"
+delete_rejected_files_cron = "0 0/10 * * * *"
 
 api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"
 allowed_client_certificate_thumbprints = ["4AF638E82FBD9959A5B8286C673360AC2C2E7053"]

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -9,8 +9,6 @@ scan_enabled = "true"
 
 orchestrator_notifications_task_enabled = "true"
 
-delete_rejected_files_enabled = "true"
-
 api_gateway_test_valid_certificate_thumbprint = "3B0D23863EE7EF90290AD02B0ACFD7C37ED5B330"
 allowed_client_certificate_thumbprints = ["919F8A770C2A2F06933BA11551001ED0581B8848"]
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
 import java.io.File;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,7 +71,7 @@ public class CleanUpRejectedFilesTaskTest {
             .createSnapshot();
 
         // when
-        new CleanUpRejectedFilesTask(blobManager, Duration.ZERO).run();
+        new CleanUpRejectedFilesTask(blobManager, "PT0H").run();
 
         // then
         assertThat(rejectedContainer.listBlobs()).isEmpty();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
@@ -31,10 +31,10 @@ public class CleanUpRejectedFilesTask {
     // region constructor
     public CleanUpRejectedFilesTask(
         BlobManager blobManager,
-        @Value("${scheduling.task.delete-rejected-files.ttl}") Duration ttl
+        @Value("${scheduling.task.delete-rejected-files.ttl}") String ttl // ISO-8601 duration string
     ) {
         this.blobManager = blobManager;
-        this.ttl = ttl;
+        this.ttl = Duration.parse(ttl);
     }
     // endregion
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
 import java.net.URISyntaxException;
@@ -20,6 +21,7 @@ import java.util.EnumSet;
 import static com.microsoft.azure.storage.blob.BlobListingDetails.SNAPSHOTS;
 import static com.microsoft.azure.storage.blob.DeleteSnapshotsOption.INCLUDE_SNAPSHOTS;
 
+@Service
 @ConditionalOnProperty(value = "scheduling.task.delete-rejected-files.enabled")
 public class CleanUpRejectedFilesTask {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -42,7 +42,8 @@ public class CleanUpRejectedFilesTaskTest {
     @Test
     public void should_remove_only_old_files() throws Exception {
         // given
-        Duration ttl = Duration.ofHours(1);
+        String ttlString = "PT1H";
+        Duration ttl = Duration.parse(ttlString);
 
         MockBlob newFile = mockBlob("new.zip", now());
         MockBlob oldFile = mockBlob("old.zip", now().minus(ttl.plusMinutes(1)));
@@ -53,7 +54,7 @@ public class CleanUpRejectedFilesTaskTest {
                 oldFile.listItem
             ));
 
-        CleanUpRejectedFilesTask task = new CleanUpRejectedFilesTask(blobManager, ttl);
+        CleanUpRejectedFilesTask task = new CleanUpRejectedFilesTask(blobManager, ttlString);
 
         // when
         task.run();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-595

### Change description ###

Fix the parsing of rejected files' TTL and make the cleanup job class a Spring service (so that the schedule could work).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
