### PR TITLE
Reject envelope when JsonMappingException is thrown when parsing metadata file

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataParseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataParseException.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
-public class OcrDataParseException extends InvalidEnvelopeException {
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
-    public OcrDataParseException(String message, Throwable cause) {
-        super(message, cause);
+public class OcrDataParseException extends JsonMappingException {
+
+    public OcrDataParseException(JsonParser jsonParser, String message, Throwable cause) {
+        super(jsonParser, message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataParseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrDataParseException.java
@@ -3,6 +3,14 @@ package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
+/**
+ * Represents a situation where OCR data format is invalid.
+ *
+ * <p>
+ * Needs to extend JsonMappingException, so that we can catch it - otherwise
+ * Jackson would wrap it in its own exception when parsing metadata file.
+ * </p>
+ */
 public class OcrDataParseException extends JsonMappingException {
 
     public OcrDataParseException(JsonParser jsonParser, String message, Throwable cause) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
@@ -64,7 +65,7 @@ public class EnvelopeProcessor {
             schemaValidator.validate(metadataStream, zipFileName);
 
             return schemaValidator.parseMetafile(metadataStream);
-        } catch (JsonParseException exception) {
+        } catch (JsonParseException | JsonMappingException exception) {
             // invalid json files should also be reported to provider
             throw new InvalidEnvelopeSchemaException("Error occurred while parsing metafile", exception);
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/EnvelopeProcessor.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
@@ -18,6 +17,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DuplicateDocumentControlNumberException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidEnvelopeSchemaException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.MetadataNotFoundException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataParseException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.PreviouslyFailedToUploadException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
@@ -65,7 +65,7 @@ public class EnvelopeProcessor {
             schemaValidator.validate(metadataStream, zipFileName);
 
             return schemaValidator.parseMetafile(metadataStream);
-        } catch (JsonParseException | JsonMappingException exception) {
+        } catch (JsonParseException | OcrDataParseException exception) {
             // invalid json files should also be reported to provider
             throw new InvalidEnvelopeSchemaException("Error occurred while parsing metafile", exception);
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/OcrDataDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/OcrDataDeserializer.java
@@ -22,11 +22,11 @@ public class OcrDataDeserializer extends StdDeserializer<InputOcrData> {
     public InputOcrData deserialize(
         JsonParser jsonParser,
         DeserializationContext deserializationContext
-    ) {
+    ) throws OcrDataParseException {
         try {
             return parseOcrData(jsonParser.getText());
         } catch (Exception ex) {
-            throw new OcrDataParseException("Failed to parse OCR data", ex);
+            throw new OcrDataParseException(jsonParser, "Failed to parse OCR data", ex);
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-769

### Change description ###

Reject envelope when JsonMappingException is thrown when parsing metadata file. This happens when custom deserialisers fail.

The affected class is completely untested - created a separate story for it: https://tools.hmcts.net/jira/browse/BPS-770

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
