### PR TITLE
Allow encoded OCR data to contain any character from Base64 set

### DIFF
--- a/src/main/resources/metafile-schema.json
+++ b/src/main/resources/metafile-schema.json
@@ -105,7 +105,7 @@
           "ocr_data": {
             "id": "#/properties/scannable_items/items/properties/ocr_data",
             "type": ["string", "null"],
-            "pattern": "^[0-9a-zA-Z=]*$"
+            "pattern": "^[0-9a-zA-Z=+/]*$"
           },
           "file_name": {
             "id": "#/properties/scannable_items/items/properties/file_name",


### PR DESCRIPTION
### Change description ###

Allow encoded OCR data to contain any character from Base64 set. Before this change, two characters were missing (`+` and `/`)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
