### PR TITLE
BPS-641 Migration script to add documentUuid column

### DIFF
--- a/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
+++ b/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
@@ -1,9 +1,3 @@
 ALTER TABLE scannable_items
   ADD COLUMN documentUuid VARCHAR(100) NULL;
 
--- Extract the text after the last slash (/) in the documentUrl
-UPDATE scannable_items
-   SET documentUuid = (
-     SELECT documentId[1]
-     FROM
-     REGEXP_MATCHES(documentUrl, '([^/]+)(?=[^/]*/?$)', 'g') AS documentId);

--- a/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
+++ b/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
@@ -6,7 +6,7 @@ UPDATE scannable_items
      SELECT documentId[1] FROM
         REGEXP_MATCHES(
         documenturl,
-        '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}',
+        '([^/]+)(?=[^/]*/?$)',
         'g'
         ) AS documentId
      );

--- a/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
+++ b/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
@@ -1,12 +1,9 @@
 ALTER TABLE scannable_items
   ADD COLUMN documentUuid VARCHAR(100) NULL;
 
+-- Extract the text after the last slash (/) in the documentUrl
 UPDATE scannable_items
    SET documentUuid = (
-     SELECT documentId[1] FROM
-        REGEXP_MATCHES(
-        documenturl,
-        '([^/]+)(?=[^/]*/?$)',
-        'g'
-        ) AS documentId
-     );
+     SELECT documentId[1]
+     FROM
+     REGEXP_MATCHES(documentUrl, '([^/]+)(?=[^/]*/?$)', 'g') AS documentId);

--- a/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
+++ b/src/main/resources/db/migration/V040__Add_document_uuid_to_scannable_items.sql
@@ -1,0 +1,12 @@
+ALTER TABLE scannable_items
+  ADD COLUMN documentUuid VARCHAR(100) NULL;
+
+UPDATE scannable_items
+   SET documentUuid = (
+     SELECT documentId[1] FROM
+        REGEXP_MATCHES(
+        documenturl,
+        '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}',
+        'g'
+        ) AS documentId
+     );


### PR DESCRIPTION
…s and set the value from documentUrl column
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-641


### Change description ###
DB Migration script to add documentUuid column to scannable items table.
~Update script to set documentUuid value from the documentUrl for the existing data.~


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
**Update:** 
Setting documentUuid value for the existing records will be added in a new PR.