### PR TITLE
Bump shedlock 2.6.0 -> 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,8 +208,8 @@ dependencies {
     exclude group: 'javax.mail', module: 'mailapi'
   }
 
-  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '2.6.0'
-  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '2.6.0'
+  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '3.0.0'
+  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '3.0.0'
 
   compile group: 'com.microsoft.azure', name: 'azure-storage', version: '8.3.0'
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.14', {


### PR DESCRIPTION
### Change description ###

Follow up of #842. All Deprecation have been solved with previous version jump (could've reviewed earlier :D) but didn't take a risk with processor and did step by step. Will go on and do a major jump on another service as already investigated current version jump

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
