### PR TITLE
Change the name of OCR data validation warnings element in queue message

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -139,6 +139,10 @@ public class ServiceBusHelperTest {
         assertThat(ocrValidationWarnings.isArray()).isTrue();
         assertThat(ocrValidationWarnings.elements()).containsExactly(new TextNode("warning 1"));
 
+        JsonNode ocrDataValidationWarnings = jsonNode.get("ocr_data_validation_warnings");
+        assertThat(ocrDataValidationWarnings.isArray()).isTrue();
+        assertThat(ocrDataValidationWarnings.elements()).containsExactly(new TextNode("warning 1"));
+
         assertDateField(jsonNode, "delivery_date", message.getDeliveryDate());
         assertDateField(jsonNode, "opening_date", message.getOpeningDate());
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
@@ -56,8 +56,8 @@ public class EnvelopeMsg implements Msg {
     @JsonProperty("ocr_data")
     private final List<OcrField> ocrData;
 
-    @JsonProperty("ocr_validation_warnings")
-    private final List<String> ocrValidationWarnings;
+    @JsonProperty("ocr_data_validation_warnings")
+    private final List<String> ocrDataValidationWarnings;
 
     private final boolean testOnly;
 
@@ -80,7 +80,14 @@ public class EnvelopeMsg implements Msg {
             .collect(toList());
 
         this.ocrData = retrieveOcrData(envelope);
-        this.ocrValidationWarnings = retrieveOcrValidationWarnings(envelope);
+        this.ocrDataValidationWarnings = retrieveOcrDataValidationWarnings(envelope);
+    }
+
+    // This method is here to allow for the field name change without downtime
+    // TODO: remove when the orchestrator has switched to the new name - ocr_data_validation_warnings
+    @JsonProperty("ocr_validation_warnings")
+    public List<String> getOcrDataValidationWarnings() {
+        return ocrDataValidationWarnings;
     }
 
     @Override
@@ -148,7 +155,7 @@ public class EnvelopeMsg implements Msg {
             + "}";
     }
 
-    private List<String> retrieveOcrValidationWarnings(Envelope envelope) {
+    private List<String> retrieveOcrDataValidationWarnings(Envelope envelope) {
         return findScannableItemsWithOcrData(envelope)
             .map(item ->
                 item.getOcrValidationWarnings() != null


### PR DESCRIPTION
### Change description ###

Part 1 of 2.

Change the name of OCR data validation warnings element in queue message, so that it would match the existing convention. For now, the old field is staying, so that current version of orchestrator can still process messages. In part 2 I'll remove the old (`ocr_validation_warnings`) field.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
