### PR TITLE
Add envelope classification to the Zip Files summary daily report

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
@@ -23,6 +23,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.EXCEPTION;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.SUPPLEMENTARY_EVIDENCE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALIDATION_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
@@ -53,8 +55,8 @@ public class ZipFilesSummaryRepositoryTest {
             event("c4", "test4.zip", createdDate.minus(30, MINUTES), FILE_VALIDATION_FAILURE)
         );
 
-        dbHasEnvelope(envelope("c1", "test1.zip", Status.COMPLETED, Classification.EXCEPTION));
-        dbHasEnvelope(envelope("c2", "test2.zip", Status.CREATED, Classification.SUPPLEMENTARY_EVIDENCE));
+        dbHasEnvelope(envelope("c1", "test1.zip", Status.COMPLETED, EXCEPTION));
+        dbHasEnvelope(envelope("c2", "test2.zip", Status.CREATED, SUPPLEMENTARY_EVIDENCE));
 
         // when
         List<ZipFileSummary> result = reportRepo.getZipFileSummaryReportFor(LocalDate.of(2019, 2, 15));
@@ -71,7 +73,7 @@ public class ZipFilesSummaryRepositoryTest {
                         "c1",
                         Event.COMPLETED.toString(),
                         Status.COMPLETED.toString(),
-                        Classification.EXCEPTION.name()
+                        EXCEPTION.name()
                     ),
                     new ZipFileSummaryItem(
                         "test2.zip",
@@ -80,7 +82,7 @@ public class ZipFilesSummaryRepositoryTest {
                         "c2",
                         Event.ZIPFILE_PROCESSING_STARTED.toString(),
                         Status.CREATED.toString(),
-                        Classification.SUPPLEMENTARY_EVIDENCE.name()
+                        SUPPLEMENTARY_EVIDENCE.name()
                     ),
                     new ZipFileSummaryItem(
                         "test4.zip",
@@ -128,7 +130,7 @@ public class ZipFilesSummaryRepositoryTest {
             event(container, "test2.zip", nextDay, ZIPFILE_PROCESSING_STARTED)
         );
 
-        dbHasEnvelope(envelope(container, zip1Name, Status.UPLOADED, Classification.SUPPLEMENTARY_EVIDENCE));
+        dbHasEnvelope(envelope(container, zip1Name, Status.UPLOADED, SUPPLEMENTARY_EVIDENCE));
 
         // when
         List<ZipFileSummary> result = reportRepo.getZipFileSummaryReportFor(LocalDate.of(2019, 2, 15));
@@ -145,7 +147,7 @@ public class ZipFilesSummaryRepositoryTest {
                         container,
                         Event.COMPLETED.toString(),
                         Status.UPLOADED.toString(),
-                        Classification.SUPPLEMENTARY_EVIDENCE.name()
+                        SUPPLEMENTARY_EVIDENCE.name()
                     )
                 )
             );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
@@ -53,8 +53,8 @@ public class ZipFilesSummaryRepositoryTest {
             event("c4", "test4.zip", createdDate.minus(30, MINUTES), FILE_VALIDATION_FAILURE)
         );
 
-        dbHasEnvelope(envelope("c1", "test1.zip", Status.COMPLETED));
-        dbHasEnvelope(envelope("c2", "test2.zip", Status.CREATED));
+        dbHasEnvelope(envelope("c1", "test1.zip", Status.COMPLETED, Classification.EXCEPTION));
+        dbHasEnvelope(envelope("c2", "test2.zip", Status.CREATED, Classification.SUPPLEMENTARY_EVIDENCE));
 
         // when
         List<ZipFileSummary> result = reportRepo.getZipFileSummaryReportFor(LocalDate.of(2019, 2, 15));
