### PR TITLE
Clean up yaml config for services accessing envelopes

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -178,12 +178,6 @@ envelope-access:
      - jurisdiction: BULKSCAN
        readService: bulk_scan_processor_tests
        updateService: bulk_scan_processor_tests
-     - jurisdiction: PROBATE
-       readService: TBD
-       updateService: TBD
-     - jurisdiction: DIVORCE
-       readService: TBD
-       updateService: TBD
 
 flyway:
   noop:


### PR DESCRIPTION
For some reason this config was also used for specifying jurisdiction for the retry job and empty entries were added.
This is no longer the case. Entries can be removed as those services do not read or update their envelopes.