### PR TITLE
Clean up reports package structure

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -13,9 +13,9 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.EnvelopeCountSumm
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.EnvelopeCountSummaryReportListResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportListResponse;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.EnvelopeCountSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
 
 import java.io.File;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSender.java
@@ -10,7 +10,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
 
 import java.io.File;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
@@ -5,6 +5,9 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummary
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFileSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.utils.ZeroRowFiller;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/EnvelopeCountSummary.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/EnvelopeCountSummary.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models;
 
 import java.time.LocalDate;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileSummaryResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileSummaryResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/utils/ZeroRowFiller.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/utils/ZeroRowFiller.java
@@ -1,9 +1,10 @@
-package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports.utils;
 
 import com.google.common.collect.Sets;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.util;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -10,9 +10,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.ReportsController;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.EnvelopeCountSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -9,6 +9,9 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummary
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.zipfilesummary.ZipFileSummaryItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.utils.ZeroRowFiller;
 
 import java.time.Instant;
 import java.time.LocalTime;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.utils.ZeroRowFiller;
 
 import java.util.List;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.util;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.Test;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ZipFileSummaryResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
 import java.io.File;
 import java.io.FileReader;


### PR DESCRIPTION
... as a preparation for adding new report and its' models (rejected envelopes)

Before:
<img width="225" alt="Screenshot 2019-05-15 at 11 16 33" src="https://user-images.githubusercontent.com/2472141/57768164-f5439e00-7702-11e9-9a0a-732f604066c8.png">

After:
<img width="225" alt="Screenshot 2019-05-15 at 11 16 13" src="https://user-images.githubusercontent.com/2472141/57768179-fd9bd900-7702-11e9-9c4c-d266a0eae591.png">

No other changes in this PR.