### PR TITLE
Remove `microserviceName` from terraform output file

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -2,10 +2,6 @@ output "app_namespace" {
   value = "${var.deployment_namespace}"
 }
 
-output "microserviceName" {
-  value = "${var.component}"
-}
-
 output "TEST_REUPLOAD_DELAY" {
   value = "${var.reupload_delay}"
 }


### PR DESCRIPTION
### Change description ###

The use of `microserviceName` is not recommended and deprecated. Direct use of `var.component` is in place instead

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
