### PR TITLE
Update unit tests to prepare for junit5 usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,17 @@ dependencyCheck {
   }
 }
 
+// it is important to specify logback classic and core packages explicitly as libraries like spring boot
+// enforces it's own (older) version which is not recommended.
+def versions = [
+  junit: '5.5.1',
+  junitPlatform: '1.5.1',
+  mockitoJupiter: '3.0.0',
+  springBoot: springBoot.class.package.implementationVersion,
+  springHystrix: '2.1.1.RELEASE',
+  springfoxSwagger: '2.9.2'
+]
+
 dependencyManagement {
   dependencies {
     dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.62'
@@ -169,6 +180,10 @@ dependencyManagement {
     // CVE-2019-12814
     dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.1') {
       entry 'jackson-databind'
+    }
+    // align with jupiter
+    dependencySet(group: 'org.mockito', version: versions.mockitoJupiter) {
+      entry 'mockito-core'
     }
   }
 }
@@ -181,14 +196,6 @@ repositories {
     url "https://dl.bintray.com/hmcts/hmcts-maven"
   }
 }
-
-// it is important to specify logback classic and core packages explicitly as libraries like spring boot
-// enforces it's own (older) version which is not recommended.
-def versions = [
-  springBoot: springBoot.class.package.implementationVersion,
-  springHystrix: '2.1.1.RELEASE',
-  springfoxSwagger: '2.9.2'
-]
 
 ext["rest-assured.version"] = '4.0.0'
 
@@ -244,6 +251,13 @@ dependencies {
   compile group: 'io.vavr', name: 'vavr', version: '1.0.0-alpha-3'
 
   compile group: 'org.apache.commons', name: 'commons-csv', version: '1.7'
+
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
+  testCompile group: 'org.junit.platform', name: 'junit-platform-commons', version: versions.junitPlatform
+  testCompile group: 'org.junit.platform', name: 'junit-platform-engine', version: versions.junitPlatform
+  testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: versions.mockitoJupiter
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'com.jayway.awaitility', name: 'awaitility', version: '1.7.0'

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -29,7 +29,6 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService.TEST_CONTAINER;
@@ -46,8 +45,6 @@ public class ReportsServiceTest {
     @Before
     public void setUp() throws Exception {
         this.service = new ReportsService(this.repo, zeroRowFiller, zipFilesSummaryRepo);
-        when(this.zeroRowFiller.fill(any(), any()))
-            .thenAnswer(invocation -> invocation.getArgument(0)); // return data unchanged
     }
 
     @Test
@@ -57,6 +54,8 @@ public class ReportsServiceTest {
                 new Item(now().plusDays(1), "A", 100, 1),
                 new Item(now().minusDays(1), "B", 200, 9)
             ));
+        given(this.zeroRowFiller.fill(any(), any()))
+            .willAnswer(invocation -> invocation.getArgument(0)); // return data unchanged
 
         // when
         List<EnvelopeCountSummary> result = service.getCountFor(now(), false);
@@ -77,6 +76,8 @@ public class ReportsServiceTest {
                 new Item(now(), TEST_CONTAINER, 100, 1),
                 new Item(now(), "some_other_container", 10, 0)
             ));
+        given(this.zeroRowFiller.fill(any(), any()))
+            .willAnswer(invocation -> invocation.getArgument(0)); // return data unchanged
 
         // when
         List<EnvelopeCountSummary> resultWithoutTestContainer = service.getCountFor(now(), false);
