### PR TITLE
Throw exception when metafile contains unknown properties

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidator.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
@@ -46,10 +45,6 @@ public class MetafileJsonValidator {
     }
 
     public InputEnvelope parseMetafile(byte[] metafile) throws IOException {
-        try {
-            return MAPPER.readValue(metafile, InputEnvelope.class);
-        } catch (UnrecognizedPropertyException e) {
-            throw new InvalidEnvelopeSchemaException("Unrecognized property in the metadata file", e);
-        }
+        return MAPPER.readValue(metafile, InputEnvelope.class);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidator.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
@@ -45,6 +46,10 @@ public class MetafileJsonValidator {
     }
 
     public InputEnvelope parseMetafile(byte[] metafile) throws IOException {
-        return MAPPER.readValue(metafile, InputEnvelope.class);
+        try {
+            return MAPPER.readValue(metafile, InputEnvelope.class);
+        } catch (UnrecognizedPropertyException e) {
+            throw new InvalidEnvelopeSchemaException("Unrecognized property in the metadata file", e);
+        }
     }
 }

--- a/src/main/resources/metafile-schema.json
+++ b/src/main/resources/metafile-schema.json
@@ -353,5 +353,6 @@
     "zip_file_name",
     "envelope_classification",
     "scannable_items"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -37,6 +38,24 @@ public class MetafileJsonValidatorTestForInvalidFiles {
                 + "\n\terror: object has missing required properties"
             )
             .hasMessageContaining("missing: [\"scannable_items\"]");
+    }
+
+    @Test
+    public void should_not_parse_envelope_with_unrecognised_fields() throws IOException {
+        // given
+        byte[] metafile = getMetafile("/metafiles/invalid/unrecognised-fields.json");
+
+        // when
+        Throwable exc = catchThrowable(() -> validator.parseMetafile(metafile));
+
+        // then
+        assertThat(exc)
+            .isInstanceOf(InvalidEnvelopeSchemaException.class)
+            .hasMessageContaining("Unrecognized property in the metadata file")
+            .hasCauseInstanceOf(UnrecognizedPropertyException.class);
+
+        assertThat(exc.getCause().getMessage())
+            .startsWith("Unrecognized field \"invalid_field_name\"");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -41,21 +40,21 @@ public class MetafileJsonValidatorTestForInvalidFiles {
     }
 
     @Test
-    public void should_not_parse_envelope_with_unrecognised_fields() throws IOException {
+    public void should_not_parse_envelope_with_unknown_properties() throws IOException {
         // given
         byte[] metafile = getMetafile("/metafiles/invalid/unrecognised-fields.json");
 
         // when
-        Throwable exc = catchThrowable(() -> validator.parseMetafile(metafile));
+        Throwable exc = catchThrowable(() -> validator.validate(metafile, SAMPLE_ZIP_FILE_NAME));
 
         // then
         assertThat(exc)
             .isInstanceOf(InvalidEnvelopeSchemaException.class)
-            .hasMessageContaining("Unrecognized property in the metadata file")
-            .hasCauseInstanceOf(UnrecognizedPropertyException.class);
+            .hasMessageStartingWith(getExpectedErrorHeaderLine(SAMPLE_ZIP_FILE_NAME)
+                + "\n\terror: object instance has properties which are not allowed by the schema: [\"invalid_field_name\"]"
+            )
+            .hasMessageContaining("unwanted: [\"invalid_field_name\"]");
 
-        assertThat(exc.getCause().getMessage())
-            .startsWith("Unrecognized field \"invalid_field_name\"");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
@@ -51,7 +51,8 @@ public class MetafileJsonValidatorTestForInvalidFiles {
         assertThat(exc)
             .isInstanceOf(InvalidEnvelopeSchemaException.class)
             .hasMessageStartingWith(getExpectedErrorHeaderLine(SAMPLE_ZIP_FILE_NAME)
-                + "\n\terror: object instance has properties which are not allowed by the schema: [\"invalid_field_name\"]"
+                + "\n\terror: object instance has properties which are not allowed by the schema:"
+                + "[\"invalid_field_name\"]"
             )
             .hasMessageContaining("unwanted: [\"invalid_field_name\"]");
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
@@ -51,7 +51,7 @@ public class MetafileJsonValidatorTestForInvalidFiles {
         assertThat(exc)
             .isInstanceOf(InvalidEnvelopeSchemaException.class)
             .hasMessageStartingWith(getExpectedErrorHeaderLine(SAMPLE_ZIP_FILE_NAME)
-                + "\n\terror: object instance has properties which are not allowed by the schema:"
+                + "\n\terror: object instance has properties which are not allowed by the schema: "
                 + "[\"invalid_field_name\"]"
             )
             .hasMessageContaining("unwanted: [\"invalid_field_name\"]");

--- a/src/test/resources/metafiles/invalid/missing-required-fields.json
+++ b/src/test/resources/metafiles/invalid/missing-required-fields.json
@@ -5,7 +5,7 @@
   "opening_date": "2017-02-24T00:00:00.010Z",
   "zip_file_createddate": "2017-02-24T00:00:00.001Z",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
-  "clasification": "exception",
+  "envelope_classification": "exception",
   "scannable_items": [
     {
       "document_control_number": "1111001",

--- a/src/test/resources/metafiles/invalid/missing-top-level-fields.json
+++ b/src/test/resources/metafiles/invalid/missing-top-level-fields.json
@@ -1,7 +1,7 @@
 {
   "po_box": "XXXX",
   "delivery_date": "2017-02-23T00:00:00.100Z",
-  "openingdate": "2017-02-24T00:00:00.010Z",
+  "opening_date": "2017-02-24T00:00:00.010Z",
   "zip_file_createddate": "2017-02-24T00:00:00.001Z",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
   "scannable_items": [

--- a/src/test/resources/metafiles/invalid/unrecognised-fields.json
+++ b/src/test/resources/metafiles/invalid/unrecognised-fields.json
@@ -1,0 +1,31 @@
+{
+  "case_number": "1111222233334446",
+  "invalid_field_name": "1234",
+  "po_box": "XXXX",
+  "jurisdiction": "SSCS",
+  "delivery_date": "2017-02-23T22:00:00.100Z",
+  "opening_date": "2017-03-31T00:00:00.010Z",
+  "zip_file_createddate": "2017-02-24T00:00:00.001Z",
+  "zip_file_name": "1_24-02-2017-00-00-00.zip",
+  "envelope_classification": "new_application",
+  "scannable_items": [
+    {
+      "document_control_number": "1111001",
+      "scanning_date": "2017-02-24T00:00:00.000Z",
+      "manual_intervention": "string",
+      "next_action": "return",
+      "next_action_date": "2017-02-24T00:00:00.000Z",
+      "file_name": "1111001.pdf",
+      "notes": "The document had ink spilled on it",
+      "document_type": "Cherished",
+      "ocr_data": "eyJNZXRhZGF0YV9maWxlIjogW3sgIm1ldGFkYXRhX2ZpZWxkX25hbWUiOiAibmFtZTIiLCAibWV0YWRhdGFfZmllbGRfdmFsdWUiOiAidmFsdWUyIn1dfQo="
+    }
+  ],
+  "non_scannable_items": [
+    {
+      "document_control_number": "1111001",
+      "item_type": "CD",
+      "notes": "4GB USB memory stick"
+    }
+  ]
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-670

### Change description ###
Updated `MetafileJsonValidator` to throw an exception when the metafile contains unknown properties. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
