### PR TITLE
Re-process stuck envelopes

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -74,9 +74,11 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
             envelopeRepository
                 .findAll()
                 .stream()
-                .peek(envelope -> {
+                .map(envelope -> {
                     envelope.setStatus(CREATED);
                     envelope.setZipDeleted(false);
+
+                    return envelope;
                 })
                 .collect(toList())
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.spy;
 
 public abstract class ProcessorTestSuite<T extends Processor> {
 
-    protected static final String SAMPLE_ZIP_FILE_NAME = "hello_24-06-2018-00-00-00.zip";
+    protected static final String SAMPLE_ZIP_FILE_NAME = "7_24-06-2018-00-00-00.zip";
 
     protected static final String DOCUMENT_URL1 =
         "http://localhost:8080/documents/1971cadc-9f79-4e1d-9033-84543bbbbc1d";

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/Processor.java
@@ -56,6 +56,9 @@ public abstract class Processor {
         List<Pdf> pdfs,
         CloudBlockBlob cloudBlockBlob
     ) {
+        if (envelope == null) {
+            return;
+        }
         if (!uploadParsedEnvelopeDocuments(envelope, pdfs)) {
             return;
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[[SPIKE]: Handle envelopes stuck in `CREATED` status](https://tools.hmcts.net/jira/browse/BPS-628)

### Change description ###

A non-destructive integration of a spike which solves rare situation of envelope being stuck in `CREATED` status. All steps are present so just needed to re-use existing envelope.

Breaking apart task is not involved - another ticket. And would be very harmful

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
