### PR TITLE
Rename helper class

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/TestHelper.java
@@ -18,7 +18,7 @@ import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeListResponse;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.EnvelopeResponse;
-import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipVerifiers;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipExtractor;
 import uk.gov.hmcts.reform.logging.appinsights.SyntheticHeaders;
 
 import java.io.ByteArrayOutputStream;
@@ -177,7 +177,7 @@ public class TestHelper {
         byte[] zipArchive = createZipArchiveWithRandomName(files, metadataFile, zipFilename);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
-            zos.putNextEntry(new ZipEntry(ZipVerifiers.DOCUMENTS_ZIP));
+            zos.putNextEntry(new ZipEntry(ZipExtractor.DOCUMENTS_ZIP));
             zos.write(zipArchive);
             zos.closeEntry();
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipExtractor.java
@@ -13,19 +13,18 @@ import java.util.zip.ZipInputStream;
 
 import static com.google.common.io.ByteStreams.toByteArray;
 
-// TODO: rename
-public class ZipVerifiers {
+public class ZipExtractor {
 
     public static final String DOCUMENTS_ZIP = "envelope.zip";
 
-    private ZipVerifiers() {
+    private ZipExtractor() {
     }
 
     public static Function<ZipInputStream, ZipInputStream> getPreprocessor(
         boolean useWrappingZip
     ) {
         if (useWrappingZip) {
-            return ZipVerifiers::extract;
+            return ZipExtractor::extract;
         } else {
             return zis -> zis;
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
@@ -33,7 +33,7 @@ public class ZipFileProcessor {
         ZipInputStream zis,
         String zipFileName
     ) throws IOException {
-        ZipInputStream extractedZis = ZipVerifiers
+        ZipInputStream extractedZis = ZipExtractor
             .getPreprocessor(useWrappingZip)
             .apply(zis);
         ZipEntry zipEntry;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/DirectoryZipper.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/DirectoryZipper.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.helper;
 
 import com.google.common.io.Files;
-import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipVerifiers;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipExtractor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -42,7 +42,7 @@ public final class DirectoryZipper {
 
         return zipItems(
             asList(
-                new ZipItem(ZipVerifiers.DOCUMENTS_ZIP, innerZip)
+                new ZipItem(ZipExtractor.DOCUMENTS_ZIP, innerZip)
             )
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipExtractorTest.java
@@ -17,12 +17,12 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDi
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipItems;
 
 @ExtendWith(MockitoExtension.class)
-public class ZipVerifiersTest {
+public class ZipExtractorTest {
     @Test
     public void should_verify_valid_zip_successfully() throws Exception {
         byte[] zipBytes = zipDirAndWrap("signature/sample_valid_content");
 
-        ZipInputStream zis = ZipVerifiers.extract(new ZipInputStream(new ByteArrayInputStream(zipBytes)));
+        ZipInputStream zis = ZipExtractor.extract(new ZipInputStream(new ByteArrayInputStream(zipBytes)));
         assertThat(zis).isNotNull();
     }
 
@@ -31,7 +31,7 @@ public class ZipVerifiersTest {
         byte[] innerZip = zipDir("signature/sample_valid_content");
         byte[] outerZip = zipItems(singletonList((new ZipItem("invalid_entry_name", innerZip))));
 
-        assertThatThrownBy(() -> ZipVerifiers.extract(new ZipInputStream(new ByteArrayInputStream(outerZip))))
+        assertThatThrownBy(() -> ZipExtractor.extract(new ZipInputStream(new ByteArrayInputStream(outerZip))))
             .isInstanceOf(InvalidZipFilesException.class)
             .hasMessageContaining("Zip does not contain envelope");
     }


### PR DESCRIPTION
`ZipVerifiers` doesn't verify the signature anymore. It just extracts the inner zip.