### PR TITLE
Introduce separate report specific class for daily summary

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/report/DailySummaryReportTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/report/DailySummaryReportTest.java
@@ -1,5 +1,6 @@
-package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks.report;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,8 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.email.ReportSender;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 
 import javax.mail.internet.MimeMessage;
 
@@ -15,17 +18,28 @@ import static org.mockito.Mockito.verify;
 
 @IntegrationTest
 @RunWith(SpringRunner.class)
-public class ReportSenderTest {
+public class DailySummaryReportTest {
 
     @Autowired
-    private ReportSender reportSender;
+    private ReportSender emailSender;
+
+    @Autowired
+    private ReportsService service;
 
     @SpyBean
     private JavaMailSender mailSender;
 
+    // will be autowired later
+    private DailySummaryReport summaryReport;
+
+    @Before
+    public void setUp() {
+        summaryReport = new DailySummaryReport(service, emailSender);
+    }
+
     @Test
     public void should_attempt_to_send_report_when_recipients_list_is_present() {
-        reportSender.send();
+        summaryReport.send();
 
         verify(mailSender).send(any(MimeMessage.class));
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -73,6 +73,7 @@ public class ReportSender {
 
             mailSender.send(msg);
 
+            log.info("Report '{}' sent to {} recipients", EMAIL_SUBJECT, recipients.length);
         } catch (Exception exc) {
             log.error("Error sending report", exc);
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/report/DailySummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/report/DailySummaryReport.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks.report;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.email.ReportSender;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+
+public class DailySummaryReport {
+
+    private static final Logger log = LoggerFactory.getLogger(DailySummaryReport.class);
+
+    // public static final String EMAIL_SUBJECT = "Bulk Scan daily report";
+    // public static final String ATTACHMENT_PREFIX = "bulk_scan_envelopes_";
+
+    private final ReportsService service;
+
+    private final ReportSender emailSender;
+
+    public DailySummaryReport(
+        ReportsService service,
+        ReportSender emailSender
+    ) {
+        this.service = service;
+        this.emailSender = emailSender;
+    }
+
+    public void send() {
+        try {
+            List<ZipFileSummaryResponse> reportDate = service.getZipFilesSummary(LocalDate.now(), null);
+
+            File report = CsvWriter.writeZipFilesSummaryToCsv(reportDate);
+
+            // will include subject, filename and report
+            // once schedule is moved here
+            emailSender.send();
+        } catch (IOException exc) {
+            log.error("Error generating daily summary report", exc);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/report/DailySummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/report/DailySummaryReportTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks.report;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.email.ReportSender;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
+
+import static java.time.LocalDate.now;
+import static java.util.Collections.emptyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DailySummaryReportTest {
+
+    @Mock
+    private ReportsService service;
+
+    @Mock
+    private ReportSender emailSender;
+
+    private DailySummaryReport summaryReport;
+
+    @Before
+    public void setUp() {
+        summaryReport = new DailySummaryReport(service, emailSender);
+    }
+
+    @Test
+    public void should_send_report_successfully() {
+        // given
+        given(service.getZipFilesSummary(now(), null)).willReturn(emptyList());
+
+        // when
+        summaryReport.send();
+
+        // then
+        verify(emailSender).send();
+    }
+}


### PR DESCRIPTION
### Change description ###

Preparing ground base for new email to be sent out. Most of `ReportSender` can be reused. Differences are:

- custom list of recipients
- attachment
- subject

For next PR will shift schedule to new class introduced in this PR and rename `ReportSender` to `EmailSender`. Other commented lines should be understandable.

- [x] Separate class specifically dedicated for daily summary report
- [ ] Usage of new report class

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