@@ -70,7 +70,8 @@ public class ZipFilesSummaryRepositoryTest {
                         completedDate,
                         "c1",
                         Event.COMPLETED.toString(),
-                        Status.COMPLETED.toString()
+                        Status.COMPLETED.toString(),
+                        Classification.EXCEPTION.name()
                     ),
                     new ZipFileSummaryItem(
                         "test2.zip",
@@ -78,7 +79,8 @@ public class ZipFilesSummaryRepositoryTest {
                         null,
                         "c2",
                         Event.ZIPFILE_PROCESSING_STARTED.toString(),
-                        Status.CREATED.toString()
+                        Status.CREATED.toString(),
+                        Classification.SUPPLEMENTARY_EVIDENCE.name()
                     ),
                     new ZipFileSummaryItem(
                         "test4.zip",
@@ -86,6 +88,7 @@ public class ZipFilesSummaryRepositoryTest {
                         null,
                         "c4",
                         Event.FILE_VALIDATION_FAILURE.toString(),
+                        null,
                         null
                     )
                 )
@@ -125,7 +128,7 @@ public class ZipFilesSummaryRepositoryTest {
             event(container, "test2.zip", nextDay, ZIPFILE_PROCESSING_STARTED)
         );
 
-        dbHasEnvelope(envelope(container, zip1Name, Status.UPLOADED));
+        dbHasEnvelope(envelope(container, zip1Name, Status.UPLOADED, Classification.SUPPLEMENTARY_EVIDENCE));
 
         // when
         List<ZipFileSummary> result = reportRepo.getZipFileSummaryReportFor(LocalDate.of(2019, 2, 15));
@@ -141,7 +144,8 @@ public class ZipFilesSummaryRepositoryTest {
                         nextDay,
                         container,
                         Event.COMPLETED.toString(),
-                        Status.UPLOADED.toString()
+                        Status.UPLOADED.toString(),
+                        Classification.SUPPLEMENTARY_EVIDENCE.name()
                     )
                 )
             );
@@ -162,7 +166,7 @@ public class ZipFilesSummaryRepositoryTest {
         return event;
     }
 
