### PR TITLE
Count summary report query

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
@@ -25,6 +26,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_PROCE
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOADED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALIDATION_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.util.TimeZones.EUROPE_LONDON_ZONE_ID;
 
 @RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -45,9 +47,11 @@ public class EnvelopeCountSummaryRepositoryTest {
             event("B", DOC_PROCESSED_NOTIFICATION_SENT),
             event("C", DOC_PROCESSED_NOTIFICATION_SENT)
         );
+        LocalDate date = now();
+        LocalDate earliest = date.atStartOfDay().minusDays(30).atZone(EUROPE_LONDON_ZONE_ID).toLocalDate();
 
         // when
-        List<EnvelopeCountSummaryItem> result = reportRepo.getReportFor(now());
+        List<EnvelopeCountSummaryItem> result = reportRepo.getReportFor(earliest, date);
 
         // then
         assertThat(result)
@@ -66,9 +70,11 @@ public class EnvelopeCountSummaryRepositoryTest {
             event("X", DOC_PROCESSED_NOTIFICATION_SENT),
             event("Y", DOC_PROCESSED_NOTIFICATION_SENT)
         );
+        LocalDate date = now().minusDays(1);
+        LocalDate earliest = date.atStartOfDay().minusDays(30).atZone(EUROPE_LONDON_ZONE_ID).toLocalDate();
 
         // when
-        List<EnvelopeCountSummaryItem> resultForYesterday = reportRepo.getReportFor(now().minusDays(1));
+        List<EnvelopeCountSummaryItem> resultForYesterday = reportRepo.getReportFor(earliest, date);
 
         // then
         assertThat(resultForYesterday).isEmpty();
@@ -87,9 +93,11 @@ public class EnvelopeCountSummaryRepositoryTest {
             event("some_service", "hello.zip", today, DOC_FAILURE),
             event("some_service", "hello.zip", today, DOC_FAILURE)
         );
+        LocalDate date = now();
+        LocalDate earliest = date.atStartOfDay().minusDays(30).atZone(EUROPE_LONDON_ZONE_ID).toLocalDate();
 
         // when
-        List<EnvelopeCountSummaryItem> resultForToday = reportRepo.getReportFor(now());
+        List<EnvelopeCountSummaryItem> resultForToday = reportRepo.getReportFor(earliest, date);
 
         // then
         assertThat(resultForToday).isEmpty();
@@ -118,9 +126,11 @@ public class EnvelopeCountSummaryRepositoryTest {
             event("service_E", "E1.zip", FILE_VALIDATION_FAILURE),
             event("service_E", "E1.zip", DOC_CONSUMED)
         );
+        LocalDate date = now();
+        LocalDate earliest = date.atStartOfDay().minusDays(30).atZone(EUROPE_LONDON_ZONE_ID).toLocalDate();
 
         // when
-        List<EnvelopeCountSummaryItem> result = reportRepo.getReportFor(now());
+        List<EnvelopeCountSummaryItem> result = reportRepo.getReportFor(earliest, date);
 
         // then
         assertThat(result)
@@ -141,9 +151,11 @@ public class EnvelopeCountSummaryRepositoryTest {
             event("service_A", "A1.zip", DOC_UPLOADED),
             event("service_B", "B1.zip", FILE_VALIDATION_FAILURE)
         );
+        LocalDate date = now();
+        LocalDate earliest = date.atStartOfDay().minusDays(30).atZone(EUROPE_LONDON_ZONE_ID).toLocalDate();
 
         // when
-        List<EnvelopeCountSummaryItem> result = reportRepo.getReportFor(now());
+        List<EnvelopeCountSummaryItem> result = reportRepo.getReportFor(earliest, date);
 
         // then
         assertThat(result)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TimeZones.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TimeZones.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.util;
 
+import java.time.ZoneId;
+
 public final class TimeZones {
 
     public static final String EUROPE_LONDON = "Europe/London";
+    public static final ZoneId EUROPE_LONDON_ZONE_ID = ZoneId.of(EUROPE_LONDON);
 
     private TimeZones() {
         // utility class construct

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReportsServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSumm
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.utils.ZeroRowFiller;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -51,7 +52,7 @@ public class ReportsServiceTest {
 
     @Test
     public void should_map_repo_result_properly_when_requested_for_envelope_count_summary() {
-        given(repo.getReportFor(now()))
+        given(repo.getReportFor(any(LocalDate.class), any(LocalDate.class)))
             .willReturn(asList(
                 new Item(now().plusDays(1), "A", 100, 1),
                 new Item(now().minusDays(1), "B", 200, 9)
@@ -73,7 +74,7 @@ public class ReportsServiceTest {
 
     @Test
     public void should_filter_out_test_container_when_requested_for_envelope_count_summary() {
-        given(repo.getReportFor(now()))
+        given(repo.getReportFor(any(LocalDate.class), any(LocalDate.class)))
             .willReturn(asList(
                 new Item(now(), TEST_CONTAINER, 100, 1),
                 new Item(now(), "some_other_container", 10, 0)
@@ -94,7 +95,7 @@ public class ReportsServiceTest {
 
     @Test
     public void should_map_empty_list_from_repo_when_requested_for_envelope_count_summary() {
-        given(repo.getReportFor(now())).willReturn(emptyList());
+        given(repo.getReportFor(any(LocalDate.class), any(LocalDate.class))).willReturn(emptyList());
         given(this.zeroRowFiller.fill(any(), any()))
             .willAnswer(invocation -> invocation.getArgument(0)); // return data unchanged
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1188


### Change description ###
After Friday's discussion this PR suggest an update to count summary report query to improve performance. Original suggestion to use

WHERE date(createdat) = :date 

does not work because it is possible that the first event for an envelope was created before the date in the query and the envelope should be included into the report for that date. But not using WHERE clause causes inefficiency of the query. The suggestion is to introduce one more query parameter 'earliest' which means the earliest possible date of the first event related to an envelope; currently it is coded as 30 days before the date of the report query. The WHERE clause looks like

WHERE date(createdat) >= :earliest AND date(createdat) <= :date

Reducing number of days (i.e. making 'earliest' closer to 'date') improves performance of the query.

This PR is just a performance improvement of the query fixing the original bug. Up to you should it be applied or not.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
