### PR TITLE
Throw timeout exception when sending message to queue fails due to connection timeout

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -115,7 +115,7 @@ public class ServiceBusHelperTest {
     }
 
     @Test
-    public void should_throw_exception_when_servcie_bus_connection_times_out() throws Exception {
+    public void should_throw_exception_when_service_bus_connection_times_out() throws Exception {
         // given
         Msg msg = new EnvelopeMsg(envelope);
         willThrow(TimeoutException.class).given(queueClient).send(any());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.Message;
+import com.microsoft.azure.servicebus.primitives.TimeoutException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +20,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Payment;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceBusConnectionTimeoutException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
@@ -38,6 +40,9 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -107,6 +112,21 @@ public class ServiceBusHelperTest {
         when(envelope.getId()).thenReturn(null);
         Msg msg = new EnvelopeMsg(envelope);
         serviceBusHelper.sendMessage(msg);
+    }
+
+    @Test
+    public void should_throw_exception_when_servcie_bus_connection_times_out() throws Exception {
+        // given
+        Msg msg = new EnvelopeMsg(envelope);
+        willThrow(TimeoutException.class).given(queueClient).send(any());
+
+        // when
+        Throwable exc = catchThrowable(() -> serviceBusHelper.sendMessage(msg));
+
+        //then
+        assertThat(exc)
+            .isInstanceOf(ServiceBusConnectionTimeoutException.class)
+            .hasMessage("Service Bus connection timed out while sending the message. Message ID: " + envelope.getId());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ServiceBusConnectionTimeoutException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ServiceBusConnectionTimeoutException.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class ServiceBusConnectionTimeoutException extends RuntimeException {
+
+    public ServiceBusConnectionTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ServiceBusConnectionTimeoutException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/ServiceBusConnectionTimeoutException.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
 
 public class ServiceBusConnectionTimeoutException extends RuntimeException {
 
+    private static final long serialVersionUID = -1850692854300268468L;
+
     public ServiceBusConnectionTimeoutException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelper.java
@@ -12,8 +12,8 @@ import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceBusConnectionTimeoutException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Msg;
 
-import javax.annotation.PreDestroy;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.PreDestroy;
 
 import static java.util.Collections.singletonList;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelper.java
@@ -7,11 +7,13 @@ import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.Message;
 import com.microsoft.azure.servicebus.MessageBody;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import com.microsoft.azure.servicebus.primitives.TimeoutException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidMessageException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceBusConnectionTimeoutException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Msg;
 
-import java.util.concurrent.CompletableFuture;
 import javax.annotation.PreDestroy;
+import java.util.concurrent.CompletableFuture;
 
 import static java.util.Collections.singletonList;
 
@@ -38,6 +40,11 @@ public class ServiceBusHelper implements AutoCloseable {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new InvalidMessageException("Unable to send message", e);
+        } catch (TimeoutException e) {
+            throw new ServiceBusConnectionTimeoutException(
+                "Service Bus connection timed out while sending the message. Message ID: " + msg.getMsgId(),
+                e
+            );
         } catch (ServiceBusException e) {
             throw new InvalidMessageException("Unable to send message", e);
         }


### PR DESCRIPTION
### Change description ###
Bulk scan processor Health check often fails due to queue connection timeout. But the logs are misleading with `Invalid Message` text. 
Added a new exception `ServicebusConnectionTimeoutException` to differentiate from the other exceptions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
