### PR TITLE
Added proxy for functional tests for all envs except preview

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -70,6 +70,7 @@ withPipeline(type, product, component) {
   env.TEST_SCAN_DELAY = '4000'
   env.TEST_STORAGE_CONTAINER_NAME = 'bulkscan'
   env.TEST_STORAGE_ACCOUNT_URL = 'https://bulkscan.aat.platform.hmcts.net'
+  env.PROXYOUT_ENABLED = true
 
   before('smoketest:preview') {
     withAksClient('nonprod') {
@@ -91,6 +92,7 @@ withPipeline(type, product, component) {
       // Get envelopes queue connection string
       def sbConnectionStr = kubectl.getSecret(serviceBusSecret, namespace, "{.data.connectionString}")
       env.PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING = "${sbConnectionStr};EntityPath=processed-envelopes"
+      env.PROXYOUT_ENABLED = false
 
     }
   }

--- a/bin/sign-zip-upload.sh
+++ b/bin/sign-zip-upload.sh
@@ -71,11 +71,11 @@ ZIP_FILE_NAME="${ZIP_ID_PREFIX}_$ZIP_TIME_PART.test.zip"
 echo "Zipping the envelope..."
 
 # zip desired contents (pdf and json only!)
-zip ${ENVELOPE_FILE_NAME} ${DIRECTORY}/*.json ${DIRECTORY}/*.pdf
+zip -j ${ENVELOPE_FILE_NAME} ${DIRECTORY}/*.json ${DIRECTORY}/*.pdf
 
 # sign
 openssl dgst -sha256 -sign private.pem -out ${SIGNATURE_FILE_NAME} ${ENVELOPE_FILE_NAME}
-zip ${ZIP_FILE_NAME} ${ENVELOPE_FILE_NAME} ${SIGNATURE_FILE_NAME} > /dev/null 2>&1
+zip -j ${ZIP_FILE_NAME} ${ENVELOPE_FILE_NAME} ${SIGNATURE_FILE_NAME} > /dev/null 2>&1
 
 # remove retrieved private key
 if [[ "$PEM_EXISTS" == "true" ]]; then

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -44,7 +44,7 @@ public abstract class BaseFunctionalTest {
         this.testPrivateKeyDer = config.getString("test-private-key-der");
         this.proxyHost = config.getString("storage-proxy-host");
         this.proxyPort = Integer.parseInt(config.getString("storage-proxy-port"));
-        this.isProxyEnabled=Boolean.getBoolean(config.getString("proxyout.enabled"));
+        this.isProxyEnabled = Boolean.getBoolean(config.getString("proxyout.enabled"));
 
         StorageCredentialsAccountAndKey storageCredentials =
             new StorageCredentialsAccountAndKey(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -30,6 +30,7 @@ public abstract class BaseFunctionalTest {
     protected CloudBlobContainer rejectedContainer;
     protected String proxyHost;
     protected int proxyPort;
+    protected boolean isProxyEnabled;
     protected TestHelper testHelper = new TestHelper();
     protected Config config;
 
@@ -43,17 +44,20 @@ public abstract class BaseFunctionalTest {
         this.testPrivateKeyDer = config.getString("test-private-key-der");
         this.proxyHost = config.getString("storage-proxy-host");
         this.proxyPort = Integer.parseInt(config.getString("storage-proxy-port"));
-        
+        this.isProxyEnabled=Boolean.getBoolean(config.getString("proxyout.enabled"));
+
         StorageCredentialsAccountAndKey storageCredentials =
             new StorageCredentialsAccountAndKey(
                 config.getString("test-storage-account-name"),
                 config.getString("test-storage-account-key")
             );
 
-        // Apply proxy for functional tests for all environments
+        // Apply proxy for functional tests for all environments except preview
         // as due to NSG config it has to go through outbound proxy
-        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
-        OperationContext.setDefaultProxy(proxy);
+        if (isProxyEnabled) {
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            OperationContext.setDefaultProxy(proxy);
+        }
 
         CloudBlobClient cloudBlobClient = new CloudStorageAccount(
             storageCredentials,

--- a/src/functionalTest/resources/application.conf
+++ b/src/functionalTest/resources/application.conf
@@ -11,3 +11,4 @@ test-private-key-der=${TEST_PRIVATE_KEY_DER}
 processed-envelopes-queue-conn-string=${PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING}
 storage-proxy-host=proxyout.reform.hmcts.net
 storage-proxy-port=8080
+proxyout.enabled=${PROXYOUT_ENABLED}

--- a/src/functionalTest/resources/application.conf
+++ b/src/functionalTest/resources/application.conf
@@ -9,3 +9,5 @@ test-s2s-url=${TEST_S2S_URL}
 test-s2s-secret=${TEST_S2S_SECRET}
 test-private-key-der=${TEST_PRIVATE_KEY_DER}
 processed-envelopes-queue-conn-string=${PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING}
+storage-proxy-host=proxyout.reform.hmcts.net
+storage-proxy-port=8080


### PR DESCRIPTION
### Change description ###

- Due to latest NSG changes made by devops functional tests will now have to go via outbound proxy.

- proxy out is not required for preview as it uses osba.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
