### PR TITLE
Make service column mandatory in the error notifications table

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
@@ -29,7 +29,7 @@ public class ErrorMsg implements Msg {
         @JsonProperty("documentControlNumber") String documentControlNumber,
         @JsonProperty(value = "errorCode", required = true) ErrorCode errorCode,
         @JsonProperty(value = "errorDescription", required = true) String errorDescription,
-        @JsonProperty(value = "service") String service
+        @JsonProperty(value = "service", required = true) String service
     ) {
         this.id = id;
         this.eventId = eventId;

--- a/src/main/resources/db/migration/V048__Make_service_column_not_null.sql
+++ b/src/main/resources/db/migration/V048__Make_service_column_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE error_notifications
+  ALTER COLUMN service SET NOT NULL;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -99,7 +99,7 @@ public class ErrorNotificationServiceTest {
             "document control number",
             ErrorCode.ERR_AV_FAILED,
             "antivirus flag",
-            null // optional service field
+            "service1"
         );
         given(client.notify(any(ErrorNotificationRequest.class))).willThrow(new RuntimeException("oh no"));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1008


### Change description ###
- Migration script to make service column mandatory in the error_notifications table.
- Make service field `required` in the `error_notifications` queue message.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
