### PR TITLE
Clarify logs related to error notifications

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -231,7 +231,7 @@ public class ErrorNotificationHandlerTest {
         );
         assertThat(output).containsPattern("INFO  \\[error-notification-service\\] "
             + ErrorNotificationService.class.getCanonicalName()
-            + ":\\d+: Error notification for "
+            + ":\\d+: Error notification for file "
             + ZIP_FILE_NAME
             + " sent. Notification ID: "
             + NOTIFICATION_ID

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -233,7 +233,7 @@ public class ErrorNotificationHandlerTest {
             + ErrorNotificationService.class.getCanonicalName()
             + ":\\d+: Error notification for "
             + ZIP_FILE_NAME
-            + " published. ID: "
+            + " sent. Notification ID: "
             + NOTIFICATION_ID
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationService.java
@@ -53,7 +53,11 @@ public class ErrorNotificationService {
 
             entity.setNotificationId(response.getNotificationId());
 
-            log.info("Error notification for {} published. ID: {}", message.zipFileName, response.getNotificationId());
+            log.info(
+                "Error notification for file {} sent. Notification ID: {}",
+                message.zipFileName,
+                response.getNotificationId()
+            );
         } finally {
             repository.saveAndFlush(entity);
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -385,7 +385,7 @@ public class BlobProcessorTask extends Processor {
         );
 
         log.info(
-            "Sent error notification for file {} in container {}. Message ID: {}",
+            "Created error notification for file {} in container {}. Queue message ID: {}",
             zipFilename,
             containerName,
             messageId

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
+@SuppressWarnings("checkstyle:LineLength")
 @ExtendWith(MockitoExtension.class)
 public class ErrorNotificationServiceTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -80,7 +80,7 @@ public class ErrorNotificationServiceTest {
 
         // and
         capturer.assertContains(
-            "Error notification for " + request.zipFileName + " published. ID: " + response.getNotificationId()
+            "Error notification for file " + request.zipFileName + " sent. Notification ID: " + response.getNotificationId()
         );
         verify(repository).saveAndFlush(any(ErrorNotification.class));
     }


### PR DESCRIPTION
To avoid any confusion between queue messaged ids and ids we get after successfully posting an error notification to our partner's api.