### PR TITLE
Fix/Update config for Jenkins pipeline(includes sonarqube config deprecations)

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -65,7 +65,7 @@ withPipeline(type, product, component) {
       def storageSecret = "storage-secret-${aksServiceName}"
       def serviceBusSecret = "servicebus-secret-namespace-${aksServiceName}"
 
-      def namespace = new TeamNames().getNameNormalizedOrThrow(product)
+      def namespace = new TeamNames(this).getNameSpace(product)
       def kubectl = new Kubectl(this, subscription, namespace)
       kubectl.login()
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,13 +124,12 @@ jacocoTestReport {
   }
 }
 
-project.tasks['sonarqube'].dependsOn test, integration
+project.tasks['sonarqube'].dependsOn jacocoTestReport
 
 sonarqube {
   properties {
     property "sonar.projectName", "Reform :: Bulk Scan Processor"
-    property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
-    property "sonar.jacoco.itReportPath", "${project.buildDir}/jacoco/integration.exec"
+    property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination.path
     property "sonar.exclusions", "**/model/out/*,**/config/**"
   }
 }


### PR DESCRIPTION
### Change description ###

As from hmcts/cnp-jenkins-library#509 the constructor of `TeamNames` is different. Fixing that

Bonus: resolve sonarqube config deprecations

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
