### PR TITLE
Add document subtype to the queue message

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrDataField;
@@ -134,6 +135,7 @@ public class ServiceBusHelperTest {
         assertThat(jsonNode.get("container").textValue()).isEqualTo(message.getContainer());
         assertThat(jsonNode.get("zip_file_name").textValue()).isEqualTo(message.getZipFileName());
         assertThat(jsonNode.get("classification").textValue()).isEqualTo(message.getClassification().name());
+        assertThat(jsonNode.get("form_type").textValue()).isEqualTo(DocumentSubtype.SSCS1);
 
         JsonNode ocrValidationWarnings = jsonNode.get("ocr_validation_warnings");
         assertThat(ocrValidationWarnings.isArray()).isTrue();
@@ -191,7 +193,8 @@ public class ServiceBusHelperTest {
         when(scannableItem2.getDocumentUuid()).thenReturn("documentUuid2");
         when(scannableItem2.getDocumentControlNumber()).thenReturn("doc2_control_number");
         when(scannableItem2.getFileName()).thenReturn("doc2_file_name");
-        when(scannableItem2.getDocumentType()).thenReturn(DocumentType.OTHER);
+        when(scannableItem2.getDocumentType()).thenReturn(DocumentType.FORM);
+        when(scannableItem2.getDocumentSubtype()).thenReturn(DocumentSubtype.SSCS1);
         when(scannableItem2.getScanningDate()).thenReturn(Instant.now());
         when(scannableItem2.getOcrData()).thenReturn(null);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrDataField;
 
@@ -50,6 +51,9 @@ public class EnvelopeMsg implements Msg {
     @JsonProperty("zip_file_name")
     private final String zipFileName;
 
+    @JsonProperty("form_type")
+    private final String formType;
+
     @JsonProperty("documents")
     private final List<Document> documents;
 
@@ -78,6 +82,7 @@ public class EnvelopeMsg implements Msg {
             .stream()
             .map(Document::fromScannableItem)
             .collect(toList());
+        this.formType = findSubtypeOfScannableItemWithFormType(envelope);
 
         this.ocrData = retrieveOcrData(envelope);
         this.ocrValidationWarnings = retrieveOcrValidationWarnings(envelope);
@@ -171,6 +176,16 @@ public class EnvelopeMsg implements Msg {
             .getScannableItems()
             .stream()
             .filter(si -> si.getOcrData() != null);
+    }
+
+    private String findSubtypeOfScannableItemWithFormType(Envelope envelope) {
+        return envelope
+            .getScannableItems()
+            .stream()
+            .filter(si -> DocumentType.FORM.equals(si.getDocumentType()))
+            .findFirst()
+            .map(ScannableItem::getDocumentSubtype)
+            .orElse(null);
     }
 
     private List<OcrField> convertFromInputOcrData(OcrData inputOcrData) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-720

### Change description ###
Add the "form type" to queue message.
"form type" value is the document subtype of the scannable item with document type as "FORM".

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
