### PR TITLE
Update ocr validation response handling

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -156,7 +156,7 @@ variable "allowed_client_certificate_thumbprints" {
 }
 
 variable "ocr_validation_url_bulkscan_sample_app" {
-  default = "https://bulk-scan-sample-app-aat.service.core-compute-aat.internal"
+  default = "http://bulk-scan-sample-app-aat.service.core-compute-aat.internal"
 }
 
 # The value of the parameter 'blob_lease_timeout' should be between 15 and 60 seconds.

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.util.Optionals;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrValidationException;
@@ -101,7 +102,10 @@ public class OcrValidator {
             envelope.zipFileName,
             exc
         );
-        // log error and proceed
+
+        if (exc instanceof NotFound) {
+            throw new OcrValidationException("Unrecognised document subtype " + docWithOcr.documentSubtype);
+        }
     }
 
     private Optional<String> findValidationUrl(String poBox) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -11,6 +11,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings.Mapping;
@@ -209,7 +210,7 @@ public class OcrValidatorTest {
         given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
 
         given(client.validate(any(), any(), any(), any()))
-            .willThrow(new RuntimeException());
+            .willThrow(HttpClientErrorException.NotFound.class);
 
         // when
         Throwable err = catchThrowable(() -> ocrValidator.assertIsValid(envelope));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings.Mapping;
@@ -212,7 +213,7 @@ public class OcrValidatorTest {
         given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
 
         given(client.validate(any(), any(), any(), any()))
-            .willThrow(HttpClientErrorException.NotFound.class);
+            .willThrow(NotFound.class);
 
         // when
         Throwable err = catchThrowable(() -> ocrValidator.assertIsValid(envelope));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -11,7 +11,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.rule.OutputCapture;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpClientErrorException.NotFound;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -189,6 +189,38 @@ public class OcrValidatorTest {
     }
 
     @Test
+    public void should_throw_an_exception_if_service_responded_with_404() {
+        // given
+        String url = "https://example.com/validate-ocr";
+        String subtype = "sample_document_subtype";
+        InputEnvelope envelope = envelope(
+            PO_BOX,
+            asList(
+                doc(subtype, sampleOcr()),
+                doc("other", null)
+            )
+        );
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, url)
+            ));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        given(client.validate(any(), any(), any(), any()))
+            .willThrow(new RuntimeException());
+
+        // when
+        Throwable err = catchThrowable(() -> ocrValidator.assertIsValid(envelope));
+
+
+        // then
+        assertThat(err)
+            .isInstanceOf(OcrValidationException.class);
+    }
+
+    @Test
     public void should_continue_if_calling_validation_endpoint_fails() {
         // given
         InputEnvelope envelope = envelope(


### PR DESCRIPTION
When document subtype is unknows, service will return 404.
Reject such envelopes.