### PR TITLE
Upload blob in func tests with operation context which includes proxy

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -34,6 +34,7 @@ public abstract class BaseFunctionalTest {
     protected boolean isProxyEnabled;
     protected TestHelper testHelper = new TestHelper();
     protected Config config;
+    protected OperationContext operationContext;
 
     public void setUp() throws Exception {
         this.config = ConfigFactory.load();
@@ -60,7 +61,9 @@ public abstract class BaseFunctionalTest {
                 Proxy.Type.HTTP,
                 new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort))
             );
-            OperationContext.setDefaultProxy(proxy);
+
+            operationContext = new OperationContext();
+            operationContext.setProxy(proxy);
 
             // This is set temporary and will be removed/modified in subsequent PRs
             System.setProperty("http.proxyHost", proxyHost);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -75,6 +75,18 @@ public abstract class BaseFunctionalTest {
             System.out.format("%s=%s%n", envName, environmentVars.get(envName));
         }
 
+        // This is set temporary and will be removed/modified in subsequent PRs
+        System.setProperty("http.proxyHost", proxyHost);
+        System.setProperty("http.proxyPort", proxyPort);
+
+        System.setProperty("https.proxyHost", proxyHost);
+        System.setProperty("https.proxyPort", proxyPort);
+
+        Map<String, String> environmentVars = System.getenv();
+        for (String envName : environmentVars.keySet()) {
+            System.out.format("%s=%s%n", envName, environmentVars.get(envName));
+        }
+
         CloudBlobClient cloudBlobClient = new CloudStorageAccount(
             storageCredentials,
             new StorageUri(new URI(config.getString("test-storage-account-url")), null),
@@ -96,8 +108,8 @@ public abstract class BaseFunctionalTest {
             .pollInterval(500, TimeUnit.MILLISECONDS)
             .until(() -> testHelper.getEnvelopeByZipFileName(testUrl, s2sToken, fileName)
                 .filter(env ->
-                    ImmutableList.of(Status.NOTIFICATION_SENT, Status.COMPLETED)
-                        .contains(env.getStatus())
+                            ImmutableList.of(Status.NOTIFICATION_SENT, Status.COMPLETED)
+                                .contains(env.getStatus())
                 )
                 .isPresent()
             );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -108,8 +108,8 @@ public abstract class BaseFunctionalTest {
             .pollInterval(500, TimeUnit.MILLISECONDS)
             .until(() -> testHelper.getEnvelopeByZipFileName(testUrl, s2sToken, fileName)
                 .filter(env ->
-                            ImmutableList.of(Status.NOTIFICATION_SENT, Status.COMPLETED)
-                                .contains(env.getStatus())
+                    ImmutableList.of(Status.NOTIFICATION_SENT, Status.COMPLETED)
+                        .contains(env.getStatus())
                 )
                 .isPresent()
             );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -75,18 +75,6 @@ public abstract class BaseFunctionalTest {
             System.out.format("%s=%s%n", envName, environmentVars.get(envName));
         }
 
-        // This is set temporary and will be removed/modified in subsequent PRs
-        System.setProperty("http.proxyHost", proxyHost);
-        System.setProperty("http.proxyPort", proxyPort);
-
-        System.setProperty("https.proxyHost", proxyHost);
-        System.setProperty("https.proxyPort", proxyPort);
-
-        Map<String, String> environmentVars = System.getenv();
-        for (String envName : environmentVars.keySet()) {
-            System.out.format("%s=%s%n", envName, environmentVars.get(envName));
-        }
-
         CloudBlobClient cloudBlobClient = new CloudStorageAccount(
             storageCredentials,
             new StorageUri(new URI(config.getString("test-storage-account-url")), null),

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -47,7 +47,14 @@ public class BlobProcessorTest extends BaseFunctionalTest {
 
     private EnvelopeResponse uploadZipFile(List<String> files, String metadataFile, String destZipFilename) {
         // valid zip file
-        testHelper.uploadZipFile(inputContainer, files, metadataFile, destZipFilename, testPrivateKeyDer);
+        testHelper.uploadZipFile(
+            inputContainer,
+            files,
+            metadataFile,
+            destZipFilename,
+            testPrivateKeyDer,
+            operationContext
+        );
 
         String s2sToken = testHelper.s2sSignIn(this.s2sName, this.s2sSecret, this.s2sUrl);
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -52,7 +52,14 @@ public class EnvelopeDeletionTest extends BaseFunctionalTest {
         String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
 
         // valid zip file
-        testHelper.uploadZipFile(inputContainer, files, metadataFile, destZipFilename, testPrivateKeyDer);
+        testHelper.uploadZipFile(
+            inputContainer,
+            files,
+            metadataFile,
+            destZipFilename,
+            testPrivateKeyDer,
+            operationContext
+        );
         filesToDeleteAfterTest.add(destZipFilename);
 
         await("file should be deleted")
@@ -72,7 +79,8 @@ public class EnvelopeDeletionTest extends BaseFunctionalTest {
             Arrays.asList("1111006.pdf"),
             null, // missing metadata file
             destZipFilename,
-            testPrivateKeyDer
+            testPrivateKeyDer,
+            operationContext
         );
 
         filesToDeleteAfterTest.add(destZipFilename);
@@ -102,7 +110,8 @@ public class EnvelopeDeletionTest extends BaseFunctionalTest {
                 Arrays.asList("1111006.pdf"),
                 null, // missing metadata file
                 fileName,
-                testPrivateKeyDer
+                testPrivateKeyDer,
+                operationContext
             );
 
             await("file should be deleted")

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
@@ -89,7 +89,8 @@ public class ProcessedEnvelopeMessageHandlingTest extends BaseFunctionalTest {
             Arrays.asList("1111006.pdf", "1111002.pdf"),
             "exception_with_ocr_metadata.json",
             zipFilename,
-            testPrivateKeyDer
+            testPrivateKeyDer,
+            operationContext
         );
 
         return zipFilename;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import com.microsoft.azure.storage.OperationContext;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.core.PathUtility;
@@ -73,13 +74,21 @@ public class TestHelper {
         List<String> files,
         String metadataFile,
         final String destZipFilename,
-        String testPrivateKeyDer
+        String testPrivateKeyDer,
+        OperationContext operationContext
     ) {
         try {
             byte[] zipFile =
                 createSignedZipArchiveWithRandomName(files, metadataFile, destZipFilename, testPrivateKeyDer);
             CloudBlockBlob blockBlobReference = container.getBlockBlobReference(destZipFilename);
-            blockBlobReference.uploadFromByteArray(zipFile, 0, zipFile.length);
+            blockBlobReference.uploadFromByteArray(
+                zipFile,
+                0,
+                zipFile.length,
+                null,
+                null,
+                operationContext
+            );
         } catch (Exception exc) {
             throw new RuntimeException(exc);
         }


### PR DESCRIPTION

### Change description ###

- Currently when we upload using `blockBlobReference.uploadFromByteArray(...)` operation context is passed as null.

- We need to operation context as that is the only way Azure SDK would allow us to set proxy.

- Next Action

   - I would need to do some clean up of old code which would be done in upcoming PR's.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
