### PR TITLE
Bugfix: mimemessage requires `from` value

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -32,16 +32,19 @@ public class ReportSender {
 
     private final JavaMailSender mailSender;
     private final ReportsService reportsService;
+    private final String from;
     private final String[] recipients;
 
     // region constructor
     public ReportSender(
         JavaMailSender mailSender,
         ReportsService reportsService,
+        @Value("${spring.mail.username}") String from,
         @Value("${reports.recipients}") String[] recipients
     ) {
         this.mailSender = mailSender;
         this.reportsService = reportsService;
+        this.from = from;
 
         if (recipients == null) {
             this.recipients = new String[0];
@@ -62,6 +65,7 @@ public class ReportSender {
             MimeMessage msg = mailSender.createMimeMessage();
 
             MimeMessageHelper helper = new MimeMessageHelper(msg, true);
+            helper.setFrom(from);
             helper.setTo(this.recipients);
             helper.setSubject(EMAIL_SUBJECT);
             helper.setText(EMAIL_BODY);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -46,6 +46,7 @@ public class ReportSenderTest {
         ReportSender reportSender = new ReportSender(
             getMailSender(),
             reportsService,
+            TEST_LOGIN,
             new String[] { reportRecipient1, reportRecipient2}
         );
 
@@ -83,7 +84,7 @@ public class ReportSenderTest {
             .given(mailSender)
             .send(any(MimeMessage.class));
 
-        ReportSender reportSender = new ReportSender(mailSender, reportsService, null);
+        ReportSender reportSender = new ReportSender(mailSender, reportsService, TEST_LOGIN, null);
 
         // when
         Throwable exc = catchThrowable(reportSender::send);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate sending reports via email](https://tools.hmcts.net/jira/browse/BPS-466)

### Change description ###

`MimeMessageHelper` requires `from` value set so that `JavaMailSender` can send an email. Otherwise it causes `com.sun.mail.smtp.SMTPSenderFailedException: 501 5.1.7 Invalid address`

**NB** emails like `username+test@hmcts.net` are not accepted by HMCTS organisation. This is reflected and fixed in key vault already

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
