### PR TITLE
Set blob storage credentials

### DIFF
--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -1,6 +1,6 @@
 name: bulk-scan-processor
 home: https://github.com/hmcts/bulk-scan-processor
-version: 0.1.6
+version: 0.1.7
 description: HMCTS Bulk scan processor service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -1,6 +1,6 @@
 name: bulk-scan-processor
 home: https://github.com/hmcts/bulk-scan-processor
-version: 0.2.0
+version: 0.2.1
 description: HMCTS Bulk scan processor service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-processor/values.yaml
+++ b/charts/bulk-scan-processor/values.yaml
@@ -44,6 +44,8 @@ java:
         - notifications-queue-send-connection-string
         - notifications-queue-listen-connection-string
         - processed-envelopes-queue-listen-connection-string
+        - storage-account-name
+        - storage-account-primary-key
   image: hmctspublic.azurecr.io/bulk-scan/processor:latest
 bsp:
   servicebus:

--- a/charts/bulk-scan-processor/values.yaml
+++ b/charts/bulk-scan-processor/values.yaml
@@ -20,6 +20,7 @@ java:
     STORAGE_BLOB_SELECTED_CONTAINER: "ALL"
     STORAGE_BLOB_SIGNATURE_ALGORITHM: "sha256withrsa"
     STORAGE_BLOB_PUBLIC_KEY: "nonprod_public_key.der"
+    STORAGE_URL: https://bulkscan.{{ .Values.global.environment }}.platform.hmcts.net
     BULK_SCANNING_DB_USER_NAME: bulk_scanner@bulk-scan-processor-{{ .Values.global.environment }}.postgres.database.azure.com
     BULK_SCANNING_DB_NAME: bulk_scan
     BULK_SCANNING_DB_HOST: bulk-scan-processor-{{ .Values.global.environment }}.postgres.database.azure.com

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -11,3 +11,5 @@ spring:
         notifications-queue-send-connection-string: QUEUE_NOTIFICATIONS_SEND
         notifications-queue-listen-connection-string: QUEUE_NOTIFICATIONS_READ
         processed-envelopes-queue-listen-connection-string: QUEUE_PROCESSED_ENVELOPES_READ
+        storage-account-name: STORAGE_ACCOUNT_NAME
+        storage-account-primary-key: STORAGE_KEY


### PR DESCRIPTION
### Change description ###

- Storage account name and account key configuration were missing for AAT and PROD. 

- Currently BlobManager fails to connect to blob storage and hence cannot list containers.
Smoke tests are failing due to this reason.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
