### PR TITLE
Change message format to one accepted by notification service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
@@ -10,25 +10,40 @@ public class ErrorMsg implements Msg {
 
     public final String id;
     public final Long eventId;
+
+    @JsonProperty("zip_file_name")
     public final String zipFileName;
+
+    @JsonProperty("jurisdiction")
     public final String jurisdiction;
+
+    @JsonProperty("po_box")
     public final String poBox;
+
+    @JsonProperty("document_control_number")
     public final String documentControlNumber;
+
+    @JsonProperty("error_code")
     public final ErrorCode errorCode;
+
+    @JsonProperty("error_description")
     public final String errorDescription;
     public final String service;
 
     // region constructors
     @SuppressWarnings("squid:S00107") // number of params
     public ErrorMsg(
-        @JsonProperty(value = "id", required = true) String id,
+        // TODO: make id transient when the application stops sending error notifications
+        @JsonProperty(value = "id", required = true)
+        String id,
+        // TODO: remove eventId when the application stops sending error notifications
         @JsonProperty(value = "eventId", required = true) Long eventId,
-        @JsonProperty(value = "zipFileName", required = true) String zipFileName,
+        @JsonProperty(value = "zip_file_name", required = true) String zipFileName,
         @JsonProperty("jurisdiction") String jurisdiction,
-        @JsonProperty("poBox") String poBox,
-        @JsonProperty("documentControlNumber") String documentControlNumber,
-        @JsonProperty(value = "errorCode", required = true) ErrorCode errorCode,
-        @JsonProperty(value = "errorDescription", required = true) String errorDescription,
+        @JsonProperty("po_box") String poBox,
+        @JsonProperty("document_control_number") String documentControlNumber,
+        @JsonProperty(value = "error_code", required = true) ErrorCode errorCode,
+        @JsonProperty(value = "error_description", required = true) String errorDescription,
         @JsonProperty(value = "service", required = true) String service
     ) {
         this.id = id;


### PR DESCRIPTION
DO NOT MERGE. This PR can only be merged after processing notification has been temporarily disabled in prod.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1089

### Change description ###

Change message format to one accepted by notification service. I've left two fields - id and eventId, as they are required by the processor. They can only go away once the processor has stopped sending notifications.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
