### PR TITLE
Update unit source code: switch to using junit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,15 @@ tasks.withType(JavaCompile) {
   options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
+test {
+  failFast = true
+  useJUnitPlatform()
+
+  testLogging {
+    exceptionFormat = 'full'
+  }
+}
+
 task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
   testClassesDirs = sourceSets.functionalTest.output.classesDirs
   classpath = sourceSets.functionalTest.runtimeClasspath
@@ -317,10 +326,3 @@ task migratePostgresDatabase(type: FlywayMigrateTask) {
     url = "jdbc:postgresql://${dburl}"
   }
 }
-
-test {
-  testLogging {
-    exceptionFormat = 'full'
-  }
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -258,6 +258,7 @@ dependencies {
   testCompile group: 'org.junit.platform', name: 'junit-platform-commons', version: versions.junitPlatform
   testCompile group: 'org.junit.platform', name: 'junit-platform-engine', version: versions.junitPlatform
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: versions.mockitoJupiter
+  testCompile group: 'io.github.netmikey.logunit', name: 'logunit-logback', version: '1.1.0'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'com.jayway.awaitility', name: 'awaitility', version: '1.7.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -31,6 +31,12 @@
   </suppress>
 
   <suppress>
+    <notes><![CDATA[ used in output capturer in static tests ]]></notes>
+    <filePath regex="true">.*logunit-logback-1\.1\.0\.jar</filePath>
+    <cve>CVE-2017-5929</cve>
+  </suppress>
+
+  <suppress>
     <notes><![CDATA[
        file name: spring-cloud-contract-wiremock-2.1.1.jar.
        This is only used for TESTING purposes.

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationDecoderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/client/ErrorNotificationDecoderTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import feign.Request;
 import feign.Response;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadEnvelopesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadEnvelopesControllerTest.java
@@ -4,13 +4,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.apache.commons.io.Charsets;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataRetrievalFailureException;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.EnvelopeController;
@@ -43,7 +41,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(EnvelopeController.class)
 public class ReadEnvelopesControllerTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadSingleEnvelopeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReadSingleEnvelopeControllerTest.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.controller;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.EnvelopeController;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ForbiddenException;
@@ -26,7 +24,6 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(EnvelopeController.class)
 public class ReadSingleEnvelopeControllerTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.controller;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.ReportsController;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedEnvelopesReportService;
@@ -32,7 +30,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CONSUMED;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(ReportsController.class)
 public class ReportsControllerTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ZipStatusControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ZipStatusControllerTest.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.controller;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.ZipStatusController;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.zipfilestatus.ZipFileEnvelope;
@@ -27,7 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(ZipStatusController.class)
 public class ZipStatusControllerTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptionhandlers/ErrorNotificationExceptionHandlerTest.java
@@ -3,11 +3,11 @@ package uk.gov.hmcts.reform.bulkscanprocessor.exceptionhandlers;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.Message;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpStatusCodeException;
 import uk.gov.hmcts.reform.bulkscanprocessor.client.ErrorNotificationException;
@@ -25,7 +25,7 @@ import static org.mockito.BDDMockito.spy;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.verifyNoMoreInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ErrorNotificationExceptionHandlerTest {
 
     @Mock
@@ -39,7 +39,7 @@ public class ErrorNotificationExceptionHandlerTest {
 
     private static final CompletableFuture<Void> COMPLETED_FUTURE = CompletableFuture.completedFuture(null);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         handler = new ErrorNotificationExceptionHandler(new MessageAutoCompletor(client));
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/jupiter/GreenMailExtension.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/jupiter/GreenMailExtension.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.jupiter;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailProxy;
+import com.icegreen.greenmail.util.ServerSetup;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * This is a copy of not yet released code.
+ * {@see https://github.com/greenmail-mail-test/greenmail/tree/master/greenmail-junit5/src/main/java/com/icegreen/greenmail/junit5}
+ */
+public class GreenMailExtension extends GreenMailProxy implements BeforeEachCallback, AfterEachCallback {
+    private final ServerSetup[] serverSetups;
+    private GreenMail greenMail;
+
+    /**
+     * Initialize with single server setups.
+     *
+     * @param serverSetup Setup to use
+     */
+    public GreenMailExtension(final ServerSetup serverSetup) {
+        this.serverSetups = new ServerSetup[]{serverSetup};
+    }
+
+    /**
+     * Initialize with all server setups.
+     */
+    public GreenMailExtension() {
+        this(ServerSetupTest.ALL);
+    }
+
+    /**
+     * Initialize with multiple server setups.
+     *
+     * @param serverSetups All setups to use
+     */
+    public GreenMailExtension(final ServerSetup[] serverSetups) {
+        this.serverSetups = serverSetups;
+    }
+
+    @Override
+    public void beforeEach(final ExtensionContext context) {
+        greenMail = new GreenMail(serverSetups);
+        start();
+    }
+
+    @Override
+    public void afterEach(final ExtensionContext context) {
+        stop();
+    }
+
+    @Override
+    protected GreenMail getGreenMail() {
+        return greenMail;
+    }
+
+    @Override
+    public GreenMailExtension withConfiguration(final GreenMailConfiguration config) {
+        super.withConfiguration(config);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.mapper;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.NonScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Payment;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeResponseMapperTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.mapper;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.ToStringComparator;
@@ -14,7 +14,7 @@ public class EnvelopeResponseMapperTest {
 
     private Envelope envelope;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         envelope = EnvelopeCreator.envelope();
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.model.mapper;
 
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputScannableItem;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.mapper;
 
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType;
@@ -10,6 +8,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.inputScannableItem;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.CHERISHED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.COVERSHEET;
@@ -18,13 +17,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.SSCS1;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.WILL;
 
-@SuppressWarnings("checkstyle:LineLength")
 public class SubtypeTest {
 
     private static final String SOME_SUBTYPE = "foo";
-
-    @Rule
-    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     @Test
     public void should_map_scannable_item_document_types_correctly() {
@@ -51,13 +46,19 @@ public class SubtypeTest {
             ScannableItem result = EnvelopeMapper.toDbScannableItem(item, null);
 
             // then
-            softly.assertThat(result.getDocumentType())
-                .as("Output document type for type '%s' and subtype '%s'", tc.input.documentType, tc.input.docSubtype)
-                .isEqualTo(tc.expected.documentType);
-
-            softly.assertThat(result.getDocumentSubtype())
-                .as("Output document subtype for type '%s' and subtype '%s'", tc.input.documentType, tc.input.docSubtype)
-                .isEqualTo(tc.expected.docSubtype);
+            assertSoftly(softly -> {
+                softly.assertThat(result.getDocumentType()).as(
+                    "Output document type for type '%s' and subtype '%s'",
+                    tc.input.documentType,
+                    tc.input.docSubtype
+                ).isEqualTo(tc.expected.documentType);
+                softly.assertThat(result.getDocumentSubtype()).as(
+                    "Output document subtype for type '%s' and subtype '%s'",
+                    tc.input.documentType,
+                    tc.input.docSubtype
+                ).isEqualTo(tc.expected.docSubtype);
+                softly.assertAll();
+            });
         });
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 
 import com.fasterxml.jackson.databind.node.TextNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/AuthServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/AuthServiceTest.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnAuthenticatedException;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AuthServiceTest {
 
     private static final String SERVICE_HEADER = "some-header";
@@ -29,12 +29,12 @@ public class AuthServiceTest {
 
     private AuthService service;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         service = new AuthService(validator);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         reset(validator);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeAccessServiceTest.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.EnvelopeAccessProperties.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceJuridictionConfigNotFoundException;
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("checkstyle:LineLength")
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EnvelopeAccessServiceTest {
 
     @Mock
@@ -23,7 +23,7 @@ public class EnvelopeAccessServiceTest {
 
     private EnvelopeAccessService service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.service = new EnvelopeAccessService(accessProps);
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverServiceTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataRetrievalFailureException;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.PROCESSED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EnvelopeRetrieverServiceTest {
 
     @Mock
@@ -34,7 +34,7 @@ public class EnvelopeRetrieverServiceTest {
     @Mock
     private EnvelopeAccessService envelopeAccess;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         envelopeRetrieverService = new EnvelopeRetrieverService(envelopeRepository, envelopeAccess);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeStatusChangeValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeStatusChangeValidatorTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidStatusChangeException;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.Rule;
+import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.rule.OutputCapture;
 import uk.gov.hmcts.reform.bulkscanprocessor.client.ErrorNotificationClient;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ErrorNotification;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ErrorNotificationRepository;
@@ -28,8 +28,8 @@ import static org.mockito.BDDMockito.verify;
 @ExtendWith(MockitoExtension.class)
 public class ErrorNotificationServiceTest {
 
-    @Rule
-    public OutputCapture capture = new OutputCapture();
+    @RegisterExtension
+    public LogCapturer capturer = LogCapturer.create().captureForType(ErrorNotificationService.class);
 
     @Captor
     public ArgumentCaptor<ErrorNotificationRequest> requestCaptor;
@@ -47,7 +47,6 @@ public class ErrorNotificationServiceTest {
 
     @BeforeEach
     public void setUp() {
-        capture.reset();
         service = new ErrorNotificationService(client, repository, entityManager);
     }
 
@@ -80,7 +79,7 @@ public class ErrorNotificationServiceTest {
         assertThat(request.referenceId).isEqualTo(serviceBusMessage.id);
 
         // and
-        assertThat(capture.toString()).contains(
+        capturer.assertContains(
             "Error notification for " + request.zipFileName + " published. ID: " + response.getNotificationId()
         );
         verify(repository).saveAndFlush(any(ErrorNotification.class));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -1,14 +1,13 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.rule.OutputCapture;
 import uk.gov.hmcts.reform.bulkscanprocessor.client.ErrorNotificationClient;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ErrorNotification;
@@ -26,7 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ErrorNotificationServiceTest {
 
     @Rule
@@ -46,15 +45,10 @@ public class ErrorNotificationServiceTest {
 
     private ErrorNotificationService service;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         capture.reset();
         service = new ErrorNotificationService(client, repository, entityManager);
-    }
-
-    @After
-    public void tearDown() {
-        capture.flush();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
@@ -6,10 +6,10 @@ import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.core.PathUtility;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.AccessTokenProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
 
@@ -22,13 +22,13 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SasTokenGeneratorServiceTest {
 
     private AccessTokenProperties accessTokenProperties;
     private SasTokenGeneratorService tokenGeneratorService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws URISyntaxException {
         StorageCredentials storageCredentials = new StorageCredentialsAccountAndKey("testAccountName", "dGVzdGtleQ==");
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/document/DocumentManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/document/DocumentManagementServiceTest.java
@@ -2,12 +2,12 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.document;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
@@ -33,7 +33,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DocumentManagementServiceTest {
 
     private static final String AUTH_HEADER = "service-auth-header";
@@ -48,7 +48,7 @@ public class DocumentManagementServiceTest {
     @Mock
     private RestTemplate restTemplate;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(authTokenGenerator.generate()).thenReturn(AUTH_HEADER);
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -4,9 +4,9 @@ import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import org.apache.commons.mail.util.MimeMessageParser;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
@@ -25,7 +25,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ReportSenderTest {
 
     private static final String TEST_LOGIN = "test@localhost.com";

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -1,15 +1,15 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import org.apache.commons.mail.util.MimeMessageParser;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import uk.gov.hmcts.reform.bulkscanprocessor.jupiter.GreenMailExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 
 import java.util.Properties;
@@ -31,8 +31,8 @@ public class ReportSenderTest {
     private static final String TEST_LOGIN = "test@localhost.com";
     private static final String TEST_PASSWORD = "test_password";
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP);
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
 
     @Test
     public void should_send_email_to_all_recipients() throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedEnvelopesReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedEnvelopesReportServiceTest.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.ListBlobItem;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RejectedEnvelopesReportServiceTest {
 
     @Mock private BlobManager blobManager;
@@ -30,7 +30,7 @@ public class RejectedEnvelopesReportServiceTest {
 
     private RejectedEnvelopesReportService service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(blobManager.listRejectedContainers())
             .willReturn(asList(containerA, containerB));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
@@ -33,7 +33,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService.TEST_CONTAINER;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ReportsServiceTest {
 
     @Mock private EnvelopeCountSummaryRepository repo;
@@ -42,7 +42,7 @@ public class ReportsServiceTest {
 
     private ReportsService service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.service = new ReportsService(this.repo, zeroRowFiller, zipFilesSummaryRepo);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ZeroRowFillerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.utils.ZeroRowFiller;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/MessageAutoCompletorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/MessageAutoCompletorTest.java
@@ -1,18 +1,18 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus;
 
 import com.microsoft.azure.servicebus.IQueueClient;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
 
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.verifyNoMoreInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MessageAutoCompletorTest {
 
     @Mock
@@ -22,7 +22,7 @@ public class MessageAutoCompletorTest {
 
     private static final UUID LOCK_TOKEN = UUID.randomUUID();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         completor = new MessageAutoCompletor(client);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/tasks/processor/DocumentProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/tasks/processor/DocumentProcessorTest.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.tasks.processor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItemRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocumentUrlNotRetrievedException;
@@ -29,7 +29,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DocumentProcessorTest {
 
     @Mock
@@ -40,7 +40,7 @@ public class DocumentProcessorTest {
 
     private DocumentProcessor documentProcessor;
 
-    @Before
+    @BeforeEach
     public void setup() {
         documentProcessor = new DocumentProcessor(
             documentManagementService,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.zipfilestatus;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ZipFileStatusServiceTest {
 
     @Mock private ProcessEventRepository eventRepo;
@@ -34,7 +34,7 @@ public class ZipFileStatusServiceTest {
 
     private ZipFileStatusService service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.service = new ZipFileStatusService(eventRepo, envelopeRepo);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.blobstorage.MockBlob;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
@@ -23,13 +23,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.blobstorage.MockBlob.mockBlob;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CleanUpRejectedFilesTaskTest {
 
     @Mock private BlobManager blobManager;
     @Mock private CloudBlobContainer container;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(blobManager.listRejectedContainers()).willReturn(singletonList(container));
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.Message;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.ErrorNotificationService;
@@ -29,7 +29,7 @@ import static org.mockito.BDDMockito.spy;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willThrow;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ErrorNotificationHandlerTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -46,7 +46,7 @@ public class ErrorNotificationHandlerTest {
 
     private ErrorNotificationHandler handler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         handler = new ErrorNotificationHandler(service, MAPPER, new MessageAutoCompletor(queueClient));
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTaskTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class OrchestratorNotificationTaskTest {
 
     @Mock private ServiceBusHelper serviceBusHelper;
@@ -29,7 +29,7 @@ public class OrchestratorNotificationTaskTest {
 
     private OrchestratorNotificationTask task;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.task = new OrchestratorNotificationTask(
             serviceBusHelper,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessedEnvelopeNotificationHandlerTest.java
@@ -3,11 +3,11 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.Message;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.EnvelopeNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.EnvelopeFinaliserService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.MessageAutoCompletor;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ProcessedEnvelopeNotificationHandlerTest {
 
     private static final String DEAD_LETTER_REASON_PROCESSING_ERROR = "Message processing error";
@@ -38,7 +38,7 @@ public class ProcessedEnvelopeNotificationHandlerTest {
 
     private ProcessedEnvelopeNotificationHandler handler;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         handler = new ProcessedEnvelopeNotificationHandler(
             envelopeFinaliserService,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesTaskTest.java
@@ -1,17 +1,17 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.monitoring;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 
 import static java.time.LocalDate.now;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class IncompleteEnvelopesTaskTest {
 
     @Mock
@@ -19,7 +19,7 @@ public class IncompleteEnvelopesTaskTest {
 
     private IncompleteEnvelopesTask task;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         task = new IncompleteEnvelopesTask(envelopeRepository);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -7,11 +7,11 @@ import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.blob.CopyState;
 import com.microsoft.azure.storage.blob.CopyStatus;
 import com.microsoft.azure.storage.blob.LeaseStatus;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
 
 import java.util.Arrays;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BlobManagerTest {
 
     private static final String INPUT_CONTAINER_NAME = "container-name";
@@ -63,7 +63,7 @@ public class BlobManagerTest {
 
     private BlobManager blobManager;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
-import org.junit.Rule;
+import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.rule.OutputCapture;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
@@ -15,15 +15,14 @@ import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 import java.util.Collections;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 public class FailedDocUploadProcessorTest {
 
-    @Rule
-    public OutputCapture outputCapture = new OutputCapture();
+    @RegisterExtension
+    public LogCapturer capturer = LogCapturer.create().captureForType(FailedDocUploadProcessor.class);
 
     @Mock
     private DocumentProcessor documentProcessor;
@@ -65,6 +64,6 @@ public class FailedDocUploadProcessorTest {
         catchThrowableOfType(() -> processor.processJurisdiction("SSCS"), NullPointerException.class);
 
         // then
-        assertThat(outputCapture.toString()).containsPattern("Processing 3 failed documents for container test");
+        capturer.assertContains("Processing 3 failed documents for container test");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -1,12 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.rule.OutputCapture;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
@@ -20,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FailedDocUploadProcessorTest {
 
     @Rule
@@ -40,7 +39,7 @@ public class FailedDocUploadProcessorTest {
 
     private FailedDocUploadProcessor processor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         processor = new FailedDocUploadProcessor(
             null,
@@ -49,11 +48,6 @@ public class FailedDocUploadProcessorTest {
             envelopeRepository,
             processEventRepository
         );
-    }
-
-    @After
-    public void tearDown() {
-        outputCapture.flush();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiersTest.java
@@ -2,10 +2,10 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocSignatureFailureException;
 
 import java.io.ByteArrayInputStream;
@@ -25,7 +25,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipAn
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.SigningHelper.signWithSha256Rsa;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ZipVerifiersTest {
 
     private static final String INVALID_SIGNATURE_MESSAGE = "Zip signature failed verification";
@@ -34,7 +34,7 @@ public class ZipVerifiersTest {
     private static String publicKeyBase64;
     private static String xyzPublicKeyBase64;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         publicKeyBase64 =
             Base64.getEncoder().encodeToString(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.util;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/FailingInstantDeserialiserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/FailingInstantDeserialiserTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.util;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidDateFormatException;
 
 import java.io.IOException;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/FlywayNoOpStrategyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/FlywayNoOpStrategyTest.java
@@ -4,11 +4,12 @@ import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationInfoService;
 import org.flywaydb.core.api.MigrationState;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.PendingMigrationScriptException;
 
@@ -17,7 +18,8 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.reset;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class FlywayNoOpStrategyTest {
 
     @Mock
@@ -31,7 +33,7 @@ public class FlywayNoOpStrategyTest {
 
     private final FlywayMigrationStrategy strategy = new FlywayNoOpStrategy();
 
-    @After
+    @AfterAll
     public void tearUp() {
         reset(flyway, infoService, info);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/InstantDeserializerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/InstantDeserializerTest.java
@@ -3,9 +3,9 @@ package uk.gov.hmcts.reform.bulkscanprocessor.util;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class InstantDeserializerTest {
 
     private static final StdDeserializer<Instant> DESERIALIZER = InstantDeserializer.INSTANCE;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/OcrDataDeserializerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/OcrDataDeserializerTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataParseException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputOcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputOcrDataField;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeProcessorValidationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeProcessorValidationTest.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ContainerJurisdictionPoBoxMismatchException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DuplicateDocumentControlNumbersInEnvelopeException;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTest.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
@@ -18,7 +18,7 @@ public class MetafileJsonValidatorTest {
 
     private MetafileJsonValidator validator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException, ProcessingException {
         validator = new MetafileJsonValidator();
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/MetafileJsonValidatorTestForInvalidFiles.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidEnvelopeSchemaException;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class MetafileJsonValidatorTestForInvalidFiles {
 
     private MetafileJsonValidator validator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException, ProcessingException {
         validator = new MetafileJsonValidator();
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -2,15 +2,15 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
-import org.junit.Rule;
+import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.web.client.HttpClientErrorException.NotFound;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
@@ -53,8 +53,8 @@ public class OcrValidatorTest {
     private static final String S2S_TOKEN = "sample-s2s-token";
     private static final String PO_BOX = "sample PO box";
 
-    @Rule
-    public OutputCapture outputCapture = new OutputCapture();
+    @RegisterExtension
+    public LogCapturer capturer = LogCapturer.create().captureForType(OcrValidator.class);
 
     @Mock private OcrValidationClient client;
     @Mock private ContainerMappings containerMappings;
@@ -318,7 +318,7 @@ public class OcrValidatorTest {
         ocrValidator.assertOcrDataIsValid(envelope);
 
         // then
-        assertThat(outputCapture.toString()).contains("Multiple documents with OCR");
+        capturer.assertContains("Multiple documents with OCR");
     }
 
     @Test
@@ -338,8 +338,7 @@ public class OcrValidatorTest {
         ocrValidator.assertOcrDataIsValid(envelope);
 
         // then
-        assertThat(outputCapture.toString())
-            .contains("OCR validation URL for po box " + envelope.poBox + " not configured");
+        capturer.assertContains("OCR validation URL for po box " + envelope.poBox + " not configured");
     }
 
     private InputOcrData sampleOcr() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -2,15 +2,14 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.web.client.HttpClientErrorException.NotFound;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
@@ -47,7 +46,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.InputEnvelopeCreator.inputEnvelope;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class OcrValidatorTest {
 
     private static final String VALIDATION_URL = "https://example.com/validate-ocr";
@@ -66,14 +65,9 @@ public class OcrValidatorTest {
 
     private OcrValidator ocrValidator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.ocrValidator = new OcrValidator(client, containerMappings, authTokenGenerator);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        outputCapture.flush();
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

Each commit is conceptually separate. But will not work individually - PR in full is a transition.

Change:

- All annotations refer to new api
- Greenmail extension copied from send letter service
- New dependency to replace `OutputCapture` junit4 rule with junit5 extension
- gradle task moved up to section where testing tasks are defined instead of lingering somewhere at the bottom

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
