### PR TITLE
Read and store 'previous_service_case_reference' field from envelope metadata

### DIFF
--- a/src/integrationTest/resources/zipcontents/ok/metadata.json
+++ b/src/integrationTest/resources/zipcontents/ok/metadata.json
@@ -1,5 +1,6 @@
 {
   "case_number": "1111222233334446",
+  "previous_service_case_reference": "12345678",
   "po_box": "BULKSCANPO",
   "jurisdiction": "BULKSCAN",
   "delivery_date": "2018-06-23T00:00:00.000Z",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
@@ -62,6 +62,8 @@ public class Envelope {
 
     private boolean zipDeleted = false;
 
+    private String previousServiceCaseReference;
+
     //We will need to retrieve all scannable item entities of Envelope every time hence fetch type is Eager
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, mappedBy = "envelope")
     @Fetch(FetchMode.SUBSELECT)
@@ -90,6 +92,7 @@ public class Envelope {
         Instant zipFileCreateddate,
         String zipFileName,
         String caseNumber,
+        String previousServiceCaseReference,
         Classification classification,
         List<ScannableItem> scannableItems,
         List<Payment> payments,
@@ -103,6 +106,7 @@ public class Envelope {
         this.zipFileCreateddate = zipFileCreateddate;
         this.zipFileName = zipFileName;
         this.caseNumber = caseNumber;
+        this.previousServiceCaseReference = previousServiceCaseReference;
         this.classification = classification;
         this.scannableItems = scannableItems;
         this.payments = payments;
@@ -136,6 +140,10 @@ public class Envelope {
 
     public String getCaseNumber() {
         return caseNumber;
+    }
+
+    public String getPreviousServiceCaseReference() {
+        return previousServiceCaseReference;
     }
 
     public void setContainer(String container) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/blob/InputEnvelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/blob/InputEnvelope.java
@@ -14,6 +14,7 @@ import static java.util.Collections.emptyList;
 public class InputEnvelope {
 
     public final String caseNumber;
+    public final String previousServiceCaseReference;
     public final String poBox;
     public final String jurisdiction;
     public final Instant deliveryDate;
@@ -37,6 +38,7 @@ public class InputEnvelope {
         @JsonProperty("zip_file_createddate") Instant zipFileCreateddate,
         @JsonProperty("zip_file_name") String zipFileName,
         @JsonProperty("case_number") String caseNumber,
+        @JsonProperty("previous_service_case_reference") String previousServiceCaseReference,
         @JsonProperty("envelope_classification") Classification classification,
         @JsonProperty("scannable_items") List<InputScannableItem> scannableItems,
         @JsonProperty("payments") List<InputPayment> payments,
@@ -49,6 +51,7 @@ public class InputEnvelope {
         this.zipFileCreateddate = zipFileCreateddate;
         this.zipFileName = zipFileName;
         this.caseNumber = caseNumber;
+        this.previousServiceCaseReference = previousServiceCaseReference;
         this.classification = classification;
         this.scannableItems = scannableItems == null ? emptyList() : scannableItems;
         this.payments = payments == null ? emptyList() : payments;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
@@ -42,6 +42,7 @@ public class EnvelopeMapper {
             envelope.zipFileCreateddate,
             envelope.zipFileName,
             envelope.caseNumber,
+            envelope.previousServiceCaseReference,
             envelope.classification,
             toDbScannableItems(envelope.scannableItems),
             toDbPayments(envelope.payments),

--- a/src/main/resources/db/migration/V039__Add_previous_service_case_reference.sql
+++ b/src/main/resources/db/migration/V039__Add_previous_service_case_reference.sql
@@ -1,0 +1,2 @@
+ALTER TABLE envelopes
+ADD COLUMN previousServiceCaseReference VARCHAR(100) NULL;

--- a/src/main/resources/metafile-schema.json
+++ b/src/main/resources/metafile-schema.json
@@ -9,6 +9,11 @@
       "type": ["string", "null"],
       "title": "Case reference number to which the envelope belongs to"
     },
+    "previous_service_case_reference": {
+      "id": "#/properties/previous_service_case_reference",
+      "type": ["string", "null"],
+      "title": "The reference number assigned by the service the case was created in"
+    },
     "po_box": {
       "id": "#/properties/po_box",
       "type": "string",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -106,6 +106,7 @@ public final class EnvelopeCreator {
             timestamp,
             zipFileName,
             "1111222233334446",
+            "123654789",
             Classification.EXCEPTION,
             scannableItems,
             payments(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/InputEnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/InputEnvelopeCreator.java
@@ -38,6 +38,7 @@ public final class InputEnvelopeCreator {
             null,
             "file.zip",
             "case_number",
+            "previous_service_case_ref",
             classification,
             scannableItems,
             emptyList(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
@@ -34,6 +34,7 @@ public class EnvelopeMapperTest {
         );
 
         assertThat(dbEnvelope.getCaseNumber()).isEqualTo(zipEnvelope.caseNumber);
+        assertThat(dbEnvelope.getPreviousServiceCaseReference()).isEqualTo(zipEnvelope.previousServiceCaseReference);
         assertThat(dbEnvelope.getPoBox()).isEqualTo(zipEnvelope.poBox);
         assertThat(dbEnvelope.getJurisdiction()).isEqualTo(zipEnvelope.jurisdiction);
         assertThat(dbEnvelope.getDeliveryDate()).isEqualTo(zipEnvelope.deliveryDate);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTest.java
@@ -54,10 +54,17 @@ public class MetafileJsonValidatorTest {
     }
 
     @Test
+    public void should_parse_envelope_data_with_no_previous_service_case_reference() throws IOException {
+        InputEnvelope envelope = getEnvelope("/metafiles/valid/no-previous-service-case-reference.json");
+        assertThat(envelope.previousServiceCaseReference).isNull();
+    }
+
+    @Test
     public void should_parse_envelope_data_with_null_values_for_non_mandatory_fields() throws IOException {
         InputEnvelope envelope = getEnvelope("/metafiles/valid/fields-with-null-values-non-mandatory.json");
 
         assertThat(envelope.caseNumber).isNull();
+        assertThat(envelope.previousServiceCaseReference).isNull();
         assertThat(envelope.nonScannableItems).hasSize(1);
         assertThat(envelope.scannableItems).hasSize(2);
         assertThat(envelope.payments).hasSize(1);

--- a/src/test/resources/metafiles/valid/fields-with-null-values-non-mandatory.json
+++ b/src/test/resources/metafiles/valid/fields-with-null-values-non-mandatory.json
@@ -1,5 +1,6 @@
 {
   "case_number": null,
+  "previous_service_case_reference": null,
   "po_box": "XXXX",
   "jurisdiction": "SSCS",
   "delivery_date": "2017-02-23T00:00:00.100Z",

--- a/src/test/resources/metafiles/valid/from-spec.json
+++ b/src/test/resources/metafiles/valid/from-spec.json
@@ -1,5 +1,6 @@
 {
   "case_number": "1111222233334446",
+  "previous_service_case_reference": "12345678",
   "po_box": "XXXX",
   "jurisdiction": "SSCS",
   "delivery_date": "2017-02-23T22:00:00.100Z",

--- a/src/test/resources/metafiles/valid/no-previous-service-case-reference.json
+++ b/src/test/resources/metafiles/valid/no-previous-service-case-reference.json
@@ -1,0 +1,22 @@
+{
+  "case_number": "1111222233334446",
+  "po_box": "XXXX",
+  "jurisdiction": "SSCS",
+  "delivery_date": "2017-02-23T22:00:00.100Z",
+  "opening_date": "2017-03-31T00:00:00.010Z",
+  "zip_file_createddate": "2017-02-24T00:00:00.001Z",
+  "zip_file_name": "1_24-02-2017-00-00-00.zip",
+  "envelope_classification": "new_application",
+  "scannable_items": [
+    {
+      "document_control_number": "1111002",
+      "scanning_date": "2017-02-24T00:00:00.000Z",
+      "manual_intervention": "string",
+      "next_action": "forward",
+      "next_action_date": "2017-02-25T00:00:00.000Z",
+      "file_name": "1111002.pdf",
+      "notes": "Cheque will be forwarded to court to bank it",
+      "document_type": "Other"
+    }
+  ]
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-583

### Change description ###

Read and store 'previous_service_case_reference' field from envelope metadata.

Including it in queue message will be done in another PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
