### PR TITLE
Set proxy explicitly for functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -61,14 +61,14 @@ public abstract class BaseFunctionalTest {
                 new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort))
             );
             OperationContext.setDefaultProxy(proxy);
+
+            // This is set temporary and will be removed/modified in subsequent PRs
+            System.setProperty("http.proxyHost", proxyHost);
+            System.setProperty("http.proxyPort", proxyPort);
+
+            System.setProperty("https.proxyHost", proxyHost);
+            System.setProperty("https.proxyPort", proxyPort);
         }
-
-        // This is set temporary and will be removed/modified in subsequent PRs
-        System.setProperty("http.proxyHost", proxyHost);
-        System.setProperty("http.proxyPort", proxyPort);
-
-        System.setProperty("https.proxyHost", proxyHost);
-        System.setProperty("https.proxyPort", proxyPort);
 
         Map<String, String> environmentVars = System.getenv();
         for (String envName : environmentVars.keySet()) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -96,8 +96,8 @@ public abstract class BaseFunctionalTest {
             .pollInterval(500, TimeUnit.MILLISECONDS)
             .until(() -> testHelper.getEnvelopeByZipFileName(testUrl, s2sToken, fileName)
                 .filter(env ->
-                            ImmutableList.of(Status.NOTIFICATION_SENT, Status.COMPLETED)
-                                .contains(env.getStatus())
+                    ImmutableList.of(Status.NOTIFICATION_SENT, Status.COMPLETED)
+                        .contains(env.getStatus())
                 )
                 .isPresent()
             );


### PR DESCRIPTION
### Change description ###

- Setting the proxy explicitly as system property.

- Also setting both http and https and printing env vars.

- This is just to check what env vars are being set and are applied before accessing blob storage.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
