### PR TITLE
Suppress jetty dependencies

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -62,4 +62,10 @@
     <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcprov\-jdk15on@.*$</packageUrl>
     <cve>CVE-2019-17359</cve>
   </suppress>
+
+  <suppress until="2020-01-06">
+    <notes><![CDATA[No fix available. Not used by server - comes with wiremock-jre8 used only in integration tests]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-(webapp|servlet|security|server|servlets|http|continuation|xml|util)@9\.4\.22\.v20191022.*$</packageUrl>
+    <cve>CVE-2019-17632</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Wiremock pulls in handful of jetty dependencies which just got marked as vulnerable. Not used by server.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
