### PR TITLE
Change message format to one accepted by notification service

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -255,7 +255,8 @@ public class ErrorNotificationHandlerTest {
                     null,
                     ERR_FILE_LIMIT_EXCEEDED,
                     "description",
-                    "service1"
+                    "service1",
+                    "container1"
                 )
             ),
             MediaType.APPLICATION_JSON_UTF8_VALUE

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
@@ -10,25 +10,40 @@ public class ErrorMsg implements Msg {
 
     public final String id;
     public final Long eventId;
+
+    @JsonProperty("zip_file_name")
     public final String zipFileName;
+
+    @JsonProperty("jurisdiction")
     public final String jurisdiction;
+
+    @JsonProperty("po_box")
     public final String poBox;
+
+    @JsonProperty("document_control_number")
     public final String documentControlNumber;
+
+    @JsonProperty("error_code")
     public final ErrorCode errorCode;
+
+    @JsonProperty("error_description")
     public final String errorDescription;
     public final String service;
 
     // region constructors
     @SuppressWarnings("squid:S00107") // number of params
     public ErrorMsg(
-        @JsonProperty(value = "id", required = true) String id,
+        // TODO: make id transient when the application stops sending error notifications
+        @JsonProperty(value = "id", required = true)
+        String id,
+        // TODO: remove eventId when the application stops sending error notifications
         @JsonProperty(value = "eventId", required = true) Long eventId,
-        @JsonProperty(value = "zipFileName", required = true) String zipFileName,
+        @JsonProperty(value = "zip_file_name", required = true) String zipFileName,
         @JsonProperty("jurisdiction") String jurisdiction,
-        @JsonProperty("poBox") String poBox,
-        @JsonProperty("documentControlNumber") String documentControlNumber,
-        @JsonProperty(value = "errorCode", required = true) ErrorCode errorCode,
-        @JsonProperty(value = "errorDescription", required = true) String errorDescription,
+        @JsonProperty("po_box") String poBox,
+        @JsonProperty("document_control_number") String documentControlNumber,
+        @JsonProperty(value = "error_code", required = true) ErrorCode errorCode,
+        @JsonProperty(value = "error_description", required = true) String errorDescription,
         @JsonProperty(value = "service", required = true) String service
     ) {
         this.id = id;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsg.java
@@ -28,7 +28,9 @@ public class ErrorMsg implements Msg {
 
     @JsonProperty("error_description")
     public final String errorDescription;
+
     public final String service;
+    public final String container;
 
     // region constructors
     @SuppressWarnings("squid:S00107") // number of params
@@ -44,7 +46,8 @@ public class ErrorMsg implements Msg {
         @JsonProperty("document_control_number") String documentControlNumber,
         @JsonProperty(value = "error_code", required = true) ErrorCode errorCode,
         @JsonProperty(value = "error_description", required = true) String errorDescription,
-        @JsonProperty(value = "service", required = true) String service
+        @JsonProperty(value = "service", required = true) String service,
+        @JsonProperty("container") String container
     ) {
         this.id = id;
         this.eventId = eventId;
@@ -55,6 +58,7 @@ public class ErrorMsg implements Msg {
         this.errorCode = errorCode;
         this.errorDescription = errorDescription;
         this.service = service;
+        this.container = container;
     }
     // endregion
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -400,7 +400,8 @@ public class BlobProcessorTask extends Processor {
                 null,
                 errorCode,
                 cause.getMessage(),
-                "bulk_scan_processor"
+                "bulk_scan_processor",
+                containerName
             )
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsgTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsgTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ErrorMsgTest {
 
     @Test
-    public void should_be_the_same_after_serialisation_and_deserialisation() throws Exception {
+    public void should_serialise_and_deserialise_correctly() throws Exception {
         // given
         ErrorMsg original = new ErrorMsg(
             "id1",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsgTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/ErrorMsgTest.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorMsgTest {
+
+    @Test
+    public void should_be_the_same_after_serialisation_and_deserialisation() throws Exception {
+        // given
+        ErrorMsg original = new ErrorMsg(
+            "id1",
+            123L,
+            "fileName1",
+            "jurisdiction1",
+            "poBox1",
+            "dcn123",
+            ErrorCode.ERR_AV_FAILED,
+            "error description 1",
+            "service 1",
+            "container 1"
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // when
+        String serialised = objectMapper.writeValueAsString(original);
+        ErrorMsg deserialised = objectMapper.readValue(serialised, ErrorMsg.class);
+
+        // then
+        assertThat(deserialised).isEqualToComparingFieldByField(original);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ErrorNotificationServiceTest.java
@@ -63,7 +63,8 @@ public class ErrorNotificationServiceTest {
             "document control number",
             ErrorCode.ERR_AV_FAILED,
             "antivirus flag",
-            "service1"
+            "service1",
+            "container1"
         );
         ErrorNotificationResponse response = new ErrorNotificationResponse("notify id");
         given(client.notify(requestCaptor.capture())).willReturn(response);
@@ -99,7 +100,8 @@ public class ErrorNotificationServiceTest {
             "document control number",
             ErrorCode.ERR_AV_FAILED,
             "antivirus flag",
-            "service1"
+            "service1",
+            "container1"
         );
         given(client.notify(any(ErrorNotificationRequest.class))).willThrow(new RuntimeException("oh no"));
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ErrorNotificationHandlerTest.java
@@ -119,7 +119,8 @@ public class ErrorNotificationHandlerTest {
             "document_control_number",
             ErrorCode.ERR_AV_FAILED,
             "av fail",
-            "service1"
+            "service1",
+            "container1"
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1089

### Change description ###

This PR is same as #1103 - reopened due to the PR being stuck in an unrecoverable failure state

Change message format to one accepted by notification service. I've left two fields - id and eventId, as they are required by the processor. They can only go away once the processor has stopped sending notifications.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
