### PR TITLE
Update script to add second argument for Zip file name

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -21,10 +21,12 @@ If help required - ask BSP team.
 ```bash
 $ export SAS_TOKEN="sv=2019-02-02&spr=https%2Chttp&se=2019-12-10T15%3A45%3A13Z&sr=c&sp=wl&sig=OmUS7%2BH62ah1rdQr0r36bkA0EZ10GH6fNSP54NAL0Lw%3D"
 $ export CONTAINER="mycontainer"
-$ ./sign-zip-upload.sh envelope
+$ ./sign-zip-upload.sh envelope 1-15-02-2020-08-08-19.zip
 ```
 
-where `envelope` is folder name existing in working directory.
+In the above command:
+ - `envelope` is folder name existing in working directory
+ - `1-15-02-2020-08-08-19.zip` is the zip file name and it should match with the `zip_file_name` property in metafile json
 
 #### Pre-requisites
 

--- a/bin/sign-zip-upload.sh
+++ b/bin/sign-zip-upload.sh
@@ -19,17 +19,25 @@ command -v jq >/dev/null 2>&1 || {
 if [[ -z "${1}" ]]; then
   echo "Missing folder name in current working directory"
   echo "Folder contents will be considered up to standards, zipped and uploaded to blob storage"
-  echo "\n  Re-run script \`./sign-zip-upload.sh <folder-name>\`\n"
+  echo "\n  Re-run script \`./sign-zip-upload.sh <folder-name> <zip-file-name>\`\n"
+
+  exit 1
+fi
+
+if [[ -z "${2}" ]]; then
+  echo "Missing zip file name"
+  echo "\n  Re-run script \`./sign-zip-upload.sh <folder-name> <zip-file-name>\`\n"
 
   exit 1
 fi
 
 ENVI="demo"
 DIRECTORY=$1
+ZIP_FILE_NAME=$2
 
 if [[ ! -d "$DIRECTORY" ]]; then
   echo "Cannot see $DIRECTORY in `pwd`"
-  echo "\n  Re-run script \`./sign-zip-upload.sh <folder-name>\`\n"
+  echo "\n  Re-run script \`./sign-zip-upload.sh <folder-name> <zip-file-name>\`\n"
 
   exit 1
 fi
@@ -62,11 +70,6 @@ fi
 # signed envelope contents:
 ENVELOPE_FILE_NAME=envelope.zip
 SIGNATURE_FILE_NAME=signature
-
-# generate zip file name
-ZIP_ID_PREFIX=`date +"%s"`
-ZIP_TIME_PART=`date +"%d-%m-%Y-%H-%M-%S"`
-ZIP_FILE_NAME="${ZIP_ID_PREFIX}_$ZIP_TIME_PART.test.zip"
 
 echo "Zipping the envelope..."
 


### PR DESCRIPTION
### Change description ###
The `sign-zip-upload.sh` script is auto-generating the zip file name which is causing file validation error because the `zip_file_name` in the metadata is not matching with the auto-generated filename.
(Filename validation is added in https://github.com/hmcts/bulk-scan-processor/pull/1056)

Updated the script to add `zip file name` argument and use the same to upload the script.
Updated Readme file.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
