### PR TITLE
Move ocr presence validator to ocr validator

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -44,7 +44,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
-import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
 import java.io.File;
@@ -104,9 +103,6 @@ public class EnvelopeControllerTest {
     private DocumentManagementService documentManagementService;
 
     @Mock
-    private OcrPresenceValidator ocrPresenceValidator;
-
-    @Mock
     private OcrValidator ocrValidator;
 
     @Mock
@@ -159,7 +155,6 @@ public class EnvelopeControllerTest {
             envelopeRepository,
             processEventRepository,
             containerMappings,
-            ocrPresenceValidator,
             ocrValidator,
             serviceBusHelper,
             "none",

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
-import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
 import java.io.File;
@@ -85,9 +84,6 @@ public abstract class ProcessorTestSuite<T extends Processor> {
     protected DocumentManagementService documentManagementService;
 
     @Mock
-    protected OcrPresenceValidator ocrPresenceValidator;
-
-    @Mock
     protected OcrValidator ocrValidator;
 
     @Mock
@@ -125,7 +121,6 @@ public abstract class ProcessorTestSuite<T extends Processor> {
             envelopeRepository,
             processEventRepository,
             containerMappings,
-            ocrPresenceValidator,
             ocrValidator,
             serviceBusHelper,
             SIGNATURE_ALGORITHM,
@@ -203,7 +198,6 @@ public abstract class ProcessorTestSuite<T extends Processor> {
             EnvelopeRepository envelopeRepository,
             ProcessEventRepository processEventRepository,
             ContainerMappings containerMappings,
-            OcrPresenceValidator ocrPresenceValidator,
             OcrValidator ocrValidator,
             ServiceBusHelper serviceBusHelper,
             String signatureAlg,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessorTest.java
@@ -47,7 +47,6 @@ public class FailedDocUploadProcessorTest extends ProcessorTestSuite<FailedDocUp
             envelopeRepository,
             processEventRepository,
             containerMappings,
-            ocrPresenceValidator,
             ocrValidator,
             serviceBusHelper,
             SIGNATURE_ALGORITHM,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -36,7 +36,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipFileProcessingRe
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipFileProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipVerifiers;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.EnvelopeValidator;
-import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.model.OcrValidationWarnings;
 
@@ -81,8 +80,6 @@ public class BlobProcessorTask extends Processor {
 
     protected final ContainerMappings containerMappings;
 
-    private final OcrPresenceValidator ocrPresenceValidator;
-
     private final OcrValidator ocrValidator;
 
     @SuppressWarnings("squid:S00107")
@@ -94,14 +91,12 @@ public class BlobProcessorTask extends Processor {
         EnvelopeRepository envelopeRepository,
         ProcessEventRepository eventRepository,
         ContainerMappings containerMappings,
-        OcrPresenceValidator ocrPresenceValidator,
         OcrValidator ocrValidator,
         @Qualifier("notifications-helper") ServiceBusHelper notificationsQueueHelper
     ) {
         super(blobManager, documentProcessor, envelopeProcessor, envelopeRepository, eventRepository);
         this.notificationsQueueHelper = notificationsQueueHelper;
         this.containerMappings = containerMappings;
-        this.ocrPresenceValidator = ocrPresenceValidator;
         this.ocrValidator = ocrValidator;
     }
 
@@ -115,7 +110,6 @@ public class BlobProcessorTask extends Processor {
         EnvelopeRepository envelopeRepository,
         ProcessEventRepository eventRepository,
         ContainerMappings containerMappings,
-        OcrPresenceValidator ocrPresenceValidator,
         OcrValidator ocrValidator,
         @Qualifier("notifications-helper") ServiceBusHelper notificationsQueueHelper,
         String signatureAlg,
@@ -128,7 +122,6 @@ public class BlobProcessorTask extends Processor {
             envelopeRepository,
             eventRepository,
             containerMappings,
-            ocrPresenceValidator,
             ocrValidator,
             notificationsQueueHelper
         );
@@ -296,8 +289,6 @@ public class BlobProcessorTask extends Processor {
             EnvelopeValidator.assertDocumentControlNumbersAreUnique(envelope);
 
             envelopeProcessor.assertDidNotFailToUploadBefore(envelope.zipFileName, containerName);
-
-            ocrPresenceValidator.assertHasProperlySetOcr(envelope.scannableItems);
 
             Optional<OcrValidationWarnings> ocrValidationWarnings = this.ocrValidator.assertOcrDataIsValid(envelope);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/FailedDocUploadProcessor.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocSignatureFailureExcep
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.ServiceBusHelper;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.Processor;
-import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
 import java.io.IOException;
@@ -57,7 +56,6 @@ public class FailedDocUploadProcessor extends Processor {
         EnvelopeRepository envelopeRepository,
         ProcessEventRepository eventRepository,
         ContainerMappings containerMappings, // NOSONAR
-        OcrPresenceValidator ocrPresenceValidator, // NOSONAR
         OcrValidator ocrValidator, // NOSONAR
         ServiceBusHelper serviceBusHelper, // NOSONAR
         String signatureAlg,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 @Component


### PR DESCRIPTION
Extracting doc with OCR now happens in single place.
Also removes obsolete warning logging about multiple docs with OCR (as such envelopes get rejected now)