### PR TITLE
Added mapping for ocr validation exception

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/errornotifications/ErrorMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/errornotifications/ErrorMapping.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.MetadataNotFoundExceptio
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.NonPdfFileFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataParseException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrValidationException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 
 import java.util.Map;
@@ -37,6 +38,7 @@ public final class ErrorMapping {
             .put(OcrDataParseException.class, ERR_METAFILE_INVALID)
             .put(MetadataNotFoundException.class, ERR_ZIP_PROCESSING_FAILED)
             .put(ContainerJurisdictionPoBoxMismatchException.class, ERR_METAFILE_INVALID)
+            .put(OcrValidationException.class, ERR_METAFILE_INVALID)
             .build();
 
     private ErrorMapping() {


### PR DESCRIPTION

### Change description ###

-  Whenever `OcrValidationException` was thrown by ocr validator blob processor task would skip the sending notification to the queue.

- We should probably change the implementation such that either error code is part of exception or we fail the processing or set some generic error code when mapping is not found(need to discuss with team)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```