### PR TITLE
Stop logging OCR-specific validation errors

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
@@ -101,7 +101,7 @@ public class OcrValidator {
                 throw new OcrValidationException(
                     "OCR validation service returned OCR-specific errors. "
                         + "Document control number: " + docWithOcr.documentControlNumber + ". "
-                        + "Envelope: " + envelope.zipFileName + ". "
+                        + "Envelope: " + envelope.zipFileName + "."
                 );
             case WARNINGS:
                 log.info(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
@@ -99,10 +99,9 @@ public class OcrValidator {
         switch (res.status) {
             case ERRORS:
                 throw new OcrValidationException(
-                    "Ocr validation failed. "
-                        + "Document OCR: " + docWithOcr.documentControlNumber + ". "
+                    "OCR validation service returned OCR-specific errors. "
+                        + "Document control number: " + docWithOcr.documentControlNumber + ". "
                         + "Envelope: " + envelope.zipFileName + ". "
-                        + "Errors: " + Strings.join(res.errors, ", ")
                 );
             case WARNINGS:
                 log.info(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidatorTest.java
@@ -283,7 +283,7 @@ public class OcrValidatorTest {
         // then
         assertThat(err)
             .isInstanceOf(OcrValidationException.class)
-            .hasMessageContaining("Error!");
+            .hasMessageContaining("OCR validation service returned OCR-specific errors");
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

Stop logging OCR-specific validation errors from the transformation service. Those errors might contain sensitive data. Our service doesn't care about them - it's enough to log the fact that OCR is invalid according to the validation service.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
