### PR TITLE
Make the rejected files' TTL an ISO-8601 duration

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -115,7 +115,7 @@ variable "delete_rejected_files_cron" {
 }
 
 variable "delete_rejected_files_ttl" {
-  default = "72h"
+  default = "PT72H"
 }
 # endregion
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-595

### Change description ###

Make the rejected files' TTL an ISO-8601 duration. That's what the application expects.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
