### PR TITLE
Updated location of servicebus due to issues in uksouth region

### DIFF
--- a/charts/bulk-scan-processor/values.preview.template.yaml
+++ b/charts/bulk-scan-processor/values.preview.template.yaml
@@ -53,7 +53,7 @@ servicebus:
 blobstorage:
   resourceGroup: bulk-scan-aks
   teamName: "Software Engineering"
-  location: uksouth
+  location: ukwest
   setup:
     containers:
       - bulkscan


### PR DESCRIPTION
- Currently creating namespace in uksouth throws back an error. Hence changed the location for now to use ukwest.

- Raised a support ticket with MS for the issue.