### PR TITLE
Add suppression for vulnerabilites

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -94,4 +94,21 @@
     <cve>CVE-2019-16335</cve>
   </suppress>
 
+  <suppress until="2019-10-31">
+    <notes><![CDATA[
+   file name: jackson-databind-2.9.10.jar
+   No fix available
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <cve>CVE-2019-16942</cve>
+    <cve>CVE-2019-16943</cve>
+  </suppress>
+  <suppress until="2019-10-31">
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.20.0.jar: handlebars-v4.0.4.js
+    This is only used for TESTING purposes.
+   ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/handlebars\.js@.*$</packageUrl>
+    <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template</vulnerabilityName>
+  </suppress>
 </suppressions>


### PR DESCRIPTION

### Change description ###

- Added two suppressions - fix not yet available for Jackson databind and wiremock is used only in tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
