### PR TITLE
Revert "Removed env var outputting for funct tests and removed unused proxy"

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URI;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Awaitility.await;
@@ -63,6 +64,18 @@ public abstract class BaseFunctionalTest {
 
             operationContext = new OperationContext();
             operationContext.setProxy(proxy);
+
+            // This is set temporary and will be removed/modified in subsequent PRs
+            System.setProperty("http.proxyHost", proxyHost);
+            System.setProperty("http.proxyPort", proxyPort);
+
+            System.setProperty("https.proxyHost", proxyHost);
+            System.setProperty("https.proxyPort", proxyPort);
+        }
+
+        Map<String, String> environmentVars = System.getenv();
+        for (String envName : environmentVars.keySet()) {
+            System.out.format("%s=%s%n", envName, environmentVars.get(envName));
         }
 
         CloudBlobClient cloudBlobClient = new CloudStorageAccount(


### PR DESCRIPTION
- Need to check the env vars being set on AAT.

- Tried through Jenkins script and replay option but those options didn't work.

- Adding this which may be reverted later.