### PR TITLE
Update incomplete envelopes task config

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -14,3 +14,5 @@ delete_rejected_files_cron = "0 0/10 * * * *"
 api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"
 allowed_client_certificate_thumbprints = ["4AF638E82FBD9959A5B8286C673360AC2C2E7053"]
 blob_signature_verification_key_file = "nonprod_public_key.der"
+
+incomplete_envelopes_cron = "0 0 * * * *"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesDisabledTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesDisabledTaskTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 
@@ -11,6 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
 @RunWith(SpringRunner.class)
+@TestPropertySource(properties = {
+    "monitoring.incomplete-envelopes.enabled=false"
+})
 public class IncompleteEnvelopesDisabledTaskTest {
 
     @Autowired

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,7 +57,7 @@ spring:
 monitoring:
   incomplete-envelopes:
     cron: ${INCOMPLETE_ENVELOPES_TASK_CRON:0 0 9 ? * MON-FRI} # can be discussed later
-    enabled: ${INCOMPLETE_ENVELOPES_TASK_ENABLED:false}
+    enabled: ${INCOMPLETE_ENVELOPES_TASK_ENABLED:true}
 
 reports:
   cron: ${REPORTS_CRON:0 0 18 ? * MON-FRI}


### PR DESCRIPTION
### Change description ###

There's problem applying config changes via our pipeline. As discussed - no harm to enable by default for the time being

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
