### PR TITLE
Remove redundant dependency management for tomcat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,10 +188,6 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: versions.mockitoJupiter) {
       entry 'mockito-core'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.30') {
-      entry 'tomcat-embed-core'
-      entry 'tomcat-embed-websocket'
-    }
   }
 }
 


### PR DESCRIPTION
### Change description ###

Vulnerabilities already solved with latest spring boot updates. Management is redundant now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
