### PR TITLE
Store only dcn of payments in db

### DIFF
--- a/src/integrationTest/resources/envelope.json
+++ b/src/integrationTest/resources/envelope.json
@@ -25,14 +25,7 @@
       ],
       "payments": [
         {
-          "document_control_number": "1111002",
-          "method": "Cheque",
-          "amount": 100.0,
-          "currency": "GBP",
-          "amount_in_pence": 10000,
-          "payment_instrument_number": "1000000000",
-          "sort_code": "112233",
-          "account_number": "12345678"
+          "document_control_number": "1111002"
         }
       ],
       "non_scannable_items": [

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Payment.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Payment.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -20,18 +19,6 @@ public class Payment implements EnvelopeAssignable {
 
     private String documentControlNumber;
 
-    private String method;
-
-    private int amountInPence;
-
-    private String currency;
-
-    private String paymentInstrumentNumber;
-
-    private String sortCode;
-
-    private String accountNumber;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "envelope_id", nullable = false)
     private Envelope envelope;
@@ -40,26 +27,8 @@ public class Payment implements EnvelopeAssignable {
         // For use by hibernate.
     }
 
-    public Payment(
-        String documentControlNumber,
-        String method,
-        BigDecimal amount,
-        String currency,
-        String paymentInstrumentNumber,
-        String sortCode,
-        String accountNumber
-    ) {
+    public Payment(String documentControlNumber) {
         this.documentControlNumber = documentControlNumber;
-        this.method = method;
-        this.amountInPence = amount.multiply(BigDecimal.valueOf(100)).intValue();
-        this.currency = currency;
-        this.paymentInstrumentNumber = paymentInstrumentNumber;
-        this.sortCode = sortCode;
-        this.accountNumber = accountNumber;
-    }
-
-    public double getAmount() {
-        return ((double) amountInPence) / 100;
     }
 
     @Override
@@ -69,29 +38,5 @@ public class Payment implements EnvelopeAssignable {
 
     public String getDocumentControlNumber() {
         return documentControlNumber;
-    }
-
-    public String getMethod() {
-        return method;
-    }
-
-    public int getAmountInPence() {
-        return amountInPence;
-    }
-
-    public String getCurrency() {
-        return currency;
-    }
-
-    public String getPaymentInstrumentNumber() {
-        return paymentInstrumentNumber;
-    }
-
-    public String getSortCode() {
-        return sortCode;
-    }
-
-    public String getAccountNumber() {
-        return accountNumber;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
@@ -146,23 +146,11 @@ public class EnvelopeMapper {
         if (payments != null) {
             return payments
                 .stream()
-                .map(EnvelopeMapper::toDbPayment)
+                .map(payment -> new Payment(payment.documentControlNumber))
                 .collect(toList());
         } else {
             return emptyList();
         }
-    }
-
-    private static Payment toDbPayment(InputPayment payment) {
-        return new Payment(
-            payment.documentControlNumber,
-            payment.method,
-            payment.amount,
-            payment.currency,
-            payment.paymentInstrumentNumber,
-            payment.sortCode,
-            payment.accountNumber
-        );
     }
 
     private static List<NonScannableItem> toDbNonScannableItems(List<InputNonScannableItem> nonScannableItems) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeResponseMapper.java
@@ -115,16 +115,9 @@ public final class EnvelopeResponseMapper {
     private static PaymentResponse toPaymentResponse(Payment payment) {
         if (payment == null) {
             return null;
+        } else {
+            return new PaymentResponse(payment.getDocumentControlNumber());
         }
-        return new PaymentResponse(
-            payment.getDocumentControlNumber(),
-            payment.getMethod(),
-            Double.toString(payment.getAmount()),
-            payment.getCurrency(),
-            payment.getPaymentInstrumentNumber(),
-            payment.getSortCode(),
-            payment.getAccountNumber()
-        );
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/PaymentResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/PaymentResponse.java
@@ -5,90 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class PaymentResponse {
 
     @JsonProperty("document_control_number")
-    private final String documentControlNumber;
-
-    @JsonProperty("method")
-    private final String method;
-
-    @JsonProperty("amount_in_pence")
-    private final int amountInPence;
-
-    @JsonProperty("currency")
-    private final String currency;
-
-    @JsonProperty("payment_instrument_number")
-    private final String paymentInstrumentNumber;
-
-    @JsonProperty("sort_code")
-    private final String sortCode;
-
-    @JsonProperty("account_number")
-    private final String accountNumber;
+    public final String documentControlNumber;
 
     public PaymentResponse(
-        @JsonProperty("document_control_number") String documentControlNumber,
-        @JsonProperty("method") String method,
-        @JsonProperty("amount") String amount,
-        @JsonProperty("currency") String currency,
-        @JsonProperty("payment_instrument_number") String paymentInstrumentNumber,
-        @JsonProperty("sort_code") String sortCode,
-        @JsonProperty("account_number") String accountNumber
+        @JsonProperty("document_control_number") String documentControlNumber
     ) {
-        Double pence = Double.valueOf(amount) * 100;
-
         this.documentControlNumber = documentControlNumber;
-        this.method = method;
-        this.amountInPence = pence.intValue();
-        this.currency = currency;
-        this.paymentInstrumentNumber = paymentInstrumentNumber;
-        this.sortCode = sortCode;
-        this.accountNumber = accountNumber;
     }
-
-    @JsonProperty("amount")
-    public double getAmount() {
-        return ((double) amountInPence) / 100;
-    }
-
-    public String getDocumentControlNumber() {
-        return documentControlNumber;
-    }
-
-    public String getMethod() {
-        return method;
-    }
-
-    public int getAmountInPence() {
-        return amountInPence;
-    }
-
-    public String getCurrency() {
-        return currency;
-    }
-
-    public String getPaymentInstrumentNumber() {
-        return paymentInstrumentNumber;
-    }
-
-    public String getSortCode() {
-        return sortCode;
-    }
-
-    public String getAccountNumber() {
-        return accountNumber;
-    }
-
-    @Override
-    public String toString() {
-        return "PaymentResponse{"
-            + "documentControlNumber='" + documentControlNumber + '\''
-            + ", method='" + method + '\''
-            + ", amountInPence=" + amountInPence
-            + ", currency='" + currency + '\''
-            + ", paymentInstrumentNumber='" + paymentInstrumentNumber + '\''
-            + ", sortCode='" + sortCode + '\''
-            + ", accountNumber='" + accountNumber + '\''
-            + '}';
-    }
-    
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -204,13 +203,7 @@ public final class EnvelopeCreator {
     private static List<Payment> payments() {
         return newArrayList(
             new Payment(
-                "1111002",
-                "Cheque",
-                BigDecimal.valueOf(100),
-                "GBP",
-                "1000000000",
-                "112233",
-                "12345678"
+                "1111002"
             )
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputNonScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputOcrData;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputOcrDataField;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputPayment;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
@@ -21,8 +20,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.getEnvelopeFromMetafile;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype.COVERSHEET;
@@ -71,9 +70,9 @@ public class EnvelopeMapperTest {
         assertThat(dbEnvelope.getPayments().size()).isEqualTo(zipEnvelope.payments.size());
 
         assertThat(dbEnvelope.getPayments())
-            .extracting(this::convertToInputPayment)
+            .extracting(Payment::getDocumentControlNumber)
             .usingFieldByFieldElementComparator()
-            .containsAll(zipEnvelope.payments);
+            .containsAll(zipEnvelope.payments.stream().map(p -> p.documentControlNumber).collect(toList()));
     }
 
     private void assertSameScannableItems(Envelope dbEnvelope, InputEnvelope zipEnvelope) {
@@ -109,18 +108,6 @@ public class EnvelopeMapperTest {
         }
     }
 
-    private InputPayment convertToInputPayment(Payment dbPayment) {
-        return new InputPayment(
-            dbPayment.getDocumentControlNumber(),
-            dbPayment.getMethod(),
-            String.format("%.2f", dbPayment.getAmount()),
-            dbPayment.getCurrency(),
-            dbPayment.getPaymentInstrumentNumber(),
-            dbPayment.getSortCode(),
-            dbPayment.getAccountNumber()
-        );
-    }
-
     private InputScannableItem convertToInputScannableItem(ScannableItem dbScannableItem) {
         return new InputScannableItem(
             dbScannableItem.getDocumentControlNumber(),
@@ -150,7 +137,7 @@ public class EnvelopeMapperTest {
             .fields
             .stream()
             .map(field -> new InputOcrDataField(field.name, field.value))
-            .collect(Collectors.toList());
+            .collect(toList());
         inputOcrData.setFields(fields);
 
         return inputOcrData;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
@@ -71,7 +71,6 @@ public class EnvelopeMapperTest {
 
         assertThat(dbEnvelope.getPayments())
             .extracting(Payment::getDocumentControlNumber)
-            .usingFieldByFieldElementComparator()
             .containsAll(zipEnvelope.payments.stream().map(p -> p.documentControlNumber).collect(toList()));
     }
 

--- a/src/test/resources/envelope.json
+++ b/src/test/resources/envelope.json
@@ -36,11 +36,7 @@
       ],
       "payments": [
         {
-          "document_control_number": "1111002",
-          "method": "Cheque",
-          "amount": 100.0,
-          "currency": "GBP",
-          "amount_in_pence": 10000
+          "document_control_number": "1111002"
         }
       ],
       "non_scannable_items": [


### PR DESCRIPTION
Input for payments remains the same, just stop writing/reading anything to/from database except for DCNs.

All columns in db are nullable.

This PR is the first step of changing the payments format. Things to be done in future PRs:
- update database schema (remove not needed columns)
- update metadata.json schema