### PR TITLE
Update service-bus 1.2.8 -> 1.2.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,7 +196,7 @@ dependencies {
   compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '2.2.1'
 
   compile group: 'com.microsoft.azure', name: 'azure-storage', version: '8.3.0'
-  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.8', {
+  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.13', {
     exclude group: 'javax.mail', module: 'mail'
     exclude group: 'net.minidev', module: 'json-smart'
   }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
@@ -152,6 +152,7 @@ public class ProcessedEnvelopeNotificationHandler implements IMessageHandler {
         }
     }
 
+    @SuppressWarnings("squid:CallToDeprecatedMethod") // for sonarqube complaining about deprecated things being used
     private ProcessedEnvelope readProcessedEnvelope(IMessage message) throws IOException {
         try {
             return objectMapper.readValue(message.getBody(), ProcessedEnvelope.class);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
@@ -139,7 +139,11 @@ public class ProcessedEnvelopeNotificationHandler implements IMessageHandler {
             log.error("Invalid 'processed envelope' message with ID {}", message.getMessageId(), e);
             return new MessageProcessingResult(MessageProcessingResultType.UNRECOVERABLE_FAILURE, e);
         } catch (EnvelopeNotFoundException e) {
-            log.error("Failed to handle 'processed envelope' message with ID {} - envelope not found", e);
+            log.error(
+                "Failed to handle 'processed envelope' message with ID {} - envelope not found",
+                message.getMessageId(),
+                e
+            );
             return new MessageProcessingResult(MessageProcessingResultType.UNRECOVERABLE_FAILURE, e);
         } catch (Exception e) {
             log.error(


### PR DESCRIPTION
### Change description ###

There's a _breaking change_ predicted from version `1.2.9` introducing `MessageBody` which is backporting to `byte[]`. Since we use `byte[]` anyway this itself is a non-breaking change but introduces a requirement to look over it before upgrading to v2.

This bugfix jump introduces a lot of serious fixes:

[1.2.8 - 1.2.9](https://github.com/Azure/azure-service-bus-java/compare/1.2.8...1.2.9)
[1.2.9 - 1.2.10](https://github.com/Azure/azure-service-bus-java/compare/1.2.9...1.2.10)
[1.2.10 - 1.2.11](https://github.com/Azure/azure-service-bus-java/compare/1.2.10...1.2.11)
[1.2.11 - 1.2.12](https://github.com/Azure/azure-service-bus-java/compare/1.2.11...1.2.12)
[1.2.12 - 1.2.13](https://github.com/Azure/azure-service-bus-java/compare/1.2.12...1.2.13)

Bonus: fixing log message

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
