### PR TITLE
Bps 798 read blob from configured container

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -127,6 +127,8 @@ module "bulk-scan" {
     STORAGE_BLOB_LEASE_TIMEOUT               = "${var.blob_lease_timeout}"               // In seconds
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES = "${var.blob_processing_delay_in_minutes}"
 
+    STORAGE_BLOB_SELECTED_CONTAINER ="${var.blob_selected_container}"
+
     STORAGE_BLOB_SIGNATURE_ALGORITHM = "sha256withrsa"                               // none or sha256withrsa
     STORAGE_BLOB_PUBLIC_KEY          = "${var.blob_signature_verification_key_file}"
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -172,6 +172,11 @@ variable "blob_processing_delay_in_minutes" {
   default = "0"
 }
 
+variable "blob_selected_container" {
+  default = "ALL"
+}
+
+
 variable "blob_signature_verification_key_file" {
   default = "trusted_public_key.der"
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -81,7 +81,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
     }
 
     @Test
-    public void should_read_from_specific_blob_container_and_save_metadata_in_database_when_zip_contains_metadata_and_pdfs()
+    public void should_read_blob_specific_container_and_save_metadata_in_database_when_zip_contains_metadata_and_pdfs()
         throws Exception {
         //Given
         this.blobManagementProperties.setBlobSelectedContainer("bulkscan");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -5,7 +5,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
@@ -13,6 +15,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ContainerNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DocumentUrlNotRetrievedException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.UnableToUploadDocumentException;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
@@ -50,6 +53,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_P
 @RunWith(SpringRunner.class)
 public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask> {
 
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
     @Before
     public void setUp() throws Exception {
         super.setUp(BlobProcessorTask::new);
@@ -59,6 +65,26 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
     public void should_read_blob_and_save_metadata_in_database_when_zip_contains_metadata_and_pdfs()
         throws Exception {
         //Given
+        uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));
+        testBlobFileProcessed();
+    }
+
+    @Test
+    public void throw_ContainerNotFoundException_when_no_blob_container_found_to_read()
+        throws Exception {
+        expectedEx.expect(ContainerNotFoundException.class);
+        expectedEx.expectMessage("No BLOB Container found");
+        //Given
+        this.blobManagementProperties.setBlobSelectedContainer("NO_CONTAINER");
+        uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));
+        testBlobFileProcessed();
+    }
+
+    @Test
+    public void should_read_from_specific_blob_container_and_save_metadata_in_database_when_zip_contains_metadata_and_pdfs()
+        throws Exception {
+        //Given
+        this.blobManagementProperties.setBlobSelectedContainer("bulkscan");
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));
         testBlobFileProcessed();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -72,7 +72,7 @@ public abstract class ProcessorTestSuite<T extends Processor> {
     private ScannableItemRepository scannableItemRepository;
 
     @Autowired
-    private BlobManagementProperties blobManagementProperties;
+    protected BlobManagementProperties blobManagementProperties;
 
     @Value("${scheduling.task.reupload.batch}")
     private int reUploadBatchSize;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/BlobManagementProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/BlobManagementProperties.java
@@ -11,6 +11,8 @@ public class BlobManagementProperties {
 
     private Integer blobCopyPollingDelayInMillis;
 
+    private String blobSelectedContainer;
+
     public Integer getBlobCopyTimeoutInMillis() {
         return blobCopyTimeoutInMillis;
     }
@@ -33,5 +35,13 @@ public class BlobManagementProperties {
 
     public void setBlobCopyPollingDelayInMillis(int blobCopyPollingDelayInMillis) {
         this.blobCopyPollingDelayInMillis = blobCopyPollingDelayInMillis;
+    }
+
+    public String getBlobSelectedContainer() {
+        return blobSelectedContainer;
+    }
+
+    public void setBlobSelectedContainer(String blobSelectedContainer) {
+        this.blobSelectedContainer = blobSelectedContainer;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ContainerNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ContainerNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class ContainerNotFoundException extends RuntimeException {
+    public ContainerNotFoundException() {
+        super("No BLOB Container found");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -99,7 +99,7 @@ public class BlobManager {
         return cloudBlobContainerList;
     }
 
-    private boolean filterBySelectedContainer (CloudBlobContainer container) {
+    private boolean filterBySelectedContainer(CloudBlobContainer container) {
         return SELECT_ALL_CONTAINER.equalsIgnoreCase(properties.getBlobSelectedContainer())
             || properties.getBlobSelectedContainer().equals(container.getName());
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -15,6 +15,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ContainerNotFoundException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.RejectedBlobCopyException;
 
 import java.net.URISyntaxException;
@@ -33,6 +34,7 @@ public class BlobManager {
 
     private static final Logger log = LoggerFactory.getLogger(BlobManager.class);
     private static final String REJECTED_CONTAINER_NAME_SUFFIX = "-rejected";
+    private static final String SELECT_ALL_CONTAINER = "ALL";
     private static final String LEASE_ALREADY_ACQUIRED_MESSAGE =
         "Can't acquire lease on file {} in container {} - already acquired";
 
@@ -84,10 +86,22 @@ public class BlobManager {
     }
 
     public List<CloudBlobContainer> listInputContainers() {
-        return StreamSupport
+        List<CloudBlobContainer> cloudBlobContainerList = StreamSupport
             .stream(cloudBlobClient.listContainers().spliterator(), false)
             .filter(c -> !c.getName().endsWith(REJECTED_CONTAINER_NAME_SUFFIX))
+            .filter(this::filterBySelectedContainer)
             .collect(toList());
+
+        if (cloudBlobContainerList.size() == 0) {
+            throw new ContainerNotFoundException();
+        }
+
+        return cloudBlobContainerList;
+    }
+
+    private boolean filterBySelectedContainer (CloudBlobContainer container) {
+        return SELECT_ALL_CONTAINER.equalsIgnoreCase(properties.getBlobSelectedContainer())
+            || properties.getBlobSelectedContainer().equals(container.getName());
     }
 
     public List<CloudBlobContainer> listRejectedContainers() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,6 +80,7 @@ storage:
   proxy_enabled: ${STORAGE_PROXY_ENABLED:false}
   proxy_host: proxyout.reform.hmcts.net
   proxy_port: 8080
+  blob_selected_container: ${STORAGE_BLOB_SELECTED_CONTAINER:ALL}
 
 queues:
   envelopes:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -165,6 +165,7 @@ public class BlobManagerTest {
         List<String> containerNames = containers.stream().map(c -> c.getName()).collect(toList());
 
     }
+
     @Test
     public void listRejectedContainers_retrieves_rejected_containers_only() {
         // given

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -8,11 +8,14 @@ import com.microsoft.azure.storage.blob.CopyState;
 import com.microsoft.azure.storage.blob.CopyStatus;
 import com.microsoft.azure.storage.blob.LeaseStatus;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ContainerNotFoundException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,6 +42,9 @@ public class BlobManagerTest {
     private static final String REJECTED_CONTAINER_NAME = INPUT_CONTAINER_NAME + "-rejected";
     private static final String INPUT_FILE_NAME = "file-name-123.zip";
     private static final String LEASE_ID = "leaseid123";
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
 
     @Mock
     private CloudBlobClient cloudBlobClient;
@@ -112,6 +118,8 @@ public class BlobManagerTest {
         );
 
         given(cloudBlobClient.listContainers()).willReturn(allContainers);
+        given(blobManagementProperties.getBlobSelectedContainer()).willReturn("all");
+
         List<CloudBlobContainer> containers = blobManager.listInputContainers();
         List<String> containerNames = containers.stream().map(c -> c.getName()).collect(toList());
 
@@ -119,6 +127,44 @@ public class BlobManagerTest {
         verify(cloudBlobClient).listContainers();
     }
 
+
+    @Test
+    public void listInputContainers_retrieves_selected_container_from_client() {
+        List<CloudBlobContainer> allContainers = Arrays.asList(
+            mockContainer("test1"),
+            mockContainer("test1-rejected"),
+            mockContainer("test2"),
+            mockContainer("test3")
+        );
+
+        given(cloudBlobClient.listContainers()).willReturn(allContainers);
+        given(blobManagementProperties.getBlobSelectedContainer()).willReturn("test2");
+
+        List<CloudBlobContainer> containers = blobManager.listInputContainers();
+        List<String> containerNames = containers.stream().map(c -> c.getName()).collect(toList());
+
+        assertThat(containerNames).hasSameElementsAs(Arrays.asList("test2"));
+        verify(cloudBlobClient).listContainers();
+    }
+
+
+    @Test
+    public void listInputContainers_throw_exception_no_container_found_in_client() {
+        List<CloudBlobContainer> allContainers = Arrays.asList(
+            mockContainer("test1"),
+            mockContainer("test1-rejected"),
+            mockContainer("test2")
+        );
+        expectedEx.expect(ContainerNotFoundException.class);
+        expectedEx.expectMessage("No BLOB Container found");
+
+        given(cloudBlobClient.listContainers()).willReturn(allContainers);
+        given(blobManagementProperties.getBlobSelectedContainer()).willReturn("test3");
+
+        List<CloudBlobContainer> containers = blobManager.listInputContainers();
+        List<String> containerNames = containers.stream().map(c -> c.getName()).collect(toList());
+
+    }
     @Test
     public void listRejectedContainers_retrieves_rejected_containers_only() {
         // given


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-798


### Change description ###

read blob from configured container , "ALL" means read from all  available containers .

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
