### PR TITLE
Include OCR validation warnings in queue messages

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
@@ -24,6 +24,8 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.OcrField;
 import java.io.InputStream;
 import java.util.UUID;
 
+import static java.util.Collections.singletonList;
+
 @RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
@@ -48,7 +50,12 @@ public class OcrDataSerializationJourneyTest {
         AssertionsForInterfaceTypes.assertThat(inputEnvelope.scannableItems.get(0).ocrData)
             .isInstanceOf(InputOcrData.class);
 
-        Envelope dbEnvelope = EnvelopeMapper.toDbEnvelope(inputEnvelope, "test");
+        Envelope dbEnvelope = EnvelopeMapper.toDbEnvelope(
+            inputEnvelope,
+            "test",
+            singletonList("warning 1")
+        );
+
         UUID envelopeId = repository.saveAndFlush(dbEnvelope).getId();
 
         Envelope readEnvelope = repository.getOne(envelopeId);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
@@ -20,8 +20,10 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.mapper.EnvelopeMapper;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.EnvelopeMsg;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.OcrField;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.model.OcrValidationWarnings;
 
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Collections.singletonList;
@@ -53,7 +55,12 @@ public class OcrDataSerializationJourneyTest {
         Envelope dbEnvelope = EnvelopeMapper.toDbEnvelope(
             inputEnvelope,
             "test",
-            singletonList("warning 1")
+            Optional.of(
+                new OcrValidationWarnings(
+                    inputEnvelope.scannableItems.get(0).documentControlNumber,
+                    singletonList("warning 1")
+                )
+            )
         );
 
         UUID envelopeId = repository.saveAndFlush(dbEnvelope).getId();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
@@ -149,7 +149,8 @@ public class EnvelopeFinaliserServiceTest {
                 "1111001.pdf",
                 "test",
                 DocumentType.CHERISHED,
-                null
+                null,
+                new String[]{"warning 1"}
             );
 
             scannableItem.setDocumentUuid("0fa1ab60-f836-43aa-8c65-b07cc9bebceb");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -135,6 +135,10 @@ public class ServiceBusHelperTest {
         assertThat(jsonNode.get("zip_file_name").textValue()).isEqualTo(message.getZipFileName());
         assertThat(jsonNode.get("classification").textValue()).isEqualTo(message.getClassification().name());
 
+        JsonNode ocrValidationWarnings = jsonNode.get("ocr_validation_warnings");
+        assertThat(ocrValidationWarnings.isArray()).isTrue();
+        assertThat(ocrValidationWarnings.elements()).containsExactly(new TextNode("warning 1"));
+
         assertDateField(jsonNode, "delivery_date", message.getDeliveryDate());
         assertDateField(jsonNode, "opening_date", message.getOpeningDate());
 
@@ -182,6 +186,7 @@ public class ServiceBusHelperTest {
         ));
 
         when(scannableItem1.getOcrData()).thenReturn(ocrData);
+        when(scannableItem1.getOcrValidationWarnings()).thenReturn(new String[]{"warning 1"});
 
         when(scannableItem2.getDocumentUuid()).thenReturn("documentUuid2");
         when(scannableItem2.getDocumentControlNumber()).thenReturn("doc2_control_number");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -193,6 +193,25 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
     }
 
     @Test
+    public void should_store_ocr_validation_warnings_in_the_envelope() throws Exception {
+        // given
+        List<String> ocrValidationWarnings = ImmutableList.of("warning 1", "warning 2");
+        given(ocrValidator.assertIsValid(any())).willReturn(ocrValidationWarnings);
+
+        uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));
+
+        // when
+        processor.processBlobs();
+
+        // then
+        Envelope envelope = getSingleEnvelopeFromDb();
+
+        assertThat(envelope.getScannableItems().size()).isEqualTo(1);
+        assertThat(envelope.getScannableItems().get(0).getOcrValidationWarnings())
+            .hasSameElementsAs(ocrValidationWarnings);
+    }
+
+    @Test
     public void should_keep_zip_file_after_unsuccessful_upload_and_not_create_doc_processed_event() throws Exception {
         // given
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -18,9 +18,11 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnableToUploadDocumentEx
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.model.OcrValidationWarnings;
 
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
@@ -195,8 +197,12 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
     @Test
     public void should_store_ocr_validation_warnings_in_the_envelope() throws Exception {
         // given
-        List<String> ocrValidationWarnings = ImmutableList.of("warning 1", "warning 2");
-        given(ocrValidator.assertIsValid(any())).willReturn(ocrValidationWarnings);
+        OcrValidationWarnings ocrValidationWarnings = new OcrValidationWarnings(
+            "1111002",
+            ImmutableList.of("warning 1", "warning 2")
+        );
+
+        given(ocrValidator.assertOcrDataIsValid(any())).willReturn(Optional.of(ocrValidationWarnings));
 
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));
 
