### PR TITLE
Remove ocr_validation_warnings field from queue message

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -137,10 +137,6 @@ public class ServiceBusHelperTest {
         assertThat(jsonNode.get("classification").textValue()).isEqualTo(message.getClassification().name());
         assertThat(jsonNode.get("form_type").textValue()).isEqualTo(DocumentSubtype.SSCS1);
 
-        JsonNode ocrValidationWarnings = jsonNode.get("ocr_validation_warnings");
-        assertThat(ocrValidationWarnings.isArray()).isTrue();
-        assertThat(ocrValidationWarnings.elements()).containsExactly(new TextNode("warning 1"));
-
         JsonNode ocrDataValidationWarnings = jsonNode.get("ocr_data_validation_warnings");
         assertThat(ocrDataValidationWarnings.isArray()).isTrue();
         assertThat(ocrDataValidationWarnings.elements()).containsExactly(new TextNode("warning 1"));

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/EnvelopeMsg.java
@@ -88,13 +88,6 @@ public class EnvelopeMsg implements Msg {
         this.ocrDataValidationWarnings = retrieveOcrDataValidationWarnings(envelope);
     }
 
-    // This method is here to allow for the field name change without downtime
-    // TODO: remove when the orchestrator has switched to the new name - ocr_data_validation_warnings
-    @JsonProperty("ocr_validation_warnings")
-    public List<String> getOcrDataValidationWarnings() {
-        return ocrDataValidationWarnings;
-    }
-
     @Override
     @JsonIgnore
     public String getMsgId() {


### PR DESCRIPTION
### Change description ###

Remove `ocr_validation_warnings` field from queue message. The orchestrator uses `ocr_data_validation_warnings` now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
