### PR TITLE
fix AAT build

### DIFF
--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -6,7 +6,7 @@ spring:
       aliases:
         service-POSTGRES-PASS: BULK_SCANNING_DB_PASSWORD
         s2s-secret: S2S_SECRET
-        flyway-password: FLYWAY_PASSWORD
+        flyway-password: flyway.password
         envelopes-queue-send-connection-string: QUEUE_ENVELOPE_SEND
         notifications-queue-send-connection-string: QUEUE_NOTIFICATIONS_SEND
         notifications-queue-listen-connection-string: QUEUE_NOTIFICATIONS_READ


### PR DESCRIPTION
This is an issue with bootstrapping, that it doesn't override well when environment variables are direct binding names of spring properties. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
