### PR TITLE
Remove signature algorithm property

### DIFF
--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-processor
 apiVersion: v1
 home: https://github.com/hmcts/bulk-scan-processor
-version: 0.2.21
+version: 0.2.22
 description: HMCTS Bulk scan processor service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-processor/values.yaml
+++ b/charts/bulk-scan-processor/values.yaml
@@ -19,7 +19,6 @@ java:
     REUPLOAD_DELAY: "4000"
     NOTIFICATIONS_TO_ORCHESTRATOR_TASK_ENABLED: "true"
     NOTIFICATIONS_TO_ORCHESTRATOR_TASK_DELAY: "3000"
-    STORAGE_BLOB_SIGNATURE_ALGORITHM: "sha256withrsa"
     STORAGE_BLOB_PUBLIC_KEY: "nonprod_public_key.der"
     STORAGE_URL: https://bulkscan.{{ .Values.global.environment }}.platform.hmcts.net
     BULK_SCANNING_DB_USER_NAME: bulk_scanner@bulk-scan-processor-{{ .Values.global.environment }}

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -12,5 +12,3 @@ allowed_client_certificate_thumbprints = ["2A1EE53E044632145C89FE428128080353127
 
 ocr_validation_url_bulkscan_sample_app = "http://bulk-scan-sample-app-demo.service.core-compute-demo.internal"
 ocr_validation_url_probate = "http://probate-back-office-demo.service.core-compute-demo.internal"
-
-enable_ase = true

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -129,7 +129,6 @@ module "bulk-scan" {
 
     STORAGE_BLOB_SELECTED_CONTAINER = "${var.blob_selected_container}"
 
-    STORAGE_BLOB_SIGNATURE_ALGORITHM = "sha256withrsa"                               // none or sha256withrsa
     STORAGE_BLOB_PUBLIC_KEY          = "${var.blob_signature_verification_key_file}"
 
     QUEUE_ENVELOPE_SEND            = "${data.azurerm_key_vault_secret.envelopes_queue_send_conn_str.value}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -151,6 +151,9 @@ module "bulk-scan" {
     OCR_VALIDATION_URL_BULKSCAN_SAMPLE_APP = "${var.ocr_validation_url_bulkscan_sample_app}"
     OCR_VALIDATION_URL_PROBATE             = "${var.ocr_validation_url_probate}"
 
+    NO_NEW_ENVELOPES_TASK_ENABLED     = "false"
+    PUBLICLAW_ENABLED                 = "true"
+
     // silence the "bad implementation" logs
     LOGBACK_REQUIRE_ALERT_LEVEL = "false"
     LOGBACK_REQUIRE_ERROR_CODE  = "false"

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -27,7 +27,8 @@ storage.blob_copy_timeout_in_millis=30000
 storage.blob_copy_polling_delay_in_millis=300
 storage.blob_lease_timeout=60
 storage.public_key_der_file=
-storage.signature_algorithm=none
+
+use-wrapping-zip=false
 
 servicebus.queue_envelope_send=Hostname=bulkscanning.servicebus.windows.net;EntityPath=envelopes
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
@@ -21,34 +21,34 @@ public class ZipFileProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(ZipFileProcessor.class);
 
-    private final String signatureAlg;
+    private final boolean useWrappingZip;
 
     public ZipFileProcessor(
-        @Value("${storage.signature_algorithm}") String signatureAlg
+        @Value("${use-wrapping-zip}") boolean useWrappingZip
     ) {
-        this.signatureAlg = signatureAlg;
+        this.useWrappingZip = useWrappingZip;
     }
 
     public ZipFileProcessingResult process(
         ZipInputStream zis,
         String zipFileName
     ) throws IOException {
-        ZipInputStream verifiedZis = ZipVerifiers
-            .getPreprocessor(signatureAlg)
+        ZipInputStream extractedZis = ZipVerifiers
+            .getPreprocessor(useWrappingZip)
             .apply(zis);
         ZipEntry zipEntry;
 
         List<Pdf> pdfs = new ArrayList<>();
         byte[] metadata = null;
 
-        while ((zipEntry = verifiedZis.getNextEntry()) != null) {
+        while ((zipEntry = extractedZis.getNextEntry()) != null) {
             switch (FilenameUtils.getExtension(zipEntry.getName())) {
                 case "json":
-                    metadata = toByteArray(verifiedZis);
+                    metadata = toByteArray(extractedZis);
 
                     break;
                 case "pdf":
-                    pdfs.add(new Pdf(zipEntry.getName(), toByteArray(verifiedZis)));
+                    pdfs.add(new Pdf(zipEntry.getName(), toByteArray(extractedZis)));
 
                     break;
                 default:

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiers.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipVerifiers.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.InvalidZipFilesException;
-import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.SignatureValidationException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -23,18 +22,13 @@ public class ZipVerifiers {
     }
 
     public static Function<ZipInputStream, ZipInputStream> getPreprocessor(
-        String signatureAlgorithm
+        boolean useWrappingZip
     ) {
-        if ("sha256withrsa".equalsIgnoreCase(signatureAlgorithm)) {
+        if (useWrappingZip) {
             return ZipVerifiers::extract;
-        } else if ("none".equalsIgnoreCase(signatureAlgorithm)) {
-            return ZipVerifiers::noOpVerification;
+        } else {
+            return zis -> zis;
         }
-        throw new SignatureValidationException("Undefined signature verification algorithm");
-    }
-
-    static ZipInputStream noOpVerification(ZipInputStream zipInputStream) {
-        return zipInputStream;
     }
 
     /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -205,4 +205,4 @@ flyway:
 process-payments:
   enabled: ${PROCESS_PAYMENTS_ENABLED:true}
 
-use-wrapping-zip: ${USE_WRAPPING_ZIP:true}
+use-wrapping-zip: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,7 +76,6 @@ storage:
   account_name: ${STORAGE_ACCOUNT_NAME:bulkscansandbox}
   key: ${STORAGE_KEY:dGVzdA==} #Base 64 encoded
   blob_lease_timeout: ${STORAGE_BLOB_LEASE_TIMEOUT:15}
-  signature_algorithm: ${STORAGE_BLOB_SIGNATURE_ALGORITHM:sha256withrsa}  # none or sha256withrsa
   public_key_der_file: ${STORAGE_BLOB_PUBLIC_KEY:test_public_key.der} # public key file in der format
   blob_copy_timeout_in_millis: ${BLOB_COPY_TIMEOUT_IN_MILLIS:30000}
   blob_copy_polling_delay_in_millis: ${BLOB_COPY_POLLING_DELAY_IN_MILLIS:500}
@@ -205,3 +204,5 @@ flyway:
 
 process-payments:
   enabled: ${PROCESS_PAYMENTS_ENABLED:true}
+
+use-wrapping-zip: ${USE_WRAPPING_ZIP:true}


### PR DESCRIPTION
I'm not sure why this property existed in the first place (all environments used `sha256withrsa`)
Keeping the toggle (now just between extracting the inner envelope and using it 'as is') as we may flip it in the future (so that it's consistent with Crime) and then remove it completely.

flux PR: https://github.com/hmcts/cnp-flux-config/pull/3081