### PR TITLE
Feature: enable reports

### DIFF
--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -9,3 +9,5 @@ orchestrator_notifications_task_delay = "3000"
 api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"
 blob_signature_verification_key_file = "nonprod_public_key.der"
 allowed_client_certificate_thumbprints = ["4AF638E82FBD9959A5B8286C673360AC2C2E7053"]
+
+smtp_host = "smtp.office365.com"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -133,6 +133,12 @@ module "bulk-scan" {
     QUEUE_NOTIFICATIONS_READ = "${data.terraform_remote_state.shared_infra.notifications_queue_primary_listen_connection_string}"
     QUEUE_PROCESSED_ENVELOPES_READ = "${data.terraform_remote_state.shared_infra.processed_envelopes_queue_primary_listen_connection_string}"
 
+    SMTP_HOST          = "${var.smtp_host}"
+    SMTP_USERNAME      = "${data.azurerm_key_vault_secret.smtp_username.value}"
+    SMTP_PASSWORD      = "${data.azurerm_key_vault_secret.smtp_password.value}"
+    REPORTS_CRON       = "${var.reports_cron}"
+    REPORTS_RECIPIENTS = "${data.azurerm_key_vault_secret.reports_recipients.value}"
+
     // silence the "bad implementation" logs
     LOGBACK_REQUIRE_ALERT_LEVEL = "false"
     LOGBACK_REQUIRE_ERROR_CODE  = "false"
@@ -177,6 +183,21 @@ resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
 data "azurerm_key_vault_secret" "s2s_secret" {
   name      = "microservicekey-bulk-scan-processor"
   vault_uri = "${local.s2s_vault_url}"
+}
+
+data "azurerm_key_vault_secret" "reports_recipients" {
+  name      = "reports-recipients"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "smtp_username" {
+  name      = "reports-email-username"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "smtp_password" {
+  name      = "reports-email-password"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
 }
 
 # region API (gateway)

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -15,3 +15,5 @@ api_gateway_test_valid_certificate_thumbprint = "3B0D23863EE7EF90290AD02B0ACFD7C
 allowed_client_certificate_thumbprints = ["919F8A770C2A2F06933BA11551001ED0581B8848"]
 
 blob_processing_delay_in_minutes = "30"
+
+smtp_host = "smtp.office365.com"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -15,5 +15,3 @@ api_gateway_test_valid_certificate_thumbprint = "3B0D23863EE7EF90290AD02B0ACFD7C
 allowed_client_certificate_thumbprints = ["919F8A770C2A2F06933BA11551001ED0581B8848"]
 
 blob_processing_delay_in_minutes = "30"
-
-smtp_host = "smtp.office365.com"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -117,6 +117,20 @@ variable "delete_rejected_files_cron" {
 variable "delete_rejected_files_ttl" {
   default = "PT72H"
 }
+
+# endregion
+
+# region reports
+variable "smtp_host" {
+  type        = "string"
+  default     = "false"
+  description = "SMTP host for sending out reports via JavaMailSender"
+}
+
+variable "reports_cron" {
+  default = "0 0 18 * * *"
+}
+
 # endregion
 
 # list of SSL client certificate thumbprints that are accepted by the API (gateway)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -13,12 +13,7 @@ import javax.mail.internet.MimeMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
-@SpringBootTest(
-    properties = {
-        "spring.mail.host=smtp.server.com", // once present in config can be deleted
-        "reports.recipients=integration@test"
-    }
-)
+@SpringBootTest
 @RunWith(SpringRunner.class)
 public class ReportSenderTest {
 

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -28,3 +28,5 @@ user.timezone=GMT
 
 # no communication with Service Bus
 spring.profiles.active=nosb
+
+reports.recipients=integration@test

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 
+import net.javacrumbs.shedlock.core.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
@@ -47,6 +49,8 @@ public class ReportSender {
     }
     // endregion
 
+    @Scheduled(cron = "${reports.cron:-}")
+    @SchedulerLock(name = "report-sender")
     public void send() {
         try {
             MimeMessage msg = mailSender.createMimeMessage();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,7 +36,7 @@ spring:
             non_contextual_creation: true
   mail:
     host: ${SMTP_HOST:smtp.localhost}
-    password: password
+    password: ${SMTP_PASSWORD:password}
     port: 587
     properties:
       mail:
@@ -44,7 +44,7 @@ spring:
           auth: true
           starttls:
             enable: true
-    username: username
+    username: ${SMTP_USERNAME:username}
 
 reports:
   recipients:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,7 +35,7 @@ spring:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types
             non_contextual_creation: true
   mail:
-    host: false #smtp.office365.com
+    host: ${SMTP_HOST:smtp.localhost}
     password: password
     port: 587
     properties:


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate sending reports via email](https://tools.hmcts.net/jira/browse/BPS-466)

### Change description ###

**NOTE**: based on #597

Secret created in available key vaults:

```bash
INFO: Found secret reports-recipients in environment saat
INFO: Found secret reports-recipients in environment sprod
INFO: Found secret reports-recipients in environment demo
INFO: Found secret reports-recipients in environment aat
INFO: Found secret reports-recipients in environment prod
```

`prod` contains all listed in the ticket, others only bulk scan one with minor modification. There has to be some value. Reports will be and shall be enabled only for `prod`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
