### PR TITLE
Update recipients for report sender

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderDisabledTest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+    properties = {
+        "spring.mail.host=false"
+    }
+)
+@RunWith(SpringRunner.class)
+public class ReportSenderDisabledTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void should_not_have_report_sender_in_context() {
+        assertThat(context.getBeanNamesForType(ReportSender.class)).isEmpty();
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.mail.internet.MimeMessage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(
+    properties = {
+        "spring.mail.host=smtp.server.com", // once present in config can be deleted
+        "reports.recipients=integration@test"
+    }
+)
+@RunWith(SpringRunner.class)
+public class ReportSenderTest {
+
+    @Autowired
+    private ReportSender reportSender;
+
+    @SpyBean
+    private JavaMailSender mailSender;
+
+    @Test
+    public void should_attempt_to_send_report_when_recipients_list_is_present() {
+        reportSender.send();
+
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -13,12 +13,7 @@ import javax.mail.internet.MimeMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
-@SpringBootTest(
-    properties = {
-        "spring.mail.host=smtp.server.com", // once present in config can be deleted
-        "reports.recipients=integration@test"
-    }
-)
+@SpringBootTest
 @RunWith(SpringRunner.class)
 public class ReportSenderTest {
 

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -28,3 +28,5 @@ user.timezone=GMT
 
 # no communication with Service Bus
 spring.profiles.active=nosb
+
+reports.recipients=integration@test

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -3,8 +3,10 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
@@ -15,6 +17,8 @@ import java.time.LocalDate;
 import java.util.List;
 import javax.mail.internet.MimeMessage;
 
+@Component
+@ConditionalOnBean(JavaMailSender.class)
 public class ReportSender {
 
     private static final Logger log = LoggerFactory.getLogger(ReportSender.class);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -35,7 +35,7 @@ public class ReportSender {
     public ReportSender(
         JavaMailSender mailSender,
         ReportsService reportsService,
-        @Value("${reports.recipients:}") String reportRecipients
+        @Value("${reports.recipients}") String reportRecipients
     ) {
         this.mailSender = mailSender;
         this.reportsService = reportsService;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -18,7 +18,7 @@ import java.util.List;
 import javax.mail.internet.MimeMessage;
 
 @Component
-@ConditionalOnClass(JavaMailSender.class)
+@ConditionalOnProperty(prefix = "spring.mail", name = "host")
 public class ReportSender {
 
     private static final Logger log = LoggerFactory.getLogger(ReportSender.class);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -35,11 +35,11 @@ public class ReportSender {
     public ReportSender(
         JavaMailSender mailSender,
         ReportsService reportsService,
-        @Value("${reports.recipients}") String reportRecipients
+        @Value("${reports.recipients}") String reportRecipientsCsv
     ) {
         this.mailSender = mailSender;
         this.reportsService = reportsService;
-        this.recipients = reportRecipients.split(",");
+        this.recipients = reportRecipientsCsv.split(",");
 
         if (this.recipients.length == 0) {
             log.warn("No recipients configured for reports");

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -18,7 +18,7 @@ import java.util.List;
 import javax.mail.internet.MimeMessage;
 
 @Component
-@ConditionalOnBean(JavaMailSender.class)
+@ConditionalOnClass(JavaMailSender.class)
 public class ReportSender {
 
     private static final Logger log = LoggerFactory.getLogger(ReportSender.class);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
@@ -11,7 +12,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
 import javax.mail.internet.MimeMessage;
 
@@ -31,16 +31,11 @@ public class ReportSender {
     public ReportSender(
         JavaMailSender mailSender,
         ReportsService reportsService,
-        String[] recipients
+        @Value("${reports.recipients:}") String reportRecipients
     ) {
         this.mailSender = mailSender;
         this.reportsService = reportsService;
-
-        if (recipients == null) {
-            this.recipients = new String[0];
-        } else {
-            this.recipients = Arrays.copyOf(recipients, recipients.length);
-        }
+        this.recipients = reportRecipients.split(",");
 
         if (this.recipients.length == 0) {
             log.warn("No recipients configured for reports");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,18 @@ spring:
           lob:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types
             non_contextual_creation: true
+  mail:
+    host: smtp.office365.com
+    password: password
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+    test-connection: true
+    username: username
 
 info:
   app:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,6 +47,9 @@ spring:
     test-connection: true
     username: username
 
+reports:
+  recipients:
+
 info:
   app:
     name: Bulk Scanning

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,7 +44,6 @@ spring:
           auth: true
           starttls:
             enable: true
-    test-connection: true
     username: username
 
 reports:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,7 +35,7 @@ spring:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types
             non_contextual_creation: true
   mail:
-    host: smtp.office365.com
+    host: false #smtp.office365.com
     password: password
     port: 587
     properties:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,7 +35,7 @@ spring:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types
             non_contextual_creation: true
   mail:
-    host: false #smtp.office365.com
+    host: ${SMTP_HOST:smtp.localhost}
     password: password
     port: 587
     properties:


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate sending reports via email](https://tools.hmcts.net/jira/browse/BPS-466)

### Change description ###

List of recipients must come through config which must be set from key vault. Since list is dynamic for painless config setup suggesting to store as comma separated value - usual approach for this kind of task.

Bonus: introducing extra config for auto configuration of `JavaMailSender` bean. ~Added `test-connection` flag. It tests connection before registering bean. Should fail the application failing that.~ Disabled at the moment. Giving the configuration is present, also _enabling_ possibility to automatically register report sender once `JavaMailSender` is enabled

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
