### PR TITLE
Validate OCR presence

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -44,6 +44,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
 import java.io.File;
@@ -103,6 +104,9 @@ public class EnvelopeControllerTest {
     private DocumentManagementService documentManagementService;
 
     @Mock
+    private OcrPresenceValidator ocrPresenceValidator;
+
+    @Mock
     private OcrValidator ocrValidator;
 
     @Mock
@@ -155,6 +159,7 @@ public class EnvelopeControllerTest {
             envelopeRepository,
             processEventRepository,
             containerMappings,
+            ocrPresenceValidator,
             ocrValidator,
             serviceBusHelper,
             "none",

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
 import java.io.File;
@@ -84,6 +85,9 @@ public abstract class ProcessorTestSuite<T extends Processor> {
     protected DocumentManagementService documentManagementService;
 
     @Mock
+    protected OcrPresenceValidator ocrPresenceValidator;
+
+    @Mock
     protected OcrValidator ocrValidator;
 
     @Mock
@@ -121,6 +125,7 @@ public abstract class ProcessorTestSuite<T extends Processor> {
             envelopeRepository,
             processEventRepository,
             containerMappings,
+            ocrPresenceValidator,
             ocrValidator,
             serviceBusHelper,
             SIGNATURE_ALGORITHM,
@@ -198,6 +203,7 @@ public abstract class ProcessorTestSuite<T extends Processor> {
             EnvelopeRepository envelopeRepository,
             ProcessEventRepository processEventRepository,
             ContainerMappings containerMappings,
+            OcrPresenceValidator ocrPresenceValidator,
             OcrValidator ocrValidator,
             ServiceBusHelper serviceBusHelper,
             String signatureAlg,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -47,6 +47,7 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
             envelopeRepository,
             processEventRepository,
             containerMappings,
+            ocrPresenceValidator,
             ocrValidator,
             serviceBusHelper,
             SIGNATURE_ALGORITHM,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrPresenceException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrPresenceException.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
-public class OcrPresenceException extends InvalidEnvelopeException{
+public class OcrPresenceException extends InvalidEnvelopeException {
     public OcrPresenceException(String message) {
         super(message);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrPresenceException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrPresenceException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class OcrPresenceException extends InvalidEnvelopeException{
+    public OcrPresenceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/errornotifications/ErrorMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/errornotifications/ErrorMapping.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.MetadataNotFoundExceptio
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.NonPdfFileFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrDataParseException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrPresenceException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrValidationException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 
@@ -39,6 +40,7 @@ public final class ErrorMapping {
             .put(MetadataNotFoundException.class, ERR_ZIP_PROCESSING_FAILED)
             .put(ContainerJurisdictionPoBoxMismatchException.class, ERR_METAFILE_INVALID)
             .put(OcrValidationException.class, ERR_METAFILE_INVALID)
+            .put(OcrPresenceException.class, ERR_METAFILE_INVALID)
             .build();
 
     private ErrorMapping() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocSignatureFailureExcep
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.ServiceBusHelper;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.Processor;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
 import java.io.IOException;
@@ -56,6 +57,7 @@ public class FailedDocUploadProcessor extends Processor {
         EnvelopeRepository envelopeRepository,
         ProcessEventRepository eventRepository,
         ContainerMappings containerMappings, // NOSONAR
+        OcrPresenceValidator ocrPresenceValidator, // NOSONAR
         OcrValidator ocrValidator, // NOSONAR
         ServiceBusHelper serviceBusHelper, // NOSONAR
         String signatureAlg,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidator.java
@@ -14,7 +14,7 @@ public class OcrPresenceValidator {
 
     public static final String MULTIPLE_OCR_MSG = "Multiple docs with OCR";
     public static final String MISSING_OCR_MSG = "Empty OCR on 'form' document";
-    public static final String MISPLACED_OCR = "OCR on document of invalid type";
+    public static final String MISPLACED_OCR_MSG = "OCR on document of invalid type";
 
     /**
      * Checks whether OCR data is on the correct document.
@@ -24,7 +24,7 @@ public class OcrPresenceValidator {
     public Optional<InputScannableItem> assertHasProperlySetOcr(List<InputScannableItem> docs) {
 
         throwIf(docs.stream().filter(it -> it.ocrData != null).count() > 1, MULTIPLE_OCR_MSG);
-        throwIf(docs.stream().anyMatch(it -> it.documentType != FORM && it.ocrData != null), MISPLACED_OCR);
+        throwIf(docs.stream().anyMatch(it -> it.documentType != FORM && it.ocrData != null), MISPLACED_OCR_MSG);
         throwIf(docs.stream().anyMatch(it -> it.documentType == FORM && it.ocrData == null), MISSING_OCR_MSG);
 
         return docs

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidator.java
@@ -23,9 +23,9 @@ public class OcrPresenceValidator {
      */
     public Optional<InputScannableItem> assertHasProperlySetOcr(List<InputScannableItem> docs) {
 
-        check(docs.stream().filter(it -> it.ocrData != null).count() > 1, MULTIPLE_OCR_MSG);
-        check(docs.stream().filter(it -> it.documentType != FORM).anyMatch(it -> it.ocrData != null), MISPLACED_OCR);
-        check(docs.stream().filter(it -> it.documentType == FORM).anyMatch(it -> it.ocrData == null), MISSING_OCR_MSG);
+        throwIf(docs.stream().filter(it -> it.ocrData != null).count() > 1, MULTIPLE_OCR_MSG);
+        throwIf(docs.stream().anyMatch(it -> it.documentType != FORM && it.ocrData != null), MISPLACED_OCR);
+        throwIf(docs.stream().anyMatch(it -> it.documentType == FORM && it.ocrData == null), MISSING_OCR_MSG);
 
         return docs
             .stream()
@@ -33,13 +33,9 @@ public class OcrPresenceValidator {
             .findFirst();
     }
 
-    private void check(boolean condition, String msg) {
+    private void throwIf(boolean condition, String msg) {
         if (condition) {
             throw new OcrPresenceException(msg);
         }
-    }
-
-    static class ErrorMessages {
-
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidator.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.validation;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrPresenceException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputScannableItem;
+
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.FORM;
+
+@Component
+public class OcrPresenceValidator {
+
+    public static final String MULTIPLE_OCR_MSG = "Multiple docs with OCR";
+    public static final String MISSING_OCR_MSG = "Empty OCR on 'form' document";
+    public static final String MISPLACED_OCR = "OCR on document of invalid type";
+
+    /**
+     * Checks whether OCR data is on the correct document.
+     *
+     * @return Document with OCR.
+     */
+    public Optional<InputScannableItem> assertHasProperlySetOcr(List<InputScannableItem> docs) {
+
+        check(docs.stream().filter(it -> it.ocrData != null).count() > 1, MULTIPLE_OCR_MSG);
+        check(docs.stream().filter(it -> it.documentType != FORM).anyMatch(it -> it.ocrData != null), MISPLACED_OCR);
+        check(docs.stream().filter(it -> it.documentType == FORM).anyMatch(it -> it.ocrData == null), MISSING_OCR_MSG);
+
+        return docs
+            .stream()
+            .filter(it -> it.ocrData != null)
+            .findFirst();
+    }
+
+    private void check(boolean condition, String msg) {
+        if (condition) {
+            throw new OcrPresenceException(msg);
+        }
+    }
+
+    static class ErrorMessages {
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidatorTest.java
@@ -88,7 +88,7 @@ public class OcrPresenceValidatorTest {
     }
 
     @Test
-    public void should_return_empty_optional_if_there_are_not_docs_with_ocr() {
+    public void should_return_empty_optional_if_there_are_no_docs_with_ocr() {
         // given
         List<InputScannableItem> docs =
             asList(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidatorTest.java
@@ -1,0 +1,122 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.validation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrPresenceException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputOcrData;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputScannableItem;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.CHERISHED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.FORM;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType.OTHER;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OcrPresenceValidatorTest {
+
+    private final OcrPresenceValidator validator = new OcrPresenceValidator();
+
+    @Test
+    public void should_throw_exception_if_multiple_docs_contain_ocr() {
+        assertThatThrownBy(
+            () -> validator.assertHasProperlySetOcr(
+                asList(
+                    doc(FORM, new InputOcrData()),
+                    doc(OTHER, new InputOcrData()),
+                    doc(OTHER, null),
+                    doc(CHERISHED, null)
+                )
+            ))
+            .isInstanceOf(OcrPresenceException.class)
+            .hasMessage(OcrPresenceValidator.MULTIPLE_OCR_MSG);
+    }
+
+    @Test
+    public void should_throw_an_exception_when_form_has_no_ocr() {
+        assertThatThrownBy(
+            () -> validator.assertHasProperlySetOcr(
+                asList(
+                    doc(FORM, null),
+                    doc(OTHER, null),
+                    doc(OTHER, null),
+                    doc(CHERISHED, null)
+                )
+            ))
+            .isInstanceOf(OcrPresenceException.class)
+            .hasMessage(OcrPresenceValidator.MISSING_OCR_MSG);
+    }
+
+    @Test
+    public void should_throw_an_exception_when_a_doc_that_is_not_form_has_ocr() {
+        assertThatThrownBy(
+            () -> validator.assertHasProperlySetOcr(
+                asList(
+                    doc(FORM, null),
+                    doc(OTHER, new InputOcrData()),
+                    doc(OTHER, null),
+                    doc(CHERISHED, null)
+                )
+            ))
+            .isInstanceOf(OcrPresenceException.class)
+            .hasMessage(OcrPresenceValidator.MISPLACED_OCR);
+    }
+
+    @Test
+    public void should_return_document_with_ocr() {
+        // given
+        InputScannableItem docWithOcr = doc(FORM, new InputOcrData());
+        List<InputScannableItem> docs =
+            asList(
+                docWithOcr,
+                doc(OTHER, null),
+                doc(OTHER, null),
+                doc(CHERISHED, null)
+            );
+
+        // when
+        Optional<InputScannableItem> result = validator.assertHasProperlySetOcr(docs);
+
+        // then
+        assertThat(result).get().isEqualTo(docWithOcr);
+    }
+
+    @Test
+    public void should_return_empty_optional_if_there_are_not_docs_with_ocr() {
+        // given
+        List<InputScannableItem> docs =
+            asList(
+                doc(OTHER, null),
+                doc(OTHER, null),
+                doc(CHERISHED, null)
+            );
+
+        // when
+        Optional<InputScannableItem> result = validator.assertHasProperlySetOcr(docs);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private InputScannableItem doc(InputDocumentType type, InputOcrData ocr) {
+        return new InputScannableItem(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            ocr,
+            null,
+            null,
+            type,
+            null
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrPresenceValidatorTest.java
@@ -65,7 +65,7 @@ public class OcrPresenceValidatorTest {
                 )
             ))
             .isInstanceOf(OcrPresenceException.class)
-            .hasMessage(OcrPresenceValidator.MISPLACED_OCR);
+            .hasMessage(OcrPresenceValidator.MISPLACED_OCR_MSG);
     }
 
     @Test


### PR DESCRIPTION
TODO: pass doc with OCR to `OcrValidator` (currently it finds the document to validate in envelope)