### PR TITLE
Not include root folders when running zip command

### DIFF
--- a/bin/sign-zip-upload.sh
+++ b/bin/sign-zip-upload.sh
@@ -71,11 +71,11 @@ ZIP_FILE_NAME="${ZIP_ID_PREFIX}_$ZIP_TIME_PART.test.zip"
 echo "Zipping the envelope..."
 
 # zip desired contents (pdf and json only!)
-zip ${ENVELOPE_FILE_NAME} ${DIRECTORY}/*.json ${DIRECTORY}/*.pdf
+zip -j ${ENVELOPE_FILE_NAME} ${DIRECTORY}/*.json ${DIRECTORY}/*.pdf
 
 # sign
 openssl dgst -sha256 -sign private.pem -out ${SIGNATURE_FILE_NAME} ${ENVELOPE_FILE_NAME}
-zip ${ZIP_FILE_NAME} ${ENVELOPE_FILE_NAME} ${SIGNATURE_FILE_NAME} > /dev/null 2>&1
+zip -j ${ZIP_FILE_NAME} ${ENVELOPE_FILE_NAME} ${SIGNATURE_FILE_NAME} > /dev/null 2>&1
 
 # remove retrieved private key
 if [[ "$PEM_EXISTS" == "true" ]]; then


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Enable Services to upload zip files to bulk scan blob storage in demo](https://tools.hmcts.net/jira/browse/BPS-931)

### Change description ###

zip command by default includes root folders when zipping. `-j` disables that:

**--junk-paths**
> Store just the name of a saved file (junk the path), and do not store directory names. By default, zip will store the full path (relative to the current directory).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
