### PR TITLE
Migrate ServiceBus `(get|set)Body` functions to new methods

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -121,7 +121,9 @@ public class ServiceBusHelperTest {
         ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
         verify(queueClient).send(argument.capture());
 
-        JsonNode jsonNode = objectMapper.readTree(argument.getValue().getBody());
+        JsonNode jsonNode = objectMapper.readTree(
+            MessageBodyRetriever.getBinaryData(argument.getValue().getMessageBody())
+        );
 
         assertThat(jsonNode.get("case_ref").textValue()).isEqualTo(message.getCaseNumber());
         assertThat(jsonNode.get("previous_service_case_ref").textValue())

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/MessageBodyRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/MessageBodyRetriever.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus;
+
+import com.microsoft.azure.servicebus.MessageBody;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+
+public final class MessageBodyRetriever {
+
+    public static byte[] getBinaryData(MessageBody messageBody) {
+        List<byte[]> binaryData = messageBody.getBinaryData();
+
+        return CollectionUtils.isEmpty(binaryData) ? null : binaryData.get(0);
+    }
+
+    private MessageBodyRetriever() {
+        // utility class construct
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandler.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.MessageAutoCompletor;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.MessageBodyRetriever;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +57,8 @@ public class ErrorNotificationHandler implements IMessageHandler {
     @Override
     public CompletableFuture<Void> onMessageAsync(IMessage message) {
         return CompletableFuture
-            .supplyAsync(message::getBody, SIMPLE_EXEC)
+            .supplyAsync(message::getMessageBody, SIMPLE_EXEC)
+            .thenApplyAsync(MessageBodyRetriever::getBinaryData, SIMPLE_EXEC)
             .thenApplyAsync(this::getErrorMessage, SIMPLE_EXEC)
             .thenAcceptAsync(this::processMessage, SERVICE_EXEC)
             .handleAsync((voided, throwable) -> exceptionHandler.handle(message, throwable), ERROR_EXEC)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandler.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.in.msg.ProcessedEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeFinaliserService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.MessageAutoCompletor;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.MessageBodyRetriever;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -156,10 +157,12 @@ public class ProcessedEnvelopeNotificationHandler implements IMessageHandler {
         }
     }
 
-    @SuppressWarnings("squid:CallToDeprecatedMethod") // for sonarqube complaining about deprecated things being used
     private ProcessedEnvelope readProcessedEnvelope(IMessage message) throws IOException {
         try {
-            return objectMapper.readValue(message.getBody(), ProcessedEnvelope.class);
+            return objectMapper.readValue(
+                MessageBodyRetriever.getBinaryData(message.getMessageBody()),
+                ProcessedEnvelope.class
+            );
         } catch (JsonParseException | JsonMappingException e) {
             throw new InvalidMessageException("Failed to parse 'processed envelope' message", e);
         }


### PR DESCRIPTION
### Change description ###

Removing layer of deprecation and using same functionality as inside the ServiceBus library. No breaking change.

Next step - backport same library version jump in orchestrator. Until that happens - no version jump to 2.0.0 can happen

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
