### PR TITLE
Allow `null` value as `document_sub_type` as input

### DIFF
--- a/src/main/resources/metafile-schema.json
+++ b/src/main/resources/metafile-schema.json
@@ -131,7 +131,7 @@
           },
           "document_sub_type": {
             "id": "#/properties/scannable_items/items/properties/document_sub_type",
-            "type": "string"
+            "type": ["string", "null"]
           }
         },
         "required": [

--- a/src/test/resources/metafiles/valid/from-spec.json
+++ b/src/test/resources/metafiles/valid/from-spec.json
@@ -28,7 +28,8 @@
       "next_action_date": "2017-02-25T00:00:00.000Z",
       "file_name": "1111002.pdf",
       "notes": "Cheque will be forwarded to court to bank it",
-      "document_type": "Other"
+      "document_type": "Other",
+      "document_sub_type": null
     },
     {
       "document_control_number": "1111003",


### PR DESCRIPTION
### Change description ###

Just including sneaky `null` in one of the metafiles. Unit tests pass. Verified such situation

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
