### PR TITLE
Updated fingerprint of new appgw test cert

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -11,7 +11,7 @@ orchestrator_notifications_task_enabled = "true"
 
 delete_rejected_files_enabled = "true"
 
-api_gateway_test_valid_certificate_thumbprint = "3B0D23863EE7EF90290AD02B0ACFD7C37ED5B330"
+api_gateway_test_valid_certificate_thumbprint = "438EBD399DE66D7081CE2CEECEAC8EEF0497FE49"
 allowed_client_certificate_thumbprints = ["919F8A770C2A2F06933BA11551001ED0581B8848"]
 
 blob_processing_delay_in_minutes = "30"


### PR DESCRIPTION
### Change description ###

- Updated finger print of the new cert. Previous test certificate has been expired now.

- Updated `test-valid-key-store` and `test-valid-key-store-password` in `bulk-scan-prod` keyvault.

- Once this PR is merged build should go green.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```