### PR TITLE
Include envelope status in zip file summary (json only)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
@@ -9,15 +9,18 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFileSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.zipfilesummary.ZipFileSummaryItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED;
@@ -50,6 +53,9 @@ public class ZipFilesSummaryRepositoryTest {
             event("c4", "test4.zip", createdDate.minus(30, MINUTES), FILE_VALIDATION_FAILURE)
         );
 
+        dbHasEnvelope(envelope("c1", "test1.zip", Status.COMPLETED));
+        dbHasEnvelope(envelope("c2", "test2.zip", Status.CREATED));
+
         // when
         List<ZipFileSummary> result = reportRepo.getZipFileSummaryReportFor(LocalDate.of(2019, 2, 15));
 
@@ -58,12 +64,29 @@ public class ZipFilesSummaryRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 asList(
-                    new ZipFileSummaryItem("test1.zip", createdDate, completedDate, "c1", COMPLETED.toString()),
                     new ZipFileSummaryItem(
-                        "test2.zip", createdDate.minus(1, MINUTES), null, "c2", ZIPFILE_PROCESSING_STARTED.toString()
+                        "test1.zip",
+                        createdDate,
+                        completedDate,
+                        "c1",
+                        Event.COMPLETED.toString(),
+                        Status.COMPLETED.toString()
                     ),
                     new ZipFileSummaryItem(
-                        "test4.zip", createdDate.minus(1, HOURS), null, "c4", FILE_VALIDATION_FAILURE.toString()
+                        "test2.zip",
+                        createdDate.minus(1, MINUTES),
+                        null,
+                        "c2",
+                        Event.ZIPFILE_PROCESSING_STARTED.toString(),
+                        Status.CREATED.toString()
+                    ),
+                    new ZipFileSummaryItem(
+                        "test4.zip",
+                        createdDate.minus(1, HOURS),
+                        null,
+                        "c4",
+                        Event.FILE_VALIDATION_FAILURE.toString(),
+                        null
                     )
                 )
             );
@@ -93,12 +116,16 @@ public class ZipFilesSummaryRepositoryTest {
         // given
         Instant createdAt = Instant.parse("2019-02-15T23:59:23.456Z");
         Instant nextDay = Instant.parse("2019-02-16T00:00:23.456Z");
+        String container = "c1";
+        String zip1Name = "test1.zip";
 
         dbHasEvents(
-            event("c1", "test1.zip", createdAt, ZIPFILE_PROCESSING_STARTED),
-            event("c1", "test1.zip", nextDay, COMPLETED),
-            event("c1", "test2.zip", nextDay, ZIPFILE_PROCESSING_STARTED)
+            event(container, zip1Name, createdAt, ZIPFILE_PROCESSING_STARTED),
+            event(container, zip1Name, nextDay, COMPLETED),
+            event(container, "test2.zip", nextDay, ZIPFILE_PROCESSING_STARTED)
         );
+
+        dbHasEnvelope(envelope(container, zip1Name, Status.UPLOADED));
 
         // when
         List<ZipFileSummary> result = reportRepo.getZipFileSummaryReportFor(LocalDate.of(2019, 2, 15));
@@ -108,7 +135,14 @@ public class ZipFilesSummaryRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 singletonList(
-                    new ZipFileSummaryItem("test1.zip", createdAt, nextDay, "c1", COMPLETED.toString())
+                    new ZipFileSummaryItem(
+                        zip1Name,
+                        createdAt,
+                        nextDay,
+                        container,
+                        Event.COMPLETED.toString(),
+                        Status.UPLOADED.toString()
+                    )
                 )
             );
     }
@@ -117,10 +151,36 @@ public class ZipFilesSummaryRepositoryTest {
         eventRepo.saveAll(asList(events));
     }
 
+    private void dbHasEnvelope(Envelope envelope) {
+        envelopeRepo.save(envelope);
+    }
+
     private ProcessEvent event(String container, String zipFileName, Instant createdAt, Event type) {
         ProcessEvent event = new ProcessEvent(container, zipFileName, type);
         event.setCreatedAt(createdAt);
 
         return event;
+    }
+
+    private Envelope envelope(String container, String zipFileName, Status status) {
+        Envelope envelope = new Envelope(
+            UUID.randomUUID().toString(),
+            "jurisdiction1",
+            Instant.now(),
+            Instant.now(),
+            Instant.now(),
+            zipFileName,
+            "1234432112344321",
+            null,
+            Classification.NEW_APPLICATION,
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            container
+        );
+
+        envelope.setStatus(status);
+
+        return envelope;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -84,7 +84,8 @@ public class ReportsController {
                     item.dateProcessed,
                     item.timeProcessed,
                     item.container,
-                    item.status
+                    item.lastEventStatus,
+                    item.envelopeStatus
                 ))
                 .collect(toList())
         );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ZipFileSummary.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ZipFileSummary.java
