### PR TITLE
Added finger print of new cert as the old cert expired

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -11,7 +11,7 @@ orchestrator_notifications_task_delay = "3000"
 delete_rejected_files_enabled = "true"
 delete_rejected_files_cron = "0 0/10 * * * *"
 
-api_gateway_test_valid_certificate_thumbprint = "C4784AD48B4B99F427D6B56FB38184D0E6457744"
+api_gateway_test_valid_certificate_thumbprint = "344F8D3870B5BAA8CBDCCA0B1993852FC147BF5D"
 allowed_client_certificate_thumbprints = ["4AF638E82FBD9959A5B8286C673360AC2C2E7053"]
 blob_signature_verification_key_file = "nonprod_public_key.der"
 


### PR DESCRIPTION
### Change description ###

- Updated finger print of the new cert. Previous test certificate has been expired now.

- Updated `test-valid-key-store` in `bulk-scan-aat` keyvault.

- Once this PR is merged build should go green.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```