### PR TITLE
BPS-641 Remove document url usages in processor

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -36,7 +36,6 @@ public class BlobProcessorTest extends BaseFunctionalTest {
 
         assertThat(ImmutableList.of(Status.NOTIFICATION_SENT, Status.COMPLETED)).contains(envelope.getStatus());
         assertThat(envelope.getScannableItems()).hasSize(2);
-        assertThat(envelope.getScannableItems()).noneMatch(item -> Strings.isNullOrEmpty(item.documentUrl));
         assertThat(envelope.getScannableItems()).noneMatch(item -> Strings.isNullOrEmpty(item.documentUuid));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItemTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItemTest.java
@@ -33,7 +33,7 @@ public class ScannableItemTest {
     }
 
     @Test
-    public void should_update_document_url_of_scannable_item() throws IOException {
+    public void should_update_document_uuid_of_scannable_item() throws IOException {
         // given
         Envelope envelope = EnvelopeCreator.envelope();
         envelope.setContainer("container");
@@ -43,7 +43,7 @@ public class ScannableItemTest {
 
         // when
         scannableItemRepository.saveAll(items.stream()
-            .peek(item -> item.setDocumentUrl("localhost/document/" + item.getId()))
+            .peek(item -> item.setDocumentUuid(item.getId().toString()))
             .collect(Collectors.toList())
         );
 
@@ -56,7 +56,7 @@ public class ScannableItemTest {
 
         // and
         dbItems.forEach(item ->
-            assertThat(item.getDocumentUrl()).isEqualTo("localhost/document/" + item.getId())
+            assertThat(item.getDocumentUuid()).isEqualTo(item.getId().toString())
         );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
@@ -152,7 +152,7 @@ public class EnvelopeFinaliserServiceTest {
                 null
             );
 
-            scannableItem.setDocumentUrl("http://localhost:8080/documents/0fa1ab60-f836-43aa-8c65-b07cc9bebceb");
+            scannableItem.setDocumentUuid("0fa1ab60-f836-43aa-8c65-b07cc9bebceb");
             return scannableItem;
         })
             .limit(count)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -169,7 +169,6 @@ public class ServiceBusHelperTest {
         when(envelope.getOpeningDate()).thenReturn(Instant.now());
         when(envelope.getScannableItems()).thenReturn(Arrays.asList(scannableItem1, scannableItem2));
 
-        when(scannableItem1.getDocumentUrl()).thenReturn("documentUrl1");
         when(scannableItem1.getDocumentUuid()).thenReturn("documentUuid1");
         when(scannableItem1.getDocumentControlNumber()).thenReturn("doc1_control_number");
         when(scannableItem1.getFileName()).thenReturn("doc1_file_name");
@@ -182,7 +181,6 @@ public class ServiceBusHelperTest {
 
         when(scannableItem1.getOcrData()).thenReturn(ocrData);
 
-        when(scannableItem2.getDocumentUrl()).thenReturn("documentUrl2");
         when(scannableItem2.getDocumentUuid()).thenReturn("documentUuid2");
         when(scannableItem2.getDocumentControlNumber()).thenReturn("doc2_control_number");
         when(scannableItem2.getFileName()).thenReturn("doc2_file_name");
@@ -196,7 +194,6 @@ public class ServiceBusHelperTest {
         assertThat(jsonNode.get("file_name").asText()).isEqualTo(scannableItem.getFileName());
         assertThat(jsonNode.get("control_number").asText()).isEqualTo(scannableItem.getDocumentControlNumber());
         assertThat(jsonNode.get("type").asText()).isEqualTo(scannableItem.getDocumentType().toString());
-        assertThat(jsonNode.get("url").asText()).isEqualTo(scannableItem.getDocumentUrl());
         assertThat(jsonNode.get("uuid").asText()).isEqualTo(scannableItem.getDocumentUuid());
         assertDateField(jsonNode, "scanned_at", scannableItem.getScanningDate());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocumentUrlNotRetrievedException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnableToUploadDocumentException;
@@ -96,13 +97,10 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
             "id", "amount", "amount_in_pence", "configuration", "json"
         );
         assertThat(actualEnvelope.getStatus()).isEqualTo(PROCESSED);
-        assertThat(actualEnvelope.getScannableItems())
-            .extracting(item -> item.getDocumentUrl())
-            .hasSameElementsAs(ImmutableList.of(DOCUMENT_URL2));
 
         assertThat(actualEnvelope.getScannableItems())
-            .extracting(item -> item.getDocumentUuid())
-            .hasSameElementsAs(ImmutableList.of("0fa1ab60-f836-43aa-8c65-b07cc9bebcbe"));
+            .extracting(ScannableItem::getDocumentUuid)
+            .hasSameElementsAs(ImmutableList.of(DOCUMENT_UUID2));
         assertThat(actualEnvelope.isZipDeleted()).isTrue();
 
         // This verifies pdf file objects were created from the zip file

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -58,7 +58,6 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         Envelope actualEnvelope = getSingleEnvelopeFromDb();
 
         assertThat(actualEnvelope.getStatus()).isEqualTo(UPLOAD_FAILURE);
-        assertThat(actualEnvelope.getScannableItems()).allMatch(item -> item.getDocumentUrl() == null);
         assertThat(actualEnvelope.getScannableItems()).allMatch(item -> item.getDocumentUuid() == null);
 
         // and
@@ -87,7 +86,6 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         Envelope actualEnvelope = getSingleEnvelopeFromDb();
 
         assertThat(actualEnvelope.getStatus()).isEqualTo(UPLOAD_FAILURE);
-        assertThat(actualEnvelope.getScannableItems()).allMatch(item -> ObjectUtils.isEmpty(item.getDocumentUrl()));
         assertThat(actualEnvelope.getScannableItems()).allMatch(item -> ObjectUtils.isEmpty(item.getDocumentUuid()));
 
         // and
@@ -110,7 +108,6 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
         Envelope actualEnvelope = envelopeRepository.findAll().get(0);
 
         assertThat(actualEnvelope.getStatus()).isEqualTo(UPLOAD_FAILURE);
-        assertThat(actualEnvelope.getScannableItems()).allMatch(e -> ObjectUtils.isEmpty(e.getDocumentUrl()));
         assertThat(actualEnvelope.getScannableItems()).allMatch(e -> ObjectUtils.isEmpty(e.getDocumentUuid()));
 
         // and

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -80,9 +80,6 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
             .extracting(envelope -> envelope.getStatus())
             .containsOnlyOnce(PROCESSED);
         assertThat(dbEnvelopes.get(0).getScannableItems())
-            .extracting(item -> item.getDocumentUrl())
-            .hasSameElementsAs(ImmutableList.of(DOCUMENT_URL2));
-        assertThat(dbEnvelopes.get(0).getScannableItems())
             .extracting(ScannableItem::getDocumentUuid)
             .hasSameElementsAs(ImmutableList.of(DOCUMENT_UUID2));
 

--- a/src/integrationTest/resources/envelope.json
+++ b/src/integrationTest/resources/envelope.json
@@ -19,7 +19,7 @@
           "ocr_data": {"Metadata_file":[{"metadata_field_name": "name1", "metadata_field_value": "value1"}]},
           "file_name": "1111002.pdf",
           "notes": "test",
-          "document_url": "http://localhost:8080/documents/0fa1ab60-f836-43aa-8c65-b07cc9bebcbe",
+          "document_uuid": "0fa1ab60-f836-43aa-8c65-b07cc9bebcbe",
           "document_type": "other"
         }
       ],

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
@@ -48,8 +48,6 @@ public class ScannableItem implements EnvelopeAssignable {
 
     private String notes;
 
-    private String documentUrl;
-
     private String documentUuid;
 
     @Enumerated(EnumType.STRING)
@@ -97,14 +95,6 @@ public class ScannableItem implements EnvelopeAssignable {
 
     public String getFileName() {
         return fileName;
-    }
-
-    public String getDocumentUrl() {
-        return documentUrl;
-    }
-
-    public void setDocumentUrl(String documentUrl) {
-        this.documentUrl = documentUrl;
     }
 
     public String getDocumentControlNumber() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeResponseMapper.java
@@ -75,7 +75,6 @@ public final class EnvelopeResponseMapper {
             scannableItem.getOcrData(),
             scannableItem.getFileName(),
             scannableItem.getNotes(),
-            scannableItem.getDocumentUrl(),
             scannableItem.getDocumentUuid(),
             scannableItem.getDocumentType(),
             scannableItem.getDocumentSubtype()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/ScannableItemResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/ScannableItemResponse.java
@@ -42,9 +42,6 @@ public class ScannableItemResponse {
     @JsonProperty("notes")
     public final String notes;
 
-    @JsonProperty("document_url")
-    public final String documentUrl;
-
     @JsonProperty("document_uuid")
     public final String documentUuid;
 
@@ -67,7 +64,6 @@ public class ScannableItemResponse {
         @JsonProperty("ocr_data") OcrData ocrData,
         @JsonProperty("file_name") String fileName,
         @JsonProperty("notes") String notes,
-        @JsonProperty("document_url") String documentUrl,
         @JsonProperty("document_uuid") String documentUuid,
         @JsonProperty("document_type") DocumentType documentType,
         @JsonProperty("document_subtype") String documentSubtype
@@ -81,7 +77,6 @@ public class ScannableItemResponse {
         this.ocrData = ocrData;
         this.fileName = fileName;
         this.notes = notes;
-        this.documentUrl = documentUrl;
         this.documentUuid = documentUuid;
         this.documentType = documentType;
         this.documentSubtype = documentSubtype;
@@ -98,7 +93,6 @@ public class ScannableItemResponse {
             + ", nextActionDate=" + nextActionDate
             + ", fileName='" + fileName + '\''
             + ", notes='" + notes + '\''
-            + ", documentUrl='" + documentUrl + '\''
             + ", documentUuid='" + documentUuid + '\''
             + ", documentType='" + documentType + '\''
             + ", documentSubtype='" + documentSubtype + '\''

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -23,9 +23,6 @@ public class Document {
     @JsonProperty("scanned_at")
     public final Instant scannedAt;
 
-    @JsonProperty("url")
-    public final String url;
-
     @JsonProperty("uuid")
     public final String uuid;
 
@@ -36,7 +33,6 @@ public class Document {
         DocumentType type,
         String subtype,
         Instant scannedAt,
-        String url,
         String uuid
     ) {
         this.fileName = fileName;
@@ -44,7 +40,6 @@ public class Document {
         this.type = type;
         this.subtype = subtype;
         this.scannedAt = scannedAt;
-        this.url = url;
         this.uuid = uuid;
     }
     // endregion
@@ -56,7 +51,6 @@ public class Document {
             item.getDocumentType(),
             item.getDocumentSubtype(),
             item.getScanningDate(),
-            item.getDocumentUrl(),
             item.getDocumentUuid()
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/DocumentProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/DocumentProcessor.java
@@ -45,10 +45,7 @@ public class DocumentProcessor {
             );
 
         if (filesWithoutUrl.isEmpty()) {
-            scannedItems.forEach(item -> {
-                item.setDocumentUrl(response.get(item.getFileName()));
-                item.setDocumentUuid(extractDocumentUuid(response.get(item.getFileName())));
-            });
+            scannedItems.forEach(item -> item.setDocumentUuid(extractDocumentUuid(response.get(item.getFileName()))));
             scannableItemRepository.saveAll(scannedItems);
         } else {
             throw new DocumentUrlNotRetrievedException(filesWithoutUrl);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -154,7 +154,6 @@ public final class EnvelopeCreator {
             DocumentType.CHERISHED,
             null
         );
-        scannableItem1.setDocumentUrl("http://localhost:8080/documents/0fa1ab60-f836-43aa-8c65-b07cc9bebceb");
         scannableItem1.setDocumentUuid("0fa1ab60-f836-43aa-8c65-b07cc9bebceb");
 
         ScannableItem scannableItem2 = new ScannableItem(
@@ -170,7 +169,6 @@ public final class EnvelopeCreator {
             DocumentType.OTHER,
             DocumentSubtype.SSCS1
         );
-        scannableItem2.setDocumentUrl("http://localhost:8080/documents/0fa1ab60-f836-43aa-8c65-b07cc9bebcbe");
         scannableItem2.setDocumentUuid("0fa1ab60-f836-43aa-8c65-b07cc9bebcbe");
 
         return ImmutableList.of(scannableItem1, scannableItem2);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -27,7 +27,7 @@ public class DocumentTest {
         assertThat(document.scannedAt).isEqualTo(scannableItem.getScanningDate());
         assertThat(document.subtype).isEqualTo(scannableItem.getDocumentSubtype());
         assertThat(document.type).isEqualTo(scannableItem.getDocumentType());
-        assertThat(document.url).isEqualTo(scannableItem.getDocumentUrl());
+        assertThat(document.uuid).isEqualTo(scannableItem.getDocumentUuid());
     }
 
     private ScannableItem scannableItem(DocumentType documentType) {
@@ -49,7 +49,7 @@ public class DocumentTest {
             DocumentSubtype.SSCS1
         );
 
-        scannableItem.setDocumentUrl("http://document-url.example.com");
+        scannableItem.setDocumentUuid("5fef5f98-e875-4084-b115-47188bc9066b");
         return scannableItem;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/tasks/processor/DocumentProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/tasks/processor/DocumentProcessorTest.java
@@ -49,7 +49,7 @@ public class DocumentProcessorTest {
     }
 
     @Test
-    public void should_update_document_url_when_doc_response_conntains_matching_file_name_and_doc_url()
+    public void should_update_document_uuid_when_doc_response_conntains_matching_file_name_and_doc_url()
         throws Exception {
         //Given
         byte[] test1PdfBytes = toByteArray(getResource("test1.pdf"));
@@ -67,8 +67,7 @@ public class DocumentProcessorTest {
 
         //then
 
-        //Document url should be set by the processor
-        scannableItem.setDocumentUrl("http://localhost/documents/5fef5f98-e875-4084-b115-47188bc9066b");
+        //Document uuid should be set by the processor
         scannableItem.setDocumentUuid("5fef5f98-e875-4084-b115-47188bc9066b");
 
         //Verify scanned item was saved with doc url updated
@@ -90,8 +89,8 @@ public class DocumentProcessorTest {
         // 'c' is missing
         given(documentManagementService.uploadDocuments(any()))
             .willReturn(ImmutableMap.of(
-                "a.pdf", "http://localhost/documents/a",
-                "b.pdf", "http://localhost/documents/b"
+                "a.pdf", "http://localhost/documents/uuida",
+                "b.pdf", "http://localhost/documents/uuidb"
             ));
 
         // when

--- a/src/test/resources/envelope.json
+++ b/src/test/resources/envelope.json
@@ -17,7 +17,7 @@
           "next_action_date": "2018-06-23T12:34:56.123Z",
           "file_name": "1111001.pdf",
           "notes": "test",
-          "document_url": "http://localhost:8080/documents/0fa1ab60-f836-43aa-8c65-b07cc9bebceb",
+          "document_uuid": "0fa1ab60-f836-43aa-8c65-b07cc9bebceb",
           "document_type": "cherished"
         },
         {
@@ -30,7 +30,7 @@
           "ocr_data": {"Metadata_file":[{"metadata_field_name": "name1", "metadata_field_value": "value1"}]},
           "file_name": "1111002.pdf",
           "notes": "test",
-          "document_url": "http://localhost:8080/documents/0fa1ab60-f836-43aa-8c65-b07cc9bebcbe",
+          "document_uuid": "0fa1ab60-f836-43aa-8c65-b07cc9bebcbe",
           "document_type": "other"
         }
       ],


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-641

### Change description ###
Removed `documentUrl` field from `ScannableItems` model and servicebus model.
Removed `documentUrl` from `ScannableItemsResponse` which is used in `\envelopes` endpoint.
Removed references to `documentUrl` field.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