@@ -12,5 +12,7 @@ public interface ZipFileSummary {
 
     String getContainer();
 
-    String getStatus();
+    String getLastEventStatus();
+
+    String getEnvelopeStatus();
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportItem.java
@@ -28,8 +28,11 @@ public class ZipFilesSummaryReportItem {
     @JsonProperty("container")
     public final String jurisdiction;
 
-    @JsonProperty("status")
-    public final String status;
+    @JsonProperty("last_event_status")
+    public final String lastEventStatus;
+
+    @JsonProperty("envelope_status")
+    public final String envelopeStatus;
 
     // region constructor
     public ZipFilesSummaryReportItem(String fileName,
@@ -38,7 +41,8 @@ public class ZipFilesSummaryReportItem {
                                      LocalDate dateProcessed,
                                      LocalTime timeProcessed,
                                      String container,
-                                     String status
+                                     String lastEventStatus,
+                                     String envelopeStatus
     ) {
         this.fileName = fileName;
         this.dateReceived = dateReceived;
@@ -46,7 +50,8 @@ public class ZipFilesSummaryReportItem {
         this.dateProcessed = dateProcessed;
         this.timeProcessed = timeProcessed;
         this.jurisdiction = container;
-        this.status = status;
+        this.lastEventStatus = lastEventStatus;
+        this.envelopeStatus = envelopeStatus;
     }
     // endregion
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
@@ -76,7 +76,8 @@ public class ReportsService {
             toLocalDate(dbItem.getCompletedDate()),
             toLocalTime(dbItem.getCompletedDate()),
             dbItem.getContainer(),
-            dbItem.getStatus()
+            dbItem.getLastEventStatus(),
+            dbItem.getEnvelopeStatus()
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileSummaryResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileSummaryResponse.java
@@ -11,7 +11,8 @@ public class ZipFileSummaryResponse {
     public final LocalDate dateProcessed;
     public final LocalTime timeProcessed;
     public final String container;
-    public final String status;
+    public final String lastEventStatus;
+    public final String envelopeStatus;
 
     // region constructor
     public ZipFileSummaryResponse(
@@ -21,7 +22,8 @@ public class ZipFileSummaryResponse {
         LocalDate dateProcessed,
         LocalTime timeProcessed,
         String container,
-        String status
+        String lastEventStatus,
+        String envelopeStatus
     ) {
         this.fileName = fileName;
         this.dateReceived = dateReceived;
@@ -29,7 +31,8 @@ public class ZipFileSummaryResponse {
         this.dateProcessed = dateProcessed;
         this.timeProcessed = timeProcessed;
         this.container = container;
-        this.status = status;
+        this.lastEventStatus = lastEventStatus;
+        this.envelopeStatus = envelopeStatus;
     }
     // endregion
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
@@ -37,7 +37,7 @@ public final class CsvWriter {
                     summary.timeReceived,
                     summary.dateProcessed,
                     summary.timeProcessed,
-                    summary.status
+                    summary.lastEventStatus
                 );
             }
         }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CONSUMED;
 
 @RunWith(SpringRunner.class)
@@ -115,7 +116,8 @@ public class ReportsControllerTest {
             localDate,
             localTime.plusHours(1),
             "bulkscan",
-            CONSUMED.toString()
+            CONSUMED.toString(),
+            COMPLETED.toString()
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan"))
@@ -167,7 +169,8 @@ public class ReportsControllerTest {
             localDate,
             localTime.plusHours(1),
             "bulkscan",
-            CONSUMED.toString()
+            CONSUMED.toString(),
+            COMPLETED.toString()
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan"))
@@ -184,7 +187,8 @@ public class ReportsControllerTest {
             .andExpect(jsonPath("$.data[0].date_processed").value("2019-01-14"))
             .andExpect(jsonPath("$.data[0].time_processed").value("13:30:10"))
             .andExpect(jsonPath("$.data[0].container").value(response.container))
-            .andExpect(jsonPath("$.data[0].status").value(response.status));
+            .andExpect(jsonPath("$.data[0].last_event_status").value(response.lastEventStatus))
+            .andExpect(jsonPath("$.data[0].envelope_status").value(response.envelopeStatus));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/reports/zipfilesummary/ZipFileSummaryItem.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/reports/zipfilesummary/ZipFileSummaryItem.java
@@ -10,20 +10,23 @@ public class ZipFileSummaryItem implements ZipFileSummary {
     private final Instant createdDate;
     private final Instant completedDate;
     private final String container;
-    private final String status;
+    private final String lastEventStatus;
+    private final String envelopeStatus;
 
     public ZipFileSummaryItem(
         String zipFileName,
         Instant createdDate,
         Instant completedDate,
         String container,
-        String status
+        String lastEventStatus,
+        String envelopeStatus
     ) {
         this.zipFileName = zipFileName;
         this.createdDate = createdDate;
         this.completedDate = completedDate;
         this.container = container;
-        this.status = status;
+        this.lastEventStatus = lastEventStatus;
+        this.envelopeStatus = envelopeStatus;
     }
 
     @Override
@@ -47,7 +50,12 @@ public class ZipFileSummaryItem implements ZipFileSummary {
     }
 
     @Override
-    public String getStatus() {
-        return status;
+    public String getLastEventStatus() {
+        return lastEventStatus;
+    }
+
+    @Override
+    public String getEnvelopeStatus() {
+        return envelopeStatus;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -5,10 +5,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.zipfilesummary.ZipFileSummaryItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.utils.ZeroRowFiller;
@@ -117,10 +119,20 @@ public class ReportsServiceTest {
         given(zipFilesSummaryRepo.getZipFileSummaryReportFor(now()))
             .willReturn(asList(
                 new ZipFileSummaryItem(
-                    "t1.zip", instant.minus(1, MINUTES), null, "c1", ZIPFILE_PROCESSING_STARTED.toString()
+                    "t1.zip",
+                    instant.minus(1, MINUTES),
+                    null,
+                    "c1",
+                    Event.ZIPFILE_PROCESSING_STARTED.toString(),
+                    Status.CREATED.toString()
                 ),
                 new ZipFileSummaryItem(
-                    "t2.zip", instant.minus(10, MINUTES), instant.minus(20, MINUTES), "c2", COMPLETED.toString()
+                    "t2.zip",
+                    instant.minus(10, MINUTES),
+                    instant.minus(20, MINUTES),
+                    "c2",
+                    Event.COMPLETED.toString(),
+                    Status.UPLOADED.toString()
                 )
             ));
 
@@ -138,7 +150,8 @@ public class ReportsServiceTest {
                     null,
                     null,
                     "c1",
-                    ZIPFILE_PROCESSING_STARTED.toString()
+                    Event.ZIPFILE_PROCESSING_STARTED.toString(),
+                    Status.CREATED.toString()
                 ),
                 new ZipFileSummaryResponse(
                     "t2.zip",
@@ -147,7 +160,8 @@ public class ReportsServiceTest {
                     ofInstant(instant.minus(20, MINUTES), UTC).toLocalDate(),
                     toLocalTime(instant.minus(20, MINUTES)),
                     "c2",
-                    COMPLETED.toString()
+                    Event.COMPLETED.toString(),
+                    Status.UPLOADED.toString()
                 )
             );
     }
@@ -158,10 +172,10 @@ public class ReportsServiceTest {
         given(zipFilesSummaryRepo.getZipFileSummaryReportFor(now()))
             .willReturn(asList(
                 new ZipFileSummaryItem(
-                    "t1.zip", instant.minus(1, MINUTES), null, "c1", ZIPFILE_PROCESSING_STARTED.toString()
+                    "t1.zip", instant.minus(1, MINUTES), null, "c1", ZIPFILE_PROCESSING_STARTED.toString(), null
                 ),
                 new ZipFileSummaryItem(
-                    "t2.zip", instant.minus(10, MINUTES), instant.minus(20, MINUTES), "c2", COMPLETED.toString()
+                    "t2.zip", instant.minus(10, MINUTES), instant.minus(20, MINUTES), "c2", COMPLETED.toString(), null
                 )
             ));
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.util;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
 import java.io.File;
@@ -27,10 +29,24 @@ public class CsvWriterTest {
         //given
         List<ZipFileSummaryResponse> csvData = Arrays.asList(
             new ZipFileSummaryResponse(
-                "test1.zip", date, time, date, time, "bulkscan", DOC_PROCESSED.toString()
+                "test1.zip",
+                date,
+                time,
+                date,
+                time,
+                "bulkscan",
+                Event.DOC_PROCESSED.toString(),
+                Status.UPLOADED.toString()
             ),
             new ZipFileSummaryResponse(
-                "test2.zip", date, time, date, time, "bulkscan", DOC_PROCESSED.toString()
+                "test2.zip",
+                date,
+                time,
+                date,
+                time,
+                "bulkscan",
+                Event.DOC_PROCESSED.toString(),
+                Status.UPLOADED.toString()
             )
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-688

### Change description ###

This is a proposal, so if you don't think we should make this change, please let me know.

Include envelope status in zip file summary (JSON version only), so that if there's a discrepancy between the status of the last event and the status of the envelope (which seems to be the case somewhere), we should be able to discover it easily.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
