### PR TITLE
Fix auth header for ocr validation calls

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/OcrValidationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/OcrValidationClientTest.java
@@ -54,7 +54,7 @@ public class OcrValidationClientTest {
         String s2sToken = randomUUID().toString();
         stubFor(
             post(urlPathMatching("/forms/D8/validate-ocr"))
-                .withHeader("ServiceAuthorization", equalTo("Bearer " + s2sToken))
+                .withHeader("ServiceAuthorization", equalTo(s2sToken))
                 .willReturn(okJson(jsonify(
                     "      {"
                         + "  'status': 'ERRORS',"
@@ -79,7 +79,7 @@ public class OcrValidationClientTest {
         String s2sToken = randomUUID().toString();
         stubFor(
             post(urlPathMatching("/forms/A1/validate-ocr"))
-                .withHeader("ServiceAuthorization", equalTo("Bearer " + s2sToken))
+                .withHeader("ServiceAuthorization", equalTo(s2sToken))
                 .willReturn(okJson(jsonify(
                     "      {"
                         + "  'status': 'SUCCESS',"
@@ -104,7 +104,7 @@ public class OcrValidationClientTest {
         String s2sToken = randomUUID().toString();
         stubFor(
             post(urlPathMatching("/forms/XY/validate-ocr"))
-                .withHeader("ServiceAuthorization", equalTo("Bearer " + s2sToken))
+                .withHeader("ServiceAuthorization", equalTo(s2sToken))
                 .willReturn(okJson(jsonify(
                     "      {"
                         + "  'status': 'WARNINGS',"

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/client/OcrValidationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/client/OcrValidationClient.java
@@ -36,7 +36,7 @@ public class OcrValidationClient {
         String s2sToken
     ) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("ServiceAuthorization", "Bearer " + s2sToken);
+        headers.add("ServiceAuthorization", s2sToken);
 
         String url =
             UriComponentsBuilder


### PR DESCRIPTION
Token returned from s2s token generator already contains the 'Bearer ' prefix