### PR TITLE
Disable blob storage and service bus usage of osba by default

### DIFF
--- a/charts/bulk-scan-processor/values.yaml
+++ b/charts/bulk-scan-processor/values.yaml
@@ -42,3 +42,8 @@ java:
         - notifications-queue-listen-connection-string
         - processed-envelopes-queue-listen-connection-string
   image: hmctspublic.azurecr.io/bulk-scan/processor:latest
+bsp:
+  servicebus:
+    enabled: false
+  blobstorage:
+    enabled: false


### PR DESCRIPTION
### Change description ###

- By default Helm evaluates conditions defined in requirements yaml to true.

- On AAT/PROD we use SB queue rather than OSBA hence disabling it by default.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
