### PR TITLE
Bump `checkstyle` to 8.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ task apiGateway(type: Test) {
 
 checkstyle {
   maxWarnings = 0
-  toolVersion = '8.21'
+  toolVersion = '8.24'
   // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
   configDir = new File(rootDir, 'config/checkstyle')
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -5,7 +5,7 @@
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
-    that can be found at https://google.github.io/styleguide/javaguide.html
+    that can be found at https://google.github.io/styleguide/javaguide.html.
 
     Checkstyle is very configurable. Be sure to read the documentation at
     http://checkstyle.sf.net (or in your downloaded distribution).
@@ -32,6 +32,11 @@
     <property name="eachLine" value="true"/>
   </module>
 
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="120"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
   <module name="SuppressWarningsFilter" />
   <module name="TreeWalker">
     <module name="UnusedImports"/>
@@ -49,10 +54,6 @@
       <property name="allowEscapesForControlCharacters" value="true"/>
       <property name="allowByTailComment" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
-    </module>
-    <module name="LineLength">
-      <property name="max" value="120"/>
-      <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>
@@ -229,6 +230,7 @@
       <property name="allowSamelineMultipleAnnotations" value="true"/>
     </module>
     <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"


### PR DESCRIPTION
### Change description ###

Use same config as orchestrator, ref hmcts/bulk-scan-orchestrator#546

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
