### PR TITLE
Added zipDeleted parameter to query

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
@@ -140,7 +140,7 @@ public class EnvelopeRepositoryTest {
         );
 
         // when
-        final List<Envelope> result = repo.findByContainerAndStatus(container1, Status.COMPLETED);
+        final List<Envelope> result = repo.findByContainerAndStatusAndZipDeleted(container1, Status.COMPLETED, false);
 
         // then
         assertThat(result)
@@ -149,6 +149,30 @@ public class EnvelopeRepositoryTest {
             .containsExactlyInAnyOrder(
                 tuple(Status.COMPLETED, container1),
                 tuple(Status.COMPLETED, container1)
+            );
+    }
+
+    @Test
+    public void should_find_complete_envelopes_by_container_excluding_already_deleted() {
+        // given
+        final String container1 = "container1";
+        dbHas(
+            envelope("X", Status.COMPLETED, container1),
+            envelope("Y", Status.PROCESSED, "container2"),
+            envelope("X", Status.COMPLETED, container1, true),
+            envelope("X", Status.PROCESSED, container1),
+            envelope("Z", Status.COMPLETED, "container3")
+        );
+
+        // when
+        final List<Envelope> result = repo.findByContainerAndStatusAndZipDeleted(container1, Status.COMPLETED, false);
+
+        // then
+        assertThat(result)
+            .hasSize(1)
+            .extracting(envelope -> tuple(envelope.getStatus(), envelope.getContainer(), envelope.isZipDeleted()))
+            .containsExactlyInAnyOrder(
+                tuple(Status.COMPLETED, container1, false)
             );
     }
 
@@ -165,7 +189,7 @@ public class EnvelopeRepositoryTest {
         );
 
         // when
-        final List<Envelope> result = repo.findByContainerAndStatus(container1, Status.COMPLETED);
+        final List<Envelope> result = repo.findByContainerAndStatusAndZipDeleted(container1, Status.COMPLETED, false);
 
         // then
         assertThat(result).isEmpty();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
@@ -157,11 +157,11 @@ public class EnvelopeRepositoryTest {
         // given
         final String container1 = "container1";
         dbHas(
-            envelope("X", Status.COMPLETED, container1),
-            envelope("Y", Status.PROCESSED, "container2"),
+            envelope("X", Status.COMPLETED, container1, false),
+            envelope("Y", Status.PROCESSED, "container2", false),
             envelope("X", Status.COMPLETED, container1, true),
-            envelope("X", Status.PROCESSED, container1),
-            envelope("Z", Status.COMPLETED, "container3")
+            envelope("X", Status.PROCESSED, container1, false),
+            envelope("Z", Status.COMPLETED, "container3", false)
         );
 
         // when

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -97,5 +97,5 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
     )
     int getIncompleteEnvelopesCountBefore(@Param("date") LocalDate date);
 
-    List<Envelope> findByContainerAndStatus(String container, Status status);
+    List<Envelope> findByContainerAndStatusAndZipDeleted(String container, Status status, boolean zipDeleted);
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -84,7 +84,13 @@ public final class EnvelopeCreator {
     }
 
     public static Envelope envelope(String jurisdiction, Status status, String container) {
-        return envelope(randomUUID() + ".zip", jurisdiction, status, scannableItems(), container);
+        return envelope(jurisdiction, status, container, false);
+    }
+
+    public static Envelope envelope(String jurisdiction, Status status, String container, boolean zipDeleted) {
+        Envelope envelope = envelope(randomUUID() + ".zip", jurisdiction, status, scannableItems(), container);
+        envelope.setZipDeleted(zipDeleted);
+        return envelope;
     }
 
     public static Envelope envelope(String jurisdiction, Status status, List<ScannableItem> scannableItems) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-716


### Change description ###
Added zipDeleted parameter to the query to make it possible to exclude already deleted envelopes from the result, otherwise such envelopes will be fetched again and again.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
