### PR TITLE
Update document subtype property name

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/blob/InputScannableItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/blob/InputScannableItem.java
@@ -37,7 +37,7 @@ public class InputScannableItem {
         @JsonProperty("file_name") String fileName,
         @JsonProperty("notes") String notes,
         @JsonProperty("document_type") InputDocumentType documentType,
-        @JsonProperty("document_subtype") String documentSubtype
+        @JsonProperty("document_sub_type") String documentSubtype
 
     ) {
         this.documentControlNumber = documentControlNumber;

--- a/src/main/resources/metafile-schema.json
+++ b/src/main/resources/metafile-schema.json
@@ -129,8 +129,8 @@
             ],
             "default": "Other"
           },
-          "document_subtype": {
-            "id": "#/properties/scannable_items/items/properties/document_subtype",
+          "document_sub_type": {
+            "id": "#/properties/scannable_items/items/properties/document_sub_type",
             "type": "string"
           }
         },


### PR DESCRIPTION
According to the technical spec, the json property name for "document subtype" should be `document_sub_type`. (instead of `document_subtype`)