### PR TITLE
Bump shedlock 2.5.0 -> 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,8 +208,8 @@ dependencies {
     exclude group: 'javax.mail', module: 'mailapi'
   }
 
-  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '2.5.0'
-  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '2.5.0'
+  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '2.6.0'
+  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '2.6.0'
 
   compile group: 'com.microsoft.azure', name: 'azure-storage', version: '8.3.0'
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.14', {


### PR DESCRIPTION
### Change description ###

Firstly bumping to non-breaking change: this jump aligns with spring version we are currently on - 5.1.9.

For the time being - ignore dependabot PRs #836 and #837

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
