### PR TITLE
DB migration script to make documentUuid field not null

### DIFF
--- a/src/main/resources/db/migration/V042__Make_document_uuid_not_null.sql
+++ b/src/main/resources/db/migration/V042__Make_document_uuid_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scannable_items
+  ALTER COLUMN documentUuid SET NOT NULL;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-641


### Change description ###
Added migration script to make the documentUuid field not null.
Note: `documentUrl` field is Nullable so there is no script to drop the `not null` constraint (As mentioned in the ticket)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
