### PR TITLE
Make doc subtype a free string

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
@@ -54,8 +54,7 @@ public class ScannableItem implements EnvelopeAssignable {
     @Enumerated(EnumType.STRING)
     private DocumentType documentType;
 
-    @Enumerated(EnumType.STRING)
-    private DocumentSubtype documentSubtype;
+    private String documentSubtype;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "envelope_id", nullable = false)
@@ -76,7 +75,7 @@ public class ScannableItem implements EnvelopeAssignable {
         String fileName,
         String notes,
         DocumentType documentType,
-        DocumentSubtype documentSubtype
+        String documentSubtype
     ) {
         this.documentControlNumber = documentControlNumber;
         this.scanningDate = scanningDate;
@@ -147,7 +146,7 @@ public class ScannableItem implements EnvelopeAssignable {
         return documentType;
     }
 
-    public DocumentSubtype getDocumentSubtype() {
+    public String getDocumentSubtype() {
         return documentSubtype;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.ocr.OcrData;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/DocumentSubtype.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/DocumentSubtype.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.common;
 
-public class DocumentSubtype {
+public final class DocumentSubtype {
 
     public static final String WILL = "will";
     public static final String SSCS1 = "sscs1";
     public static final String COVERSHEET = "coversheet";
 
+    private DocumentSubtype() {
+        // util class
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/DocumentSubtype.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/DocumentSubtype.java
@@ -1,21 +1,9 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.common;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+public class DocumentSubtype {
 
-public enum DocumentSubtype {
-    WILL("will"),
-    SSCS1("sscs1"),
-    COVERSHEET("coversheet");
+    public static final String WILL = "will";
+    public static final String SSCS1 = "sscs1";
+    public static final String COVERSHEET = "coversheet";
 
-    private final String value;
-
-    DocumentSubtype(String value) {
-        this.value = value;
-    }
-
-    @Override
-    @JsonValue
-    public String toString() {
-        return value;
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
@@ -22,7 +22,7 @@ import static java.util.stream.Collectors.toList;
 public class EnvelopeMapper {
 
     // Maps metadata file document type to target ccd subtype.
-    private static final Map<InputDocumentType, DocumentSubtype> subtypeMapping =
+    private static final Map<InputDocumentType, String> subtypeMapping =
         ImmutableMap.of(
             InputDocumentType.SSCS1, DocumentSubtype.SSCS1,
             InputDocumentType.WILL, DocumentSubtype.WILL,
@@ -83,7 +83,7 @@ public class EnvelopeMapper {
             : DocumentType.OTHER;
     }
 
-    private static DocumentSubtype extractDocumentSubtype(InputDocumentType inputDocumentType) {
+    private static String extractDocumentSubtype(InputDocumentType inputDocumentType) {
         return subtypeMapping.get(inputDocumentType);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/ScannableItemResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/ScannableItemResponse.java
@@ -50,7 +50,7 @@ public class ScannableItemResponse {
     public final DocumentType documentType;
 
     @JsonProperty("document_subtype")
-    public final DocumentSubtype documentSubtype;
+    public final String documentSubtype;
 
     @JsonCreator
     public ScannableItemResponse(
@@ -67,7 +67,7 @@ public class ScannableItemResponse {
         @JsonProperty("notes") String notes,
         @JsonProperty("document_url") String documentUrl,
         @JsonProperty("document_type") DocumentType documentType,
-        @JsonProperty("document_subtype") DocumentSubtype documentSubtype
+        @JsonProperty("document_subtype") String documentSubtype
     ) {
         this.documentControlNumber = documentControlNumber;
         this.scanningDate = scanningDate;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/ScannableItemResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/ScannableItemResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.ocr.OcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.util.InstantDeserializer;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 
 import java.time.Instant;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -19,7 +19,7 @@ public class Document {
     public final DocumentType type;
 
     @JsonProperty("subtype")
-    public final DocumentSubtype subtype;
+    public final String subtype;
 
     @JsonProperty("scanned_at")
     public final Instant scannedAt;
@@ -32,7 +32,7 @@ public class Document {
         String fileName,
         String controlNumber,
         DocumentType type,
-        DocumentSubtype subtype,
+        String subtype,
         Instant scannedAt,
         String url
     ) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
@@ -18,6 +18,9 @@ import java.time.Instant;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.getEnvelopeFromMetafile;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype.COVERSHEET;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype.SSCS1;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype.WILL;
 
 public class EnvelopeMapperTest {
 
@@ -114,7 +117,7 @@ public class EnvelopeMapperTest {
 
     private InputDocumentType convertToInputDocumentType(
         DocumentType documentType,
-        DocumentSubtype documentSubtype
+        String documentSubtype
     ) {
         switch (documentType) {
             case CHERISHED:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputNonScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputPayment;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputScannableItem;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 
 import java.time.Instant;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
@@ -46,10 +46,10 @@ public class SubtypeTest {
     private class TestCase {
         InputScannableItem input;
         DocumentType expectedDocType;
-        DocumentSubtype expectedDocSubtype;
+        String expectedDocSubtype;
 
         // region constructor
-        TestCase(InputScannableItem input, DocumentType expectedDocType, DocumentSubtype expectedDocSubtype) {
+        TestCase(InputScannableItem input, DocumentType expectedDocType, String expectedDocSubtype) {
             this.input = input;
             this.expectedDocType = expectedDocType;
             this.expectedDocSubtype = expectedDocSubtype;


### PR DESCRIPTION
A non-breaking change in preparation for https://tools.hmcts.net/jira/browse/BPS-585 (changes to doc types, arbitrary subtype sent as part of envelope metadata)

ℹ️ Note: both subtype and type are strings in orchestrator atm