### PR TITLE
Introduce `TestStorageHelper` for storage boilerplate actions

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
@@ -2,11 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -16,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.testcontainers.containers.DockerComposeContainer;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
@@ -28,10 +22,8 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.UploadEnvelopeDocumentsSer
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.DocumentManagementService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.util.TestStorageHelper;
 
-import java.io.File;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -40,19 +32,12 @@ import static com.google.common.io.Resources.toByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOADED;
-import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 
 @IntegrationTest
 @RunWith(SpringRunner.class)
 public class UploadEnvelopeDocumentsTaskTest {
 
-    private static final String CONTAINER_NAME = "bulkscan";
-    private static final String ZIP_FILE_NAME = "1_24-06-2018-00-00-00.zip";
-    private static final DockerComposeContainer DOCKER_CONTAINER = new DockerComposeContainer(
-        new File("src/integrationTest/resources/docker-compose.yml")
-    ).withExposedService("azure-storage", 10000);
-
-    private static CloudBlobClient cloudBlobClient;
+    private static final TestStorageHelper STORAGE_HELPER = TestStorageHelper.getInstance();
 
     @Autowired private EnvelopeProcessor envelopeProcessor;
     @Autowired private EnvelopeRepository envelopeRepository;
@@ -62,32 +47,27 @@ public class UploadEnvelopeDocumentsTaskTest {
     @MockBean private AuthTokenGenerator tokenGenerator;
     @MockBean private DocumentManagementService documentManagementService;
 
-    private CloudBlobContainer testContainer;
-
     @BeforeClass
-    public static void initializeContainer() throws InvalidKeyException, URISyntaxException {
-        DOCKER_CONTAINER.start();
-        cloudBlobClient = CloudStorageAccount
-            .parse("UseDevelopmentStorage=true")
-            .createCloudBlobClient();
+    public static void initializeContainer() {
+        TestStorageHelper.createDocker();
+        TestStorageHelper.startDocker();
     }
 
     @AfterClass
     public static void tearDownContainer() {
-        DOCKER_CONTAINER.stop();
+        TestStorageHelper.stopDocker();
     }
 
     @Before
-    public void prepare() throws URISyntaxException, StorageException {
+    public void prepare() {
+        STORAGE_HELPER.createContainer();
         envelopeRepository.deleteAll();
         eventRepository.deleteAll();
-        testContainer = cloudBlobClient.getContainerReference(CONTAINER_NAME);
-        testContainer.createIfNotExists();
     }
 
     @After
-    public void cleanUp() throws StorageException {
-        testContainer.deleteIfExists();
+    public void cleanUp() {
+        STORAGE_HELPER.deleteContainer();
         envelopeRepository.deleteAll();
         eventRepository.deleteAll();
     }
@@ -95,7 +75,7 @@ public class UploadEnvelopeDocumentsTaskTest {
     @Test
     public void should_mark_envelope_as_uploaded() throws Exception {
         // given
-        uploadToBlobStorage();
+        STORAGE_HELPER.upload();
 
         // and
         Pdf pdf = new Pdf("1111002.pdf", toByteArray(getResource("zipcontents/ok/1111002.pdf")));
@@ -109,9 +89,13 @@ public class UploadEnvelopeDocumentsTaskTest {
         // and
         InputEnvelope inputEnvelope = envelopeProcessor.parseEnvelope(
             toByteArray(getResource("zipcontents/ok/metadata.json")),
-            ZIP_FILE_NAME
+            TestStorageHelper.ZIP_FILE_NAME
         );
-        Envelope envelope = EnvelopeMapper.toDbEnvelope(inputEnvelope, CONTAINER_NAME, Optional.empty());
+        Envelope envelope = EnvelopeMapper.toDbEnvelope(
+            inputEnvelope,
+            TestStorageHelper.CONTAINER_NAME,
+            Optional.empty()
+        );
         UUID envelopeId = envelopeRepository.saveAndFlush(envelope).getId();
 
         // when
@@ -123,19 +107,5 @@ public class UploadEnvelopeDocumentsTaskTest {
             .get()
             .extracting(Envelope::getStatus)
             .isEqualTo(UPLOADED);
-    }
-
-    private void uploadToBlobStorage() throws Exception {
-        CloudBlockBlob blockBlobReference = testContainer.getBlockBlobReference(ZIP_FILE_NAME);
-
-        // Blob need to be deleted as same blob may exists if previously uploaded blob was not deleted
-        // due to doc upload failure
-        if (blockBlobReference.exists()) {
-            blockBlobReference.breakLease(0);
-            blockBlobReference.delete();
-        }
-
-        byte[] fileContent = zipDir("zipcontents/ok");
-        blockBlobReference.uploadFromByteArray(fileContent, 0, fileContent.length);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
@@ -48,9 +48,8 @@ public class UploadEnvelopeDocumentsTaskTest {
     @MockBean private DocumentManagementService documentManagementService;
 
     @BeforeClass
-    public static void initializeContainer() {
-        TestStorageHelper.createDocker();
-        TestStorageHelper.startDocker();
+    public static void initializeStorage() {
+        TestStorageHelper.initialize();
     }
 
     @AfterClass
@@ -60,14 +59,14 @@ public class UploadEnvelopeDocumentsTaskTest {
 
     @Before
     public void prepare() {
-        STORAGE_HELPER.createContainer();
+        STORAGE_HELPER.createBulkscanContainer();
         envelopeRepository.deleteAll();
         eventRepository.deleteAll();
     }
 
     @After
     public void cleanUp() {
-        STORAGE_HELPER.deleteContainer();
+        STORAGE_HELPER.deleteBulkscanContainer();
         envelopeRepository.deleteAll();
         eventRepository.deleteAll();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TestStorageHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TestStorageHelper.java
@@ -1,0 +1,109 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.util;
+
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import org.testcontainers.containers.DockerComposeContainer;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
+
+public class TestStorageHelper {
+
+    private static TestStorageHelper INSTANCE;
+
+    public static final String CONTAINER_NAME = "bulkscan";
+    public static final String ZIP_FILE_NAME = "1_24-06-2018-00-00-00.zip";
+
+    private static DockerComposeContainer<?> dockerContainer;
+    public static CloudBlobClient cloudBlobClient;
+    private CloudBlobContainer testContainer;
+
+    private TestStorageHelper() {
+        // empty constructor
+    }
+
+    public static TestStorageHelper getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TestStorageHelper();
+        }
+
+        return INSTANCE;
+    }
+
+    public static void createDocker() {
+        dockerContainer = new DockerComposeContainer<>(
+            new File("src/integrationTest/resources/docker-compose.yml")
+        ).withExposedService("azure-storage", 10000);
+    }
+
+    public static void startDocker() {
+        if (dockerContainer == null) {
+            throw new RuntimeException(
+                "Cannot start container. Did you create one with "
+                    + TestStorageHelper.class.getSimpleName()
+                    + "::createDocker in a static context?"
+            );
+        }
+
+        try {
+            dockerContainer.start();
+            cloudBlobClient = CloudStorageAccount
+                .parse("UseDevelopmentStorage=true")
+                .createCloudBlobClient();
+        } catch (InvalidKeyException | URISyntaxException exception) {
+            throw new RuntimeException("Unable to setup docker environment", exception);
+        }
+    }
+
+    public static void stopDocker() {
+        dockerContainer.stop();
+    }
+
+    public void createContainer() {
+        try {
+            testContainer = cloudBlobClient.getContainerReference(CONTAINER_NAME);
+            testContainer.createIfNotExists();
+        } catch (URISyntaxException | StorageException exception) {
+            throw new RuntimeException("Unable to create container", exception);
+        }
+    }
+
+    public void deleteContainer() {
+        try {
+            testContainer.deleteIfExists();
+        } catch (StorageException exception) {
+            throw new RuntimeException("Unable to delete container", exception);
+        }
+    }
+
+    public void upload(String directory) {
+        try {
+            CloudBlockBlob blockBlobReference = testContainer.getBlockBlobReference(ZIP_FILE_NAME);
+
+            // Blob need to be deleted as same blob may exists if previously uploaded blob was not deleted
+            // due to doc upload failure
+            if (blockBlobReference.exists()) {
+                blockBlobReference.breakLease(0);
+                blockBlobReference.delete();
+            }
+
+            byte[] fileContent = zipDir(directory);
+            blockBlobReference.uploadFromByteArray(fileContent, 0, fileContent.length);
+        } catch (Exception exception) {
+            throw new RuntimeException("Unable to upload zip to test container", exception);
+        }
+    }
+
+    /**
+     * Uploads the default contents which are under 'zipcontents/ok' directory.
+     */
+    public void upload() {
+        upload("zipcontents/ok");
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TestStorageHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TestStorageHelper.java
@@ -36,36 +36,33 @@ public class TestStorageHelper {
         return INSTANCE;
     }
 
-    public static void createDocker() {
+    private static void createDocker() {
         dockerContainer = new DockerComposeContainer<>(
             new File("src/integrationTest/resources/docker-compose.yml")
         ).withExposedService("azure-storage", 10000);
+        dockerContainer.start();
     }
 
-    public static void startDocker() {
-        if (dockerContainer == null) {
-            throw new RuntimeException(
-                "Cannot start container. Did you create one with "
-                    + TestStorageHelper.class.getSimpleName()
-                    + "::createDocker in a static context?"
-            );
-        }
-
+    private static void initializeStorage() {
         try {
-            dockerContainer.start();
             cloudBlobClient = CloudStorageAccount
                 .parse("UseDevelopmentStorage=true")
                 .createCloudBlobClient();
         } catch (InvalidKeyException | URISyntaxException exception) {
-            throw new RuntimeException("Unable to setup docker environment", exception);
+            throw new RuntimeException("Unable to initialize storage", exception);
         }
+    }
+
+    public static void initialize() {
+        createDocker();
+        initializeStorage();
     }
 
     public static void stopDocker() {
         dockerContainer.stop();
     }
 
-    public void createContainer() {
+    public void createBulkscanContainer() {
         try {
             testContainer = cloudBlobClient.getContainerReference(CONTAINER_NAME);
             testContainer.createIfNotExists();
@@ -74,7 +71,7 @@ public class TestStorageHelper {
         }
     }
 
-    public void deleteContainer() {
+    public void deleteBulkscanContainer() {
         try {
             testContainer.deleteIfExists();
         } catch (StorageException exception) {


### PR DESCRIPTION
### Change description ###

When removing/refactoring re-upload task repeated actions cam into play so extracting this into separate helper class. We can use this in all other tests so to reduce the clutter of all this setup

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
