### PR TITLE
Add `.csv` as file extension for report attachment

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -69,7 +69,7 @@ public class ReportSender {
             helper.setTo(this.recipients);
             helper.setSubject(EMAIL_SUBJECT);
             helper.setText(EMAIL_BODY);
-            helper.addAttachment(ATTACHMENT_PREFIX + LocalDate.now(), getCsvReport());
+            helper.addAttachment(ATTACHMENT_PREFIX + LocalDate.now() + ".csv", getCsvReport());
 
             mailSender.send(msg);
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -66,7 +66,7 @@ public class ReportSenderTest {
         assertThat(msg.getSubject()).isEqualTo(ReportSender.EMAIL_SUBJECT);
         assertThat(msg.getPlainContent()).isEqualTo(ReportSender.EMAIL_BODY);
         assertThat(msg.getAttachmentList()).hasSize(1);
-        assertThat(msg.getAttachmentList().get(0).getName()).isEqualTo(ReportSender.ATTACHMENT_PREFIX + now());
+        assertThat(msg.getAttachmentList().get(0).getName()).isEqualTo(ReportSender.ATTACHMENT_PREFIX + now() + ".csv");
 
         verify(reportsService).getZipFilesSummary(now(), null);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate sending reports via email](https://tools.hmcts.net/jira/browse/BPS-466)

### Change description ###

Email attachment is missing `.csv` file extension

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