@@ -208,7 +214,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
 
         assertThat(envelope.getScannableItems().size()).isEqualTo(1);
         assertThat(envelope.getScannableItems().get(0).getOcrValidationWarnings())
-            .hasSameElementsAs(ocrValidationWarnings);
+            .hasSameElementsAs(ocrValidationWarnings.warnings);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
@@ -65,7 +65,7 @@ public class ScannableItem implements EnvelopeAssignable {
     private Envelope envelope;
 
     @Type(type = "string-array")
-    @Column(name = "validationWarnings", columnDefinition = "varchar[]")
+    @Column(name = "ocrValidationWarnings", columnDefinition = "varchar[]")
     private String[] ocrValidationWarnings;
 
     private ScannableItem() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItem.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
+import com.vladmihalcea.hibernate.type.array.StringArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
 
@@ -21,7 +23,10 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "scannable_items")
-@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+@TypeDefs({
+    @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class),
+    @TypeDef(name = "string-array", typeClass = StringArrayType.class)
+})
 public class ScannableItem implements EnvelopeAssignable {
 
     @Id
@@ -59,6 +64,10 @@ public class ScannableItem implements EnvelopeAssignable {
     @JoinColumn(name = "envelope_id", nullable = false)
     private Envelope envelope;
 
+    @Type(type = "string-array")
+    @Column(name = "validationWarnings", columnDefinition = "varchar[]")
+    private String[] ocrValidationWarnings;
+
     private ScannableItem() {
         // For use by hibernate.
     }
@@ -74,7 +83,8 @@ public class ScannableItem implements EnvelopeAssignable {
         String fileName,
         String notes,
         DocumentType documentType,
-        String documentSubtype
+        String documentSubtype,
+        String[] ocrValidationWarnings
     ) {
         this.documentControlNumber = documentControlNumber;
         this.scanningDate = scanningDate;
@@ -87,6 +97,7 @@ public class ScannableItem implements EnvelopeAssignable {
         this.notes = notes;
         this.documentType = documentType;
         this.documentSubtype = documentSubtype;
+        this.ocrValidationWarnings = ocrValidationWarnings;
     }
 
     public UUID getId() {
@@ -152,5 +163,9 @@ public class ScannableItem implements EnvelopeAssignable {
     @Override
     public void setEnvelope(Envelope envelope) {
         this.envelope = envelope;
+    }
+
+    public String[] getOcrValidationWarnings() {
+        return ocrValidationWarnings;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
@@ -36,7 +36,11 @@ public class EnvelopeMapper {
         // utility class
     }
 
-    public static Envelope toDbEnvelope(InputEnvelope envelope, String containerName) {
+    public static Envelope toDbEnvelope(
+        InputEnvelope envelope,
+        String containerName,
+        List<String> ocrValidationWarnings
+    ) {
         return new Envelope(
             envelope.poBox,
             envelope.jurisdiction,
@@ -47,25 +51,35 @@ public class EnvelopeMapper {
             envelope.caseNumber,
             envelope.previousServiceCaseReference,
             envelope.classification,
-            toDbScannableItems(envelope.scannableItems),
+            toDbScannableItems(envelope.scannableItems, ocrValidationWarnings),
             toDbPayments(envelope.payments),
             toDbNonScannableItems(envelope.nonScannableItems),
             containerName
         );
     }
 
-    private static List<ScannableItem> toDbScannableItems(List<InputScannableItem> scannableItems) {
+    private static List<ScannableItem> toDbScannableItems(
+        List<InputScannableItem> scannableItems,
+        List<String> ocrValidationWarnings
+    ) {
         if (scannableItems != null) {
             return scannableItems
                 .stream()
-                .map(EnvelopeMapper::toDbScannableItem)
+                .map(item ->
+                    toDbScannableItem(
+                        item,
+                        item.ocrData != null ? ocrValidationWarnings.toArray(new String[0]) : null
+                    ))
                 .collect(toList());
         } else {
             return emptyList();
         }
     }
 
-    public static ScannableItem toDbScannableItem(InputScannableItem scannableItem) {
+    public static ScannableItem toDbScannableItem(
+        InputScannableItem scannableItem,
+        String[] ocrValidationWarnings
+    ) {
         return new ScannableItem(
             scannableItem.documentControlNumber,
             scannableItem.scanningDate,
@@ -77,7 +91,8 @@ public class EnvelopeMapper {
             scannableItem.fileName,
             scannableItem.notes,
             mapDocumentType(scannableItem.documentType),
-            extractDocumentSubtype(scannableItem.documentType, scannableItem.documentSubtype)
+            extractDocumentSubtype(scannableItem.documentType, scannableItem.documentSubtype),
+            ocrValidationWarnings
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrDataField;
@@ -10,6 +11,8 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrDataField;
 import java.time.Instant;
 import java.util.List;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 
@@ -51,6 +54,9 @@ public class EnvelopeMsg implements Msg {
     @JsonProperty("ocr_data")
     private final List<OcrField> ocrData;
 
+    @JsonProperty("ocr_validation_warnings")
+    private final List<String> ocrValidationWarnings;
+
     private final boolean testOnly;
 
     public EnvelopeMsg(Envelope envelope) {
@@ -72,6 +78,7 @@ public class EnvelopeMsg implements Msg {
             .collect(toList());
 
         this.ocrData = retrieveOcrData(envelope);
+        this.ocrValidationWarnings = retrieveOcrValidationWarnings(envelope);
     }
 
     @Override
@@ -137,6 +144,17 @@ public class EnvelopeMsg implements Msg {
             + "testOnly='" + testOnly + "'"
             + "zipFileName='" + zipFileName + "'"
             + "}";
+    }
+
+    private List<String> retrieveOcrValidationWarnings(Envelope envelope) {
+        return envelope
+            .getScannableItems()
+            .stream()
+            .map(ScannableItem::getOcrValidationWarnings)
+            .filter(warnings -> warnings != null && warnings.length > 0)
+            .map(warnings -> asList(warnings))
+            .findFirst()
+            .orElse(emptyList());
     }
 
     private List<OcrField> retrieveOcrData(Envelope envelope) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
@@ -9,7 +9,9 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrDataField;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -147,24 +149,28 @@ public class EnvelopeMsg implements Msg {
     }
 
     private List<String> retrieveOcrValidationWarnings(Envelope envelope) {
-        return envelope
-            .getScannableItems()
-            .stream()
-            .map(ScannableItem::getOcrValidationWarnings)
-            .filter(warnings -> warnings != null && warnings.length > 0)
-            .map(warnings -> asList(warnings))
+        return findScannableItemsWithOcrData(envelope)
+            .map(item ->
+                item.getOcrValidationWarnings() != null
+                    ? asList(item.getOcrValidationWarnings())
+                    : Collections.<String>emptyList()
+            )
             .findFirst()
             .orElse(emptyList());
     }
 
     private List<OcrField> retrieveOcrData(Envelope envelope) {
-        return envelope
-            .getScannableItems()
-            .stream()
-            .filter(si -> si.getOcrData() != null)
+        return findScannableItemsWithOcrData(envelope)
             .map(item -> convertFromInputOcrData(item.getOcrData()))
             .findFirst()
             .orElse(null);
+    }
+
+    private Stream<ScannableItem> findScannableItemsWithOcrData(Envelope envelope) {
+        return envelope
+            .getScannableItems()
+            .stream()
+            .filter(si -> si.getOcrData() != null);
     }
 
     private List<OcrField> convertFromInputOcrData(OcrData inputOcrData) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -37,6 +37,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipFileProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipVerifiers;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.EnvelopeValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.model.OcrValidationWarnings;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -289,7 +290,7 @@ public class BlobProcessorTask extends Processor {
 
             envelopeProcessor.assertDidNotFailToUploadBefore(envelope.zipFileName, containerName);
 
-            List<String> ocrValidationWarnings = this.ocrValidator.assertIsValid(envelope);
+            Optional<OcrValidationWarnings> ocrValidationWarnings = this.ocrValidator.assertOcrDataIsValid(envelope);
 
             Envelope dbEnvelope = toDbEnvelope(envelope, containerName, ocrValidationWarnings);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -286,11 +286,14 @@ public class BlobProcessorTask extends Processor {
             EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope);
             EnvelopeValidator.assertEnvelopeHasPdfs(envelope, result.getPdfs());
             EnvelopeValidator.assertDocumentControlNumbersAreUnique(envelope);
-            this.ocrValidator.assertIsValid(envelope);
 
             envelopeProcessor.assertDidNotFailToUploadBefore(envelope.zipFileName, containerName);
 
-            result.setEnvelope(envelopeProcessor.saveEnvelope(toDbEnvelope(envelope, containerName)));
+            List<String> ocrValidationWarnings = this.ocrValidator.assertIsValid(envelope);
+
+            Envelope dbEnvelope = toDbEnvelope(envelope, containerName, ocrValidationWarnings);
+
+            result.setEnvelope(envelopeProcessor.saveEnvelope(dbEnvelope));
 
             return result;
         } catch (InvalidEnvelopeException ex) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/model/OcrValidationWarnings.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/model/OcrValidationWarnings.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.validation.model;
+
+import java.util.List;
+
+public class OcrValidationWarnings {
+
+    public final String documentControlNumber;
+    public final List<String> warnings;
+
+    public OcrValidationWarnings(String documentControlNumber, List<String> warnings) {
+        this.documentControlNumber = documentControlNumber;
+        this.warnings = warnings;
+    }
+}

--- a/src/main/resources/db/migration/V044__Add_validation_warnings_column.sql
+++ b/src/main/resources/db/migration/V044__Add_validation_warnings_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scannable_items
+ADD COLUMN ocrValidationWarnings VARCHAR(5000)[] NULL;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -167,7 +167,8 @@ public final class EnvelopeCreator {
             dcn + ".pdf",
             "test",
             documentType,
-            documentSubtype
+            documentSubtype,
+            new String[]{"warning 1"}
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/SubtypeTest.java
@@ -48,7 +48,7 @@ public class SubtypeTest {
             InputScannableItem item = inputScannableItem(tc.input.documentType, tc.input.docSubtype);
 
             // when
-            ScannableItem result = EnvelopeMapper.toDbScannableItem(item);
+            ScannableItem result = EnvelopeMapper.toDbScannableItem(item, null);
 
             // then
             softly.assertThat(result.getDocumentType())

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -44,7 +44,8 @@ public class DocumentTest {
             "fileName1.pdf",
             "notes 1",
             documentType,
-            DocumentSubtype.SSCS1
+            DocumentSubtype.SSCS1,
+            new String[]{"warning 1"}
         );
 
         scannableItem.setDocumentUuid("5fef5f98-e875-4084-b115-47188bc9066b");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/tasks/processor/DocumentProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/tasks/processor/DocumentProcessorTest.java
@@ -114,6 +114,7 @@ public class DocumentProcessorTest {
             fileName,
             null,
             null,
+            null,
             null
         );
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-759

### Change description ###

Include OCR validation warnings in queue messages. This involves storing those warnings together with the envelope.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
