### PR TITLE
Remove unused check on who can update envelope

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessService.java
@@ -2,8 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 
 import java.util.Objects;
@@ -15,30 +13,6 @@ public class EnvelopeAccessService {
 
     public EnvelopeAccessService(EnvelopeAccessProperties accessProps) {
         this.access = accessProps;
-    }
-
-    /**
-     * Checks whether envelope from given jurisdiction can be updated by given service.
-     * Throws an exception if service is not allowed to make an update
-     * or configuration for the jurisdiction is not found.
-     */
-    public void assertCanUpdate(String envelopeJurisdiction, String serviceName) {
-        String serviceThanCanUpdateEnvelope =
-            access
-                .getMappings()
-                .stream()
-                .filter(m -> Objects.equals(m.getJurisdiction(), envelopeJurisdiction))
-                .findFirst()
-                .map(m -> m.getUpdateService())
-                .orElseThrow(() -> new ServiceConfigNotFoundException(
-                    "No service configuration found to update envelopes in jurisdiction: " + envelopeJurisdiction
-                ));
-
-        if (!serviceThanCanUpdateEnvelope.equals(serviceName)) {
-            throw new ForbiddenException(
-                "Service " + serviceName + " cannot update envelopes in jurisdiction " + envelopeJurisdiction
-            );
-        }
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
@@ -8,13 +8,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("checkstyle:LineLength")
@@ -36,31 +33,6 @@ public class EnvelopeAccessServiceTest {
                 new Mapping("jur_A", "read_A", "update_A"),
                 new Mapping("jur_B", "read_B", "update_B")
             ));
-    }
-
-    @Test
-    public void assertCanUpdate_should_throw_an_exception_if_service_is_not_allowed_to_update_in_given_jurisdiction() {
-
-        assertThatThrownBy(() -> service.assertCanUpdate("jur_A", "update_B"))
-            .isNotNull()
-            .isInstanceOf(ForbiddenException.class)
-            .hasMessageContaining("jur_A")
-            .hasMessageContaining("update_B");
-    }
-
-    @Test
-    public void assertCanUpdate_should_throw_an_exception_if_there_is_not_configuration_for_given_jurisdiction() {
-
-        assertThatThrownBy(() -> service.assertCanUpdate("nonExistingJurisdiction", "update_A"))
-            .isNotNull()
-            .isInstanceOf(ServiceConfigNotFoundException.class)
-            .hasMessageContaining("nonExistingJurisdiction");
-    }
-
-    @Test
-    public void assertCanUpdate_should_not_throw_an_exception_if_service_can_update_envelopes_in_given_jurisdiction() {
-        assertThatCode(() -> service.assertCanUpdate("jur_A", "update_A"))
-            .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
The endpoint for updating envelope status has been removed recently I think, but there are some leftovers.

https://tools.hmcts.net/jira/browse/BPS-513