### PR TITLE
Wiremock brings jetty dependencies which are vulnerable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,20 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: versions.mockitoJupiter) {
       entry 'mockito-core'
     }
+
+    //to suppress  CVE-2019-17632
+    dependencySet(group: 'org.eclipse.jetty', version: '9.2.28.v20190418') {
+      entry  'jetty-server'
+      entry 'jetty-http'
+      entry 'jetty-webapp'
+      entry 'jetty-servlet'
+      entry 'jetty-security'
+      entry 'jetty-servlets'
+      entry 'jetty-util'
+      entry 'jetty-io'
+      entry 'jetty-continuation'
+      entry 'jetty-xml'
+    }
   }
 }
 


### PR DESCRIPTION


### Change description ###

Wiremock brings jetty dependencies which are vulnerable, try to use different version of jetty


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