-    private Envelope envelope(String container, String zipFileName, Status status) {
+    private Envelope envelope(String container, String zipFileName, Status status, Classification classification) {
         Envelope envelope = new Envelope(
             UUID.randomUUID().toString(),
             "jurisdiction1",
@@ -172,7 +176,7 @@ public class ZipFilesSummaryRepositoryTest {
             zipFileName,
             "1234432112344321",
             null,
-            Classification.NEW_APPLICATION,
+            classification,
             emptyList(),
             emptyList(),
             emptyList(),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -85,7 +85,8 @@ public class ReportsController {
                     item.timeProcessed,
                     item.container,
                     item.lastEventStatus,
-                    item.envelopeStatus
+                    item.envelopeStatus,
+                    item.classification
                 ))
                 .collect(toList())
         );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ZipFileSummary.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ZipFileSummary.java
@@ -15,4 +15,6 @@ public interface ZipFileSummary {
     String getLastEventStatus();
 
     String getEnvelopeStatus();
+
+    String getClassification();
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ZipFilesSummaryRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ZipFilesSummaryRepository.java
@@ -13,7 +13,8 @@ public interface ZipFilesSummaryRepository extends JpaRepository<Envelope, UUID>
 
     @Query(
         nativeQuery = true,
-        value = "SELECT createdEvent.container, createdEvent.zipfilename, createdEvent.createdDate, "
+        value = "SELECT createdEvent.container, createdEvent.zipfilename, "
+            + "  createdEvent.createdDate, envelope.classification AS classification, "
             + "  lastEventName.event AS lastEventStatus, envelope.status AS envelopeStatus, "
             + "  (CASE WHEN lastEventName.event = 'COMPLETED' "
             + "        THEN lastEvent.eventDate ELSE null END "

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportItem.java
@@ -34,6 +34,8 @@ public class ZipFilesSummaryReportItem {
     @JsonProperty("envelope_status")
     public final String envelopeStatus;
 
+    public final String classification;
+
     // region constructor
     public ZipFilesSummaryReportItem(String fileName,
                                      LocalDate dateReceived,
@@ -42,7 +44,8 @@ public class ZipFilesSummaryReportItem {
                                      LocalTime timeProcessed,
                                      String container,
                                      String lastEventStatus,
-                                     String envelopeStatus
+                                     String envelopeStatus,
+                                     String classification
     ) {
         this.fileName = fileName;
         this.dateReceived = dateReceived;
@@ -52,6 +55,7 @@ public class ZipFilesSummaryReportItem {
         this.jurisdiction = container;
         this.lastEventStatus = lastEventStatus;
         this.envelopeStatus = envelopeStatus;
+        this.classification = classification;
     }
     // endregion
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsService.java
@@ -77,7 +77,8 @@ public class ReportsService {
             toLocalTime(dbItem.getCompletedDate()),
             dbItem.getContainer(),
             dbItem.getLastEventStatus(),
-            dbItem.getEnvelopeStatus()
+            dbItem.getEnvelopeStatus(),
+            dbItem.getClassification()
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileSummaryResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileSummaryResponse.java
@@ -13,6 +13,7 @@ public class ZipFileSummaryResponse {
     public final String container;
     public final String lastEventStatus;
     public final String envelopeStatus;
+    public final String classification;
 
     // region constructor
     public ZipFileSummaryResponse(
@@ -23,7 +24,8 @@ public class ZipFileSummaryResponse {
         LocalTime timeProcessed,
         String container,
         String lastEventStatus,
-        String envelopeStatus
+        String envelopeStatus,
+        String classification
     ) {
         this.fileName = fileName;
         this.dateReceived = dateReceived;
@@ -33,6 +35,7 @@ public class ZipFileSummaryResponse {
         this.container = container;
         this.lastEventStatus = lastEventStatus;
         this.envelopeStatus = envelopeStatus;
+        this.classification = classification;
     }
     // endregion
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriter.java
@@ -13,7 +13,8 @@ import java.util.List;
 public final class CsvWriter {
 
     private static final String[] ZIP_FILES_SUMMARY_CSV_HEADERS = {
-        "Container", "Zip File Name", "Date Received", "Time Received", "Date Processed", "Time Processed", "Status"
+        "Container", "Zip File Name", "Date Received", "Time Received",
+        "Date Processed", "Time Processed", "Status", "Classification"
     };
 
     private CsvWriter() {
@@ -37,7 +38,8 @@ public final class CsvWriter {
                     summary.timeReceived,
                     summary.dateProcessed,
                     summary.timeProcessed,
-                    summary.lastEventStatus
+                    summary.lastEventStatus,
+                    summary.classification
                 );
             }
         }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.ReportsController;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedEnvelopesReportService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
@@ -115,15 +116,17 @@ public class ReportsControllerTest {
             localTime.plusHours(1),
             "bulkscan",
             CONSUMED.toString(),
-            COMPLETED.toString()
+            COMPLETED.toString(),
+            Classification.EXCEPTION.name()
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan"))
             .willReturn(singletonList(zipFileSummaryResponse));
 
         String expectedContent = String.format(
-            "Container,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Status\r\n"
-                + "bulkscan,test.zip,%s,%s,%s,%s,CONSUMED\r\n",
+            "Container,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,"
+                + "Status,Classification\r\n"
+                + "bulkscan,test.zip,%s,%s,%s,%s,CONSUMED,EXCEPTION\r\n",
             localDate.toString(), "12:30:10",
             localDate.toString(), "13:30:10"
         );
@@ -151,7 +154,8 @@ public class ReportsControllerTest {
             .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=zip-files-summary.csv"))
             .andExpect(content().contentType(APPLICATION_OCTET_STREAM))
             .andExpect(content().string(
-                "Container,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,Status\r\n"
+                "Container,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,"
+                    + "Status,Classification\r\n"
             ));
     }
 
@@ -168,7 +172,8 @@ public class ReportsControllerTest {
             localTime.plusHours(1),
             "bulkscan",
             CONSUMED.toString(),
-            COMPLETED.toString()
+            COMPLETED.toString(),
+            Classification.SUPPLEMENTARY_EVIDENCE.name()
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan"))
@@ -186,7 +191,8 @@ public class ReportsControllerTest {
             .andExpect(jsonPath("$.data[0].time_processed").value("13:30:10"))
             .andExpect(jsonPath("$.data[0].container").value(response.container))
             .andExpect(jsonPath("$.data[0].last_event_status").value(response.lastEventStatus))
-            .andExpect(jsonPath("$.data[0].envelope_status").value(response.envelopeStatus));
+            .andExpect(jsonPath("$.data[0].envelope_status").value(response.envelopeStatus))
+            .andExpect(jsonPath("$.data[0].classification").value(response.classification));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -7,7 +7,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.ReportsController;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedEnvelopesReportService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
@@ -31,6 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CONSUMED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.EXCEPTION;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.SUPPLEMENTARY_EVIDENCE;
 
 @WebMvcTest(ReportsController.class)
 public class ReportsControllerTest {
@@ -117,7 +118,7 @@ public class ReportsControllerTest {
             "bulkscan",
             CONSUMED.toString(),
             COMPLETED.toString(),
-            Classification.EXCEPTION.name()
+            EXCEPTION.name()
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan"))
@@ -173,7 +174,7 @@ public class ReportsControllerTest {
             "bulkscan",
             CONSUMED.toString(),
             COMPLETED.toString(),
-            Classification.SUPPLEMENTARY_EVIDENCE.name()
+            SUPPLEMENTARY_EVIDENCE.name()
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan"))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/reports/zipfilesummary/ZipFileSummaryItem.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/reports/zipfilesummary/ZipFileSummaryItem.java
@@ -12,6 +12,7 @@ public class ZipFileSummaryItem implements ZipFileSummary {
     private final String container;
     private final String lastEventStatus;
     private final String envelopeStatus;
+    private final String classification;
 
     public ZipFileSummaryItem(
         String zipFileName,
@@ -19,7 +20,8 @@ public class ZipFileSummaryItem implements ZipFileSummary {
         Instant completedDate,
         String container,
         String lastEventStatus,
-        String envelopeStatus
+        String envelopeStatus,
+        String classification
     ) {
         this.zipFileName = zipFileName;
         this.createdDate = createdDate;
@@ -27,6 +29,7 @@ public class ZipFileSummaryItem implements ZipFileSummary {
         this.container = container;
         this.lastEventStatus = lastEventStatus;
         this.envelopeStatus = envelopeStatus;
+        this.classification = classification;
     }
 
     @Override
@@ -57,5 +60,10 @@ public class ZipFileSummaryItem implements ZipFileSummary {
     @Override
     public String getEnvelopeStatus() {
         return envelopeStatus;
+    }
+
+    @Override
+    public String getClassification() {
+        return classification;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummary
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.zipfilesummary.ZipFileSummaryItem;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
@@ -30,6 +29,8 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.EXCEPTION;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.NEW_APPLICATION;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService.TEST_CONTAINER;
@@ -128,7 +129,7 @@ public class ReportsServiceTest {
                     "c1",
                     Event.ZIPFILE_PROCESSING_STARTED.toString(),
                     Status.CREATED.toString(),
-                    Classification.EXCEPTION.name()
+                    EXCEPTION.name()
                 ),
                 new ZipFileSummaryItem(
                     "t2.zip",
@@ -137,7 +138,7 @@ public class ReportsServiceTest {
                     "c2",
                     Event.COMPLETED.toString(),
                     Status.UPLOADED.toString(),
-                    Classification.NEW_APPLICATION.name()
+                    NEW_APPLICATION.name()
                 )
             ));
 
@@ -157,7 +158,7 @@ public class ReportsServiceTest {
                     "c1",
                     Event.ZIPFILE_PROCESSING_STARTED.toString(),
                     Status.CREATED.toString(),
-                    Classification.EXCEPTION.name()
+                    EXCEPTION.name()
                 ),
                 new ZipFileSummaryResponse(
                     "t2.zip",
@@ -168,7 +169,7 @@ public class ReportsServiceTest {
                     "c2",
                     Event.COMPLETED.toString(),
                     Status.UPLOADED.toString(),
-                    Classification.NEW_APPLICATION.name()
+                    NEW_APPLICATION.name()
                 )
             );
     }
@@ -185,7 +186,7 @@ public class ReportsServiceTest {
                     "c1",
                     ZIPFILE_PROCESSING_STARTED.toString(),
                     null,
-                    Classification.EXCEPTION.name()
+                    EXCEPTION.name()
                 ),
                 new ZipFileSummaryItem(
                     "t2.zip",
@@ -194,7 +195,7 @@ public class ReportsServiceTest {
                     "c2",
                     COMPLETED.toString(),
                     null,
-                    Classification.EXCEPTION.name()
+                    EXCEPTION.name()
                 )
             ));
 
@@ -206,7 +207,7 @@ public class ReportsServiceTest {
         assertThat(result.get(0).container).isEqualTo("c2");
 
         assertThat(result.get(0).fileName).isEqualTo("t2.zip");
-        assertThat(result.get(0).classification).isEqualTo(Classification.EXCEPTION.name());
+        assertThat(result.get(0).classification).isEqualTo(EXCEPTION.name());
     }
 
     private LocalTime toLocalTime(Instant instant) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummary
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.zipfilesummary.ZipFileSummaryItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
@@ -126,7 +127,8 @@ public class ReportsServiceTest {
                     null,
                     "c1",
                     Event.ZIPFILE_PROCESSING_STARTED.toString(),
-                    Status.CREATED.toString()
+                    Status.CREATED.toString(),
+                    Classification.EXCEPTION.name()
                 ),
                 new ZipFileSummaryItem(
                     "t2.zip",
@@ -134,7 +136,8 @@ public class ReportsServiceTest {
                     instant.minus(20, MINUTES),
                     "c2",
                     Event.COMPLETED.toString(),
-                    Status.UPLOADED.toString()
+                    Status.UPLOADED.toString(),
+                    Classification.NEW_APPLICATION.name()
                 )
             ));
 
@@ -153,7 +156,8 @@ public class ReportsServiceTest {
                     null,
                     "c1",
                     Event.ZIPFILE_PROCESSING_STARTED.toString(),
-                    Status.CREATED.toString()
+                    Status.CREATED.toString(),
+                    Classification.EXCEPTION.name()
                 ),
                 new ZipFileSummaryResponse(
                     "t2.zip",
@@ -163,7 +167,8 @@ public class ReportsServiceTest {
                     toLocalTime(instant.minus(20, MINUTES)),
                     "c2",
                     Event.COMPLETED.toString(),
-                    Status.UPLOADED.toString()
+                    Status.UPLOADED.toString(),
+                    Classification.NEW_APPLICATION.name()
                 )
             );
     }
@@ -174,10 +179,22 @@ public class ReportsServiceTest {
         given(zipFilesSummaryRepo.getZipFileSummaryReportFor(now()))
             .willReturn(asList(
                 new ZipFileSummaryItem(
-                    "t1.zip", instant.minus(1, MINUTES), null, "c1", ZIPFILE_PROCESSING_STARTED.toString(), null
+                    "t1.zip",
+                    instant.minus(1, MINUTES),
+                    null,
+                    "c1",
+                    ZIPFILE_PROCESSING_STARTED.toString(),
+                    null,
+                    Classification.EXCEPTION.name()
                 ),
                 new ZipFileSummaryItem(
-                    "t2.zip", instant.minus(10, MINUTES), instant.minus(20, MINUTES), "c2", COMPLETED.toString(), null
+                    "t2.zip",
+                    instant.minus(10, MINUTES),
+                    instant.minus(20, MINUTES),
+                    "c2",
+                    COMPLETED.toString(),
+                    null,
+                    Classification.EXCEPTION.name()
                 )
             ));
 
@@ -189,6 +206,7 @@ public class ReportsServiceTest {
         assertThat(result.get(0).container).isEqualTo("c2");
 
         assertThat(result.get(0).fileName).isEqualTo("t2.zip");
+        assertThat(result.get(0).classification).isEqualTo(Classification.EXCEPTION.name());
     }
 
     private LocalTime toLocalTime(Instant instant) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -4,7 +4,6 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
@@ -18,6 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.SUPPLEMENTARY_EVIDENCE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_PROCESSED;
 
 public class CsvWriterTest {
@@ -38,7 +38,7 @@ public class CsvWriterTest {
                 "bulkscan",
                 Event.DOC_PROCESSED.toString(),
                 Status.UPLOADED.toString(),
-                Classification.SUPPLEMENTARY_EVIDENCE.name()
+                SUPPLEMENTARY_EVIDENCE.name()
             ),
             new ZipFileSummaryResponse(
                 "test2.zip",
@@ -84,7 +84,7 @@ public class CsvWriterTest {
                     date.toString(),
                     time.toString(),
                     DOC_PROCESSED.toString(),
-                    Classification.SUPPLEMENTARY_EVIDENCE.name()
+                    SUPPLEMENTARY_EVIDENCE.name()
                 ),
                 tuple(
                     "bulkscan",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
@@ -36,7 +37,8 @@ public class CsvWriterTest {
                 time,
                 "bulkscan",
                 Event.DOC_PROCESSED.toString(),
-                Status.UPLOADED.toString()
+                Status.UPLOADED.toString(),
+                Classification.SUPPLEMENTARY_EVIDENCE.name()
             ),
             new ZipFileSummaryResponse(
                 "test2.zip",
@@ -46,7 +48,8 @@ public class CsvWriterTest {
                 time,
                 "bulkscan",
                 Event.DOC_PROCESSED.toString(),
-                Status.UPLOADED.toString()
+                Status.UPLOADED.toString(),
+                null
             )
         );
 
@@ -60,7 +63,7 @@ public class CsvWriterTest {
             .isNotEmpty()
             .hasSize(3)
             .extracting(data -> tuple(
-                data.get(0), data.get(1), data.get(2), data.get(3), data.get(4), data.get(5), data.get(6))
+                data.get(0), data.get(1), data.get(2), data.get(3), data.get(4), data.get(5), data.get(6), data.get(7))
             )
             .containsExactly(
                 tuple(
@@ -70,7 +73,8 @@ public class CsvWriterTest {
                     "Time Received",
                     "Date Processed",
                     "Time Processed",
-                    "Status"
+                    "Status",
+                    "Classification"
                 ),
                 tuple(
                     "bulkscan",
@@ -79,7 +83,8 @@ public class CsvWriterTest {
                     time.toString(),
                     date.toString(),
                     time.toString(),
-                    DOC_PROCESSED.toString()
+                    DOC_PROCESSED.toString(),
+                    Classification.SUPPLEMENTARY_EVIDENCE.name()
                 ),
                 tuple(
                     "bulkscan",
@@ -88,7 +93,8 @@ public class CsvWriterTest {
                     time.toString(),
                     date.toString(),
                     time.toString(),
-                    DOC_PROCESSED.toString()
+                    DOC_PROCESSED.toString(),
+                    ""
                 )
             );
     }
@@ -105,7 +111,7 @@ public class CsvWriterTest {
             .isNotEmpty()
             .hasSize(1)
             .extracting(data -> tuple(
-                data.get(0), data.get(1), data.get(2), data.get(3), data.get(4), data.get(5), data.get(6))
+                data.get(0), data.get(1), data.get(2), data.get(3), data.get(4), data.get(5), data.get(6), data.get(7))
             )
             .containsExactly(
                 tuple(
@@ -115,7 +121,8 @@ public class CsvWriterTest {
                     "Time Received",
                     "Date Processed",
                     "Time Processed",
-                    "Status"
+                    "Status",
+                    "Classification"
                 )
             );
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1059

### Change description ###
Add classification column to the Zip Files Summary report.
Updated JSON format report endpoint as well.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
