### PR TITLE
Fix bug to parse string to boolean

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -46,7 +46,7 @@ public abstract class BaseFunctionalTest {
         this.testPrivateKeyDer = config.getString("test-private-key-der");
         this.proxyHost = config.getString("storage-proxy-host");
         this.proxyPort = config.getString("storage-proxy-port");
-        this.isProxyEnabled = Boolean.getBoolean(config.getString("proxyout.enabled"));
+        this.isProxyEnabled = Boolean.valueOf(config.getString("proxyout.enabled"));
 
         StorageCredentialsAccountAndKey storageCredentials =
             new StorageCredentialsAccountAndKey(


### PR DESCRIPTION
### Change description ###

- `Boolean.getBoolean()` argument expects the name of a system property. 

-  we want to get boolean value from string for which there is `Boolean.valueOf("true")`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