@@ -91,8 +92,9 @@ public class ReportsServiceTest {
 
     @Test
     public void should_map_empty_list_from_repo_when_requested_for_envelope_count_summary() {
-        given(repo.getReportFor(now()))
-            .willReturn(emptyList());
+        given(repo.getReportFor(now())).willReturn(emptyList());
+        given(this.zeroRowFiller.fill(any(), any()))
+            .willAnswer(invocation -> invocation.getArgument(0)); // return data unchanged
 
         // when
         List<EnvelopeCountSummary> result = service.getCountFor(now(), false);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandlerTest.java
@@ -51,9 +51,12 @@ public class ProcessedEnvelopeNotificationHandlerTest {
     public void should_call_envelope_finaliser_when_message_is_valid() {
         // given
         UUID envelopeId = UUID.randomUUID();
+        IMessage message = validMessage(envelopeId);
+
+        given(message.getLockToken()).willReturn(UUID.randomUUID());
 
         // when
-        CompletableFuture<Void> future = handler.onMessageAsync(validMessage(envelopeId));
+        CompletableFuture<Void> future = handler.onMessageAsync(message);
         future.join();
 
         // then
@@ -81,6 +84,8 @@ public class ProcessedEnvelopeNotificationHandlerTest {
         UUID envelopeId = UUID.randomUUID();
         IMessage message = validMessage(envelopeId);
 
+        given(message.getLockToken()).willReturn(UUID.randomUUID());
+
         // when
         CompletableFuture<Void> future = handler.onMessageAsync(message);
         future.join();
@@ -101,6 +106,8 @@ public class ProcessedEnvelopeNotificationHandlerTest {
 
         UUID envelopeId = UUID.randomUUID();
         IMessage message = validMessage(envelopeId);
+
+        given(message.getLockToken()).willReturn(UUID.randomUUID());
 
         // when
         CompletableFuture<Void> future = handler.onMessageAsync(message);
@@ -154,8 +161,6 @@ public class ProcessedEnvelopeNotificationHandlerTest {
     }
 
     private IMessage validMessage(UUID envelopeId) {
-        IMessage message = spy(new Message(String.format("{\"id\":\"%s\"}", envelopeId)));
-        given(message.getLockToken()).willReturn(UUID.randomUUID());
-        return message;
+        return spy(new Message(String.format("{\"id\":\"%s\"}", envelopeId)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -65,16 +65,6 @@ public class BlobManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        given(blobManagementProperties.getBlobLeaseTimeout()).willReturn(30000);
-        given(blobManagementProperties.getBlobCopyTimeoutInMillis()).willReturn(1000);
-        given(blobManagementProperties.getBlobCopyPollingDelayInMillis()).willReturn(50);
-
-        given(inputContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(inputBlob);
-        given(rejectedContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(rejectedBlob);
-
-        given(cloudBlobClient.getContainerReference(INPUT_CONTAINER_NAME)).willReturn(inputContainer);
-        given(cloudBlobClient.getContainerReference(REJECTED_CONTAINER_NAME)).willReturn(rejectedContainer);
-
         blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
     }
 
@@ -155,6 +145,13 @@ public class BlobManagerTest {
     @Test
     public void tryMoveFileToRejectedContainer_copies_and_deletes_original_blob() throws Exception {
         // given
+        given(blobManagementProperties.getBlobCopyTimeoutInMillis()).willReturn(1000);
+        given(inputContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(inputBlob);
+        given(rejectedContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(rejectedBlob);
+        given(cloudBlobClient.getContainerReference(INPUT_CONTAINER_NAME)).willReturn(inputContainer);
+        given(cloudBlobClient.getContainerReference(REJECTED_CONTAINER_NAME)).willReturn(rejectedContainer);
+
+        // and
         mockRejectedBlobToReturnCopyState(PENDING, SUCCESS);
 
         // when
@@ -168,6 +165,13 @@ public class BlobManagerTest {
     @Test
     public void tryMoveFileToRejectedContainer_does_not_delete_blob_when_copying_failed() throws Exception {
         // given
+        given(blobManagementProperties.getBlobCopyTimeoutInMillis()).willReturn(1000);
+        given(inputContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(inputBlob);
+        given(rejectedContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(rejectedBlob);
+        given(cloudBlobClient.getContainerReference(INPUT_CONTAINER_NAME)).willReturn(inputContainer);
+        given(cloudBlobClient.getContainerReference(REJECTED_CONTAINER_NAME)).willReturn(rejectedContainer);
+
+        // and
         mockRejectedBlobToReturnCopyState(PENDING, PENDING, FAILED);
 
         // when
@@ -182,6 +186,12 @@ public class BlobManagerTest {
     @Test
     public void tryMoveFileToRejectedContainer_does_not_delete_blob_when_copying_timed_out() throws Exception {
         // given
+        given(inputContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(inputBlob);
+        given(rejectedContainer.getBlockBlobReference(INPUT_FILE_NAME)).willReturn(rejectedBlob);
+        given(cloudBlobClient.getContainerReference(INPUT_CONTAINER_NAME)).willReturn(inputContainer);
+        given(cloudBlobClient.getContainerReference(REJECTED_CONTAINER_NAME)).willReturn(rejectedContainer);
+
+        // and
         mockRejectedBlobToReturnCopyState(PENDING);
 
         given(blobManagementProperties.getBlobCopyTimeoutInMillis()).willReturn(300);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiersTest.java
@@ -20,6 +20,7 @@ import static com.google.common.io.Resources.toByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipAndSignDir;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.SigningHelper.signWithSha256Rsa;
@@ -113,13 +114,16 @@ public class ZipVerifiersTest {
         assertThat(zis).isNotNull();
     }
 
-    @Test(expected = DocSignatureFailureException.class)
+    @Test
     public void should_not_verify_invalid_zip_successfully() throws Exception {
         byte[] zipBytes = zipAndSignDir("signature/sample_valid_content", "signature/some_other_private_key.der");
         ZipVerifiers.ZipStreamWithSignature zipStreamWithSig = new ZipVerifiers.ZipStreamWithSignature(
             new ZipInputStream(new ByteArrayInputStream(zipBytes)), publicKeyBase64, "hello.zip", "x"
         );
-        ZipVerifiers.sha256WithRsaVerification(zipStreamWithSig);
+        assertThrows(
+            DocSignatureFailureException.class,
+            () -> ZipVerifiers.sha256WithRsaVerification(zipStreamWithSig)
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -63,8 +63,6 @@ public class OcrValidatorTest {
 
     @Before
     public void setUp() throws Exception {
-        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
-
         this.ocrValidator = new OcrValidator(client, containerMappings, authTokenGenerator);
     }
 
@@ -77,6 +75,18 @@ public class OcrValidatorTest {
     public void should_call_rest_client_with_correct_parameters() {
         // given
         String url = "https://example.com/validate-ocr";
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, url)
+            ));
+
+        given(client.validate(eq(url), any(), any(), any()))
+            .willReturn(new ValidationResponse(Status.SUCCESS, emptyList(), emptyList()));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        // and
         String subtype = "sample_document_subtype";
         InputEnvelope envelope = inputEnvelope(
             "BULKSCAN",
@@ -87,14 +97,6 @@ public class OcrValidatorTest {
                 doc("other", null)
             )
         );
-
-        given(containerMappings.getMappings())
-            .willReturn(singletonList(
-                new Mapping("container", "jurisdiction", PO_BOX, url)
-            ));
-
-        given(client.validate(eq(url), any(), any(), any()))
-            .willReturn(new ValidationResponse(Status.SUCCESS, emptyList(), emptyList()));
 
         // when
         ocrValidator.assertIsValid(envelope);
@@ -205,6 +207,8 @@ public class OcrValidatorTest {
             ));
 
         given(client.validate(any(), any(), any(), any())).willThrow(new RuntimeException());
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
 
         // when
         Throwable err = catchThrowable(() -> ocrValidator.assertIsValid(envelope));


### PR DESCRIPTION
### Change description ###

Including necessary junit5 libraries but not using them at the moment. Just a way to reduce the following PR which will be for actual transition.

In preparation to that:

- solve unused mocks
- remove deprecated `@Test(expected = Exception)` usage

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
