### PR TITLE
Amend tests for upload documents task

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
@@ -66,7 +66,7 @@ class UploadEnvelopeDocumentsTaskTest {
     // will verify grouping by container and throwing different error
     // so both exception branches are covered in a single test
     @Test
-    void should_do_nothing_when_failing_to_get_container_client() {
+    void should_call_service_twice_when_2_different_containers_are_present_in_the_list() {
         // given
         List<Envelope> envelopes = Arrays.asList(
             getEnvelope(CONTAINER_1, MINIMUM_ENVELOPE_AGE - 1),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
@@ -9,10 +9,12 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.UploadEnvelopeDocumentsService;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 
 import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -30,6 +32,7 @@ class UploadEnvelopeDocumentsTaskTest {
     private static final String CONTAINER_1 = "container-1";
     private static final String CONTAINER_2 = "container-2";
     private static final String ZIP_FILE_NAME = "zip-file-name";
+    private static final long MINIMUM_ENVELOPE_AGE = 20;
 
     @Mock private EnvelopeRepository envelopeRepository;
     @Mock private UploadEnvelopeDocumentsService uploadService;
@@ -53,7 +56,7 @@ class UploadEnvelopeDocumentsTaskTest {
         given(envelopeRepository.findByStatus(CREATED)).willReturn(singletonList(getEnvelope()));
 
         // when
-        getTask(1).run();
+        getTask(MINIMUM_ENVELOPE_AGE + 1).run();
 
         // then
         verifyNoInteractions(uploadService);
@@ -66,8 +69,8 @@ class UploadEnvelopeDocumentsTaskTest {
     void should_do_nothing_when_failing_to_get_container_client() {
         // given
         List<Envelope> envelopes = Arrays.asList(
-            getEnvelope(CONTAINER_1),
-            getEnvelope(CONTAINER_2)
+            getEnvelope(CONTAINER_1, MINIMUM_ENVELOPE_AGE - 1),
+            getEnvelope(CONTAINER_2, MINIMUM_ENVELOPE_AGE - 1)
         );
         given(envelopeRepository.findByStatus(CREATED)).willReturn(envelopes);
 
@@ -89,25 +92,37 @@ class UploadEnvelopeDocumentsTaskTest {
         );
     }
 
-    private Envelope getEnvelope(String containerName) {
-        return new Envelope(
-            "po-box",
-            "jurisdiction",
-            now(), // delivery date
-            now(), // opening date
-            now(), // zip file created at (from blob storage)
-            ZIP_FILE_NAME,
-            "case-number",
-            "previous-service-case-reference",
-            Classification.EXCEPTION,
-            emptyList(),
-            emptyList(),
-            emptyList(),
-            containerName
-        );
+    private Envelope getEnvelope(String containerName, long amountOfMinutesToSubtract) {
+        try {
+            Envelope envelope = new Envelope(
+                "po-box",
+                "jurisdiction",
+                now(), // delivery date
+                now(), // opening date
+                now(), // zip file created at (from blob storage)
+                ZIP_FILE_NAME,
+                "case-number",
+                "previous-service-case-reference",
+                Classification.EXCEPTION,
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                containerName
+            );
+
+            Field field = Envelope.class.getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(envelope, now().minus(amountOfMinutesToSubtract, MINUTES));
+
+            return envelope;
+        } catch (NoSuchFieldException | SecurityException exception) {
+            throw new RuntimeException("Could not access 'createdAt' field in envelope", exception);
+        } catch (IllegalArgumentException | IllegalAccessException exception) {
+            throw new RuntimeException("Could not update 'createdAt' field in envelope", exception);
+        }
     }
 
     private Envelope getEnvelope() {
-        return getEnvelope(CONTAINER_1);
+        return getEnvelope(CONTAINER_1, MINIMUM_ENVELOPE_AGE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
@@ -32,7 +32,7 @@ class UploadEnvelopeDocumentsTaskTest {
     private static final String CONTAINER_1 = "container-1";
     private static final String CONTAINER_2 = "container-2";
     private static final String ZIP_FILE_NAME = "zip-file-name";
-    private static final long MINIMUM_ENVELOPE_AGE = 20;
+    private static final long MINIMUM_ENVELOPE_AGE_IN_MINUTES = 20;
 
     @Mock private EnvelopeRepository envelopeRepository;
     @Mock private UploadEnvelopeDocumentsService uploadService;
@@ -56,7 +56,7 @@ class UploadEnvelopeDocumentsTaskTest {
         given(envelopeRepository.findByStatus(CREATED)).willReturn(singletonList(getEnvelope()));
 
         // when
-        getTask(MINIMUM_ENVELOPE_AGE + 1).run();
+        getTask(MINIMUM_ENVELOPE_AGE_IN_MINUTES + 1).run();
 
         // then
         verifyNoInteractions(uploadService);
@@ -69,8 +69,8 @@ class UploadEnvelopeDocumentsTaskTest {
     void should_call_service_twice_when_2_different_containers_are_present_in_the_list() {
         // given
         List<Envelope> envelopes = Arrays.asList(
-            getEnvelope(CONTAINER_1, MINIMUM_ENVELOPE_AGE - 1),
-            getEnvelope(CONTAINER_2, MINIMUM_ENVELOPE_AGE - 1)
+            getEnvelope(CONTAINER_1, MINIMUM_ENVELOPE_AGE_IN_MINUTES - 1),
+            getEnvelope(CONTAINER_2, MINIMUM_ENVELOPE_AGE_IN_MINUTES - 1)
         );
         given(envelopeRepository.findByStatus(CREATED)).willReturn(envelopes);
 
@@ -123,6 +123,6 @@ class UploadEnvelopeDocumentsTaskTest {
     }
 
     private Envelope getEnvelope() {
-        return getEnvelope(CONTAINER_1, MINIMUM_ENVELOPE_AGE);
+        return getEnvelope(CONTAINER_1, MINIMUM_ENVELOPE_AGE_IN_MINUTES);
     }
 }


### PR DESCRIPTION
### Change description ###

Every now and then unit test fails because envelope is not created in the past. Making sure creation date is set manually to make tests valid.

This config is temporary and all these changes will be reverted in the future

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
