### PR TITLE
Rename classes related to rejected files report

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.testcontainers.containers.DockerComposeContainer;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedEnvelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFile;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
 import java.io.File;
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RejectedEnvelopesReportServiceTest {
+public class RejectedFilesReportServiceTest {
 
     @Autowired
     private BlobManagementProperties blobManagementProperties;
@@ -63,14 +63,14 @@ public class RejectedEnvelopesReportServiceTest {
         assertThat(rejectedContainer.listBlobs()).hasSize(2); // sanity check
 
         // when
-        List<RejectedEnvelope> result = new RejectedEnvelopesReportService(blobManager).getRejectedEnvelopes();
+        List<RejectedFile> result = new RejectedFilesReportService(blobManager).getRejectedFiles();
 
         // then
         assertThat(result)
             .usingFieldByFieldElementComparator()
             .containsExactlyInAnyOrder(
-                new RejectedEnvelope("foo.zip", "test-rejected"),
-                new RejectedEnvelope("bar.zip", "test-rejected")
+                new RejectedFile("foo.zip", "test-rejected"),
+                new RejectedFile("bar.zip", "test-rejected")
             );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -14,10 +14,10 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.EnvelopeCountSumm
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.RejectedEnvelopesResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportListResponse;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedEnvelopesReportService;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedFilesReportService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedEnvelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFile;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.util.CsvWriter;
 
@@ -35,15 +35,15 @@ import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 public class ReportsController {
 
     private final ReportsService reportsService;
-    private final RejectedEnvelopesReportService rejectedEnvelopesReportService;
+    private final RejectedFilesReportService rejectedFilesReportService;
 
     // region constructor
     public ReportsController(
         ReportsService reportsService,
-        RejectedEnvelopesReportService rejectedEnvelopesReportService
+        RejectedFilesReportService rejectedFilesReportService
     ) {
         this.reportsService = reportsService;
-        this.rejectedEnvelopesReportService = rejectedEnvelopesReportService;
+        this.rejectedFilesReportService = rejectedFilesReportService;
     }
     // endregion
 
@@ -108,9 +108,9 @@ public class ReportsController {
     }
 
     @GetMapping(path = "/rejected")
-    @ApiOperation("Retrieves rejected envelopes")
-    public RejectedEnvelopesResponse getRejectedEnvelopes() {
-        List<RejectedEnvelope> rejectedEnvs = this.rejectedEnvelopesReportService.getRejectedEnvelopes();
+    @ApiOperation("Retrieves rejected files")
+    public RejectedEnvelopesResponse getRejectedFiles() {
+        List<RejectedFile> rejectedEnvs = this.rejectedFilesReportService.getRejectedFiles();
         return new RejectedEnvelopesResponse(rejectedEnvs.size(), rejectedEnvs);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ReportsController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.EnvelopeCountSummaryReportItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.EnvelopeCountSummaryReportListResponse;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.RejectedEnvelopesResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.RejectedFilesResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports.ZipFilesSummaryReportListResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedFilesReportService;
@@ -109,8 +109,8 @@ public class ReportsController {
 
     @GetMapping(path = "/rejected")
     @ApiOperation("Retrieves rejected files")
-    public RejectedEnvelopesResponse getRejectedFiles() {
+    public RejectedFilesResponse getRejectedFiles() {
         List<RejectedFile> rejectedEnvs = this.rejectedFilesReportService.getRejectedFiles();
-        return new RejectedEnvelopesResponse(rejectedEnvs.size(), rejectedEnvs);
+        return new RejectedFilesResponse(rejectedEnvs.size(), rejectedEnvs);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/RejectedEnvelopesResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/RejectedEnvelopesResponse.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.out.reports;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedEnvelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFile;
 
 import java.util.List;
 
@@ -11,10 +11,10 @@ public class RejectedEnvelopesResponse {
     public final int count;
 
     @JsonProperty("rejected_envelopes")
-    public final List<RejectedEnvelope> rejectedEnvelopes;
+    public final List<RejectedFile> rejectedFiles;
 
-    public RejectedEnvelopesResponse(int count, List<RejectedEnvelope> rejectedEnvelopes) {
+    public RejectedEnvelopesResponse(int count, List<RejectedFile> rejectedFiles) {
         this.count = count;
-        this.rejectedEnvelopes = rejectedEnvelopes;
+        this.rejectedFiles = rejectedFiles;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/RejectedFilesResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/RejectedFilesResponse.java
@@ -10,7 +10,7 @@ public class RejectedFilesResponse {
     @JsonProperty("count")
     public final int count;
 
-    @JsonProperty("rejected_envelopes")
+    @JsonProperty("rejected_files")
     public final List<RejectedFile> rejectedFiles;
 
     public RejectedFilesResponse(int count, List<RejectedFile> rejectedFiles) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/RejectedFilesResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/RejectedFilesResponse.java
@@ -5,7 +5,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFil
 
 import java.util.List;
 
-public class RejectedEnvelopesResponse {
+public class RejectedFilesResponse {
 
     @JsonProperty("count")
     public final int count;
@@ -13,7 +13,7 @@ public class RejectedEnvelopesResponse {
     @JsonProperty("rejected_envelopes")
     public final List<RejectedFile> rejectedFiles;
 
-    public RejectedEnvelopesResponse(int count, List<RejectedFile> rejectedFiles) {
+    public RejectedFilesResponse(int count, List<RejectedFile> rejectedFiles) {
         this.count = count;
         this.rejectedFiles = rejectedFiles;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
@@ -4,7 +4,7 @@ import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.ListBlobItem;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedEnvelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFile;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
 import java.util.EnumSet;
@@ -16,21 +16,21 @@ import static com.microsoft.azure.storage.blob.BlobListingDetails.SNAPSHOTS;
 import static java.util.stream.Collectors.toList;
 
 @Service
-public class RejectedEnvelopesReportService {
+public class RejectedFilesReportService {
 
     private final BlobManager blobManager;
 
-    public RejectedEnvelopesReportService(BlobManager blobManager) {
+    public RejectedFilesReportService(BlobManager blobManager) {
         this.blobManager = blobManager;
     }
 
-    public List<RejectedEnvelope> getRejectedEnvelopes() {
+    public List<RejectedFile> getRejectedFiles() {
         return blobManager
             .listRejectedContainers()
             .stream()
             .flatMap(container ->
                 getBlobs(container)
-                    .map(listItem -> new RejectedEnvelope(
+                    .map(listItem -> new RejectedFile(
                         FilenameUtils.getName(listItem.getUri().toString()),
                         container.getName()
                     )))

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/RejectedFile.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/RejectedFile.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models;
 
-public class RejectedEnvelope {
+public class RejectedFile {
 
     public final String filename;
     public final String container;
 
-    public RejectedEnvelope(String filename, String container) {
+    public RejectedFile(String filename, String container) {
         this.filename = filename;
         this.container = container;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -7,10 +7,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.bulkscanprocessor.controllers.ReportsController;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedEnvelopesReportService;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.RejectedFilesReportService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReportsService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.EnvelopeCountSummary;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedEnvelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFile;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
 import java.time.LocalDate;
@@ -40,7 +40,7 @@ public class ReportsControllerTest {
     private ReportsService reportsService;
 
     @MockBean
-    private RejectedEnvelopesReportService rejectedEnvelopesReportService;
+    private RejectedFilesReportService rejectedFilesReportService;
 
     @Autowired
     private MockMvc mockMvc;
@@ -212,10 +212,10 @@ public class ReportsControllerTest {
 
     @Test
     public void should_return_rejected_envelopes() throws Exception {
-        given(rejectedEnvelopesReportService.getRejectedEnvelopes())
+        given(rejectedFilesReportService.getRejectedFiles())
             .willReturn(Arrays.asList(
-                new RejectedEnvelope("a.zip", "A"),
-                new RejectedEnvelope("b.zip", "B")
+                new RejectedFile("a.zip", "A"),
+                new RejectedFile("b.zip", "B")
             ));
 
         mockMvc
@@ -240,7 +240,7 @@ public class ReportsControllerTest {
 
     @Test
     public void should_return_proper_response_when_there_are_no_rejected_envelopes() throws Exception {
-        given(rejectedEnvelopesReportService.getRejectedEnvelopes())
+        given(rejectedFilesReportService.getRejectedFiles())
             .willReturn(emptyList());
 
         mockMvc

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -211,7 +211,7 @@ public class ReportsControllerTest {
     }
 
     @Test
-    public void should_return_rejected_envelopes() throws Exception {
+    public void should_return_rejected_files() throws Exception {
         given(rejectedFilesReportService.getRejectedFiles())
             .willReturn(Arrays.asList(
                 new RejectedFile("a.zip", "A"),
@@ -224,7 +224,7 @@ public class ReportsControllerTest {
             .andExpect(content().json(
                 "{"
                     + "'count': 2,"
-                    + "'rejected_envelopes': ["
+                    + "'rejected_files': ["
                     + "  {"
                     + "    'filename': 'a.zip',"
                     + "    'container': 'A'"
@@ -239,7 +239,7 @@ public class ReportsControllerTest {
     }
 
     @Test
-    public void should_return_proper_response_when_there_are_no_rejected_envelopes() throws Exception {
+    public void should_return_proper_response_when_there_are_no_rejected_files() throws Exception {
         given(rejectedFilesReportService.getRejectedFiles())
             .willReturn(emptyList());
 
@@ -247,7 +247,7 @@ public class ReportsControllerTest {
             .perform(get("/reports/rejected"))
             .andExpect(status().isOk())
             .andExpect(content().json(
-                "{'count': 0, 'rejected_envelopes': []}"
+                "{'count': 0, 'rejected_files': []}"
             ));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedEnvelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFile;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
 import java.net.URI;
@@ -22,20 +22,20 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-public class RejectedEnvelopesReportServiceTest {
+public class RejectedFilesReportServiceTest {
 
     @Mock private BlobManager blobManager;
     @Mock private CloudBlobContainer containerA;
     @Mock private CloudBlobContainer containerB;
 
-    private RejectedEnvelopesReportService service;
+    private RejectedFilesReportService service;
 
     @BeforeEach
     public void setUp() throws Exception {
         given(blobManager.listRejectedContainers())
             .willReturn(asList(containerA, containerB));
 
-        service = new RejectedEnvelopesReportService(blobManager);
+        service = new RejectedFilesReportService(blobManager);
     }
 
     @Test
@@ -45,7 +45,7 @@ public class RejectedEnvelopesReportServiceTest {
         setUpContainer(containerB, emptyList());
 
         // when
-        List<RejectedEnvelope> result = service.getRejectedEnvelopes();
+        List<RejectedFile> result = service.getRejectedFiles();
 
         // then
         assertThat(result).isEmpty();
@@ -61,17 +61,17 @@ public class RejectedEnvelopesReportServiceTest {
         setUpContainer(containerB, asList(mockItem("b1.zip"), mockItem("b2.zip"), mockItem("b3.zip")));
 
         // when
-        List<RejectedEnvelope> result = service.getRejectedEnvelopes();
+        List<RejectedFile> result = service.getRejectedFiles();
 
         // then
         assertThat(result)
             .usingFieldByFieldElementComparator()
             .containsExactlyInAnyOrder(
-                new RejectedEnvelope("a1.zip", "A"),
-                new RejectedEnvelope("a2.zip", "A"),
-                new RejectedEnvelope("b1.zip", "B"),
-                new RejectedEnvelope("b2.zip", "B"),
-                new RejectedEnvelope("b3.zip", "B")
+                new RejectedFile("a1.zip", "A"),
+                new RejectedFile("a2.zip", "A"),
+                new RejectedFile("b1.zip", "B"),
+                new RejectedFile("b2.zip", "B"),
+                new RejectedFile("b3.zip", "B")
             );
     }
 


### PR DESCRIPTION
The report return info about files that are currently in rejected **containers**, not envelopes in DB that are in rejected status.

Renaming for clarity