### PR TITLE
Add 'reason' field to envelope events model in reports

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEvent.java
@@ -18,11 +18,15 @@ public class ZipFileEvent {
     @JsonSerialize(using = InstantSerializer.class)
     public final Instant createdAt;
 
+    @JsonProperty("reason")
+    public final String reason;
+
     // region constructor
-    public ZipFileEvent(String eventType, String container, Instant createdAt) {
+    public ZipFileEvent(String eventType, String container, Instant createdAt, String reason) {
         this.eventType = eventType;
         this.container = container;
         this.createdAt = createdAt;
+        this.reason = reason;
     }
     // endregion
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusService.java
@@ -51,7 +51,8 @@ public class ZipFileStatusService {
         return new ZipFileEvent(
             event.getEvent().name(),
             event.getContainer(),
-            event.getCreatedAt()
+            event.getCreatedAt(),
+            event.getReason()
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ZipStatusControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ZipStatusControllerTest.java
@@ -46,8 +46,8 @@ public class ZipStatusControllerTest {
         );
 
         List<ZipFileEvent> events = asList(
-            new ZipFileEvent("type0", "container0", now().minusSeconds(10)),
-            new ZipFileEvent("type1", "container1", now().minusSeconds(15))
+            new ZipFileEvent("type0", "container0", now().minusSeconds(10), "reason0"),
+            new ZipFileEvent("type1", "container1", now().minusSeconds(15), "reason1")
         );
 
         given(service.getStatusFor("hello.zip")).willReturn(new ZipFileStatus("hello.zip", envelopes, events));
@@ -68,10 +68,11 @@ public class ZipStatusControllerTest {
             .andExpect(jsonPath("$.events[0].type").value(events.get(0).eventType))
             .andExpect(jsonPath("$.events[0].container").value(events.get(0).container))
             .andExpect(jsonPath("$.events[0].created_at").value(toIso(events.get(0).createdAt)))
+            .andExpect(jsonPath("$.events[0].reason").value(events.get(0).reason))
             .andExpect(jsonPath("$.events[1].type").value(events.get(1).eventType))
             .andExpect(jsonPath("$.events[1].container").value(events.get(1).container))
-            .andExpect(jsonPath("$.events[1].created_at").value(toIso(events.get(1).createdAt)));
-
+            .andExpect(jsonPath("$.events[1].created_at").value(toIso(events.get(1).createdAt)))
+            .andExpect(jsonPath("$.events[1].reason").value(events.get(1).reason));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
@@ -43,9 +43,9 @@ public class ZipFileStatusServiceTest {
     public void should_return_envelopes_and_events_from_db() {
         // given
         List<ProcessEvent> events = asList(
-            event(Event.DOC_UPLOADED, "A", now()),
-            event(Event.DOC_PROCESSED, "A", now().minusSeconds(1)),
-            event(Event.DOC_FAILURE, "B", now().minusSeconds(2))
+            event(Event.DOC_UPLOADED, "A", now(), null),
+            event(Event.DOC_PROCESSED, "A", now().minusSeconds(1), "reason1"),
+            event(Event.DOC_FAILURE, "B", now().minusSeconds(2), "reason2")
         );
 
         List<Envelope> envelopes = asList(
@@ -83,17 +83,20 @@ public class ZipFileStatusServiceTest {
                 new ZipFileEvent(
                     events.get(0).getEvent().name(),
                     events.get(0).getContainer(),
-                    events.get(0).getCreatedAt()
+                    events.get(0).getCreatedAt(),
+                    events.get(0).getReason()
                 ),
                 new ZipFileEvent(
                     events.get(1).getEvent().name(),
                     events.get(1).getContainer(),
-                    events.get(1).getCreatedAt()
+                    events.get(1).getCreatedAt(),
+                    events.get(1).getReason()
                 ),
                 new ZipFileEvent(
                     events.get(2).getEvent().name(),
                     events.get(2).getContainer(),
-                    events.get(2).getCreatedAt()
+                    events.get(2).getCreatedAt(),
+                    events.get(2).getReason()
                 )
             );
     }
@@ -121,11 +124,12 @@ public class ZipFileStatusServiceTest {
         return envelope;
     }
 
-    private ProcessEvent event(Event eventType, String container, Instant createdAt) {
+    private ProcessEvent event(Event eventType, String container, Instant createdAt, String reason) {
         ProcessEvent event = mock(ProcessEvent.class);
         given(event.getEvent()).willReturn(eventType);
         given(event.getContainer()).willReturn(container);
         given(event.getCreatedAt()).willReturn(createdAt);
+        given(event.getReason()).willReturn(reason);
         return event;
     }
 }


### PR DESCRIPTION
May come in handy when something when wrong (which is mostly when we use the endpoint to check the history of given file ;))