### PR TITLE
Remove no longer needed PROCESSED/DOC_PROCESSED

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepositoryTest.java
@@ -25,9 +25,9 @@ public class ProcessEventRepositoryTest {
     public void findByZipFileName_should_find_events_in_db() {
         // given
         repo.saveAll(asList(
-            new ProcessEvent("A", "hello.zip", Event.DOC_PROCESSED),
-            new ProcessEvent("B", "hello.zip", Event.DOC_PROCESSED),
-            new ProcessEvent("C", "world.zip", Event.DOC_PROCESSED)
+            new ProcessEvent("A", "hello.zip", Event.DOC_UPLOADED),
+            new ProcessEvent("B", "hello.zip", Event.DOC_UPLOADED),
+            new ProcessEvent("C", "world.zip", Event.DOC_UPLOADED)
         ));
 
         // when
@@ -40,8 +40,8 @@ public class ProcessEventRepositoryTest {
         softly.assertThat(resultForHello)
             .usingElementComparatorOnFields("container", "zipFileName", "event")
             .containsExactlyInAnyOrder(
-                new ProcessEvent("A", "hello.zip", Event.DOC_PROCESSED),
-                new ProcessEvent("B", "hello.zip", Event.DOC_PROCESSED)
+                new ProcessEvent("A", "hello.zip", Event.DOC_UPLOADED),
+                new ProcessEvent("B", "hello.zip", Event.DOC_UPLOADED)
             );
 
         softly.assertThat(resultForX).hasSize(0);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
@@ -26,8 +26,6 @@ public enum Status {
                 return Optional.of(UPLOADED);
             case DOC_UPLOAD_FAILURE:
                 return Optional.of(UPLOAD_FAILURE);
-            case DOC_PROCESSED:
-                return Optional.of(PROCESSED);
             case DOC_CONSUMED:
                 return Optional.of(CONSUMED);
             case DOC_PROCESSED_NOTIFICATION_SENT:

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTask.java
@@ -16,10 +16,8 @@ import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.EnvelopeMsg;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.ServiceBusHelper;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.PROCESSED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOADED;
 
 /**
@@ -52,13 +50,9 @@ public class OrchestratorNotificationTask {
     public void run() {
         log.info("Started sending notifications to orchestrator");
 
-        // once all PROCESSED are consumed the list will always be empty and can be removed
-        List<Envelope> uploadedEnvelopes = envelopeRepo.findByStatus(UPLOADED);
-        List<Envelope> processedEnvelopes = envelopeRepo.findByStatus(PROCESSED);
-        List<Envelope> envelopesToSend = new ArrayList<>(uploadedEnvelopes);
-        envelopesToSend.addAll(processedEnvelopes);
+        List<Envelope> envelopesToSend = envelopeRepo.findByStatus(UPLOADED);
 
-        int successCount = (int)envelopesToSend
+        int successCount = (int) envelopesToSend
             .stream()
             .filter(env -> {
                 try {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
@@ -44,7 +44,7 @@ public class ZipFileStatusServiceTest {
         // given
         List<ProcessEvent> events = asList(
             event(Event.DOC_UPLOADED, "A", now(), null),
-            event(Event.DOC_PROCESSED, "A", now().minusSeconds(1), "reason1"),
+            event(Event.DOC_PROCESSED_NOTIFICATION_SENT, "A", now().plusSeconds(1), null),
             event(Event.DOC_FAILURE, "B", now().minusSeconds(2), "reason2")
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/util/CsvWriterTest.java
@@ -4,7 +4,6 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
-import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileSummaryResponse;
 
 import java.io.File;
@@ -18,7 +17,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.SUPPLEMENTARY_EVIDENCE;
-import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_PROCESSED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOADED;
 
 public class CsvWriterTest {
 
@@ -36,7 +35,7 @@ public class CsvWriterTest {
                 date,
                 time,
                 "bulkscan",
-                Event.DOC_PROCESSED.toString(),
+                DOC_UPLOADED.toString(),
                 Status.UPLOADED.toString(),
                 SUPPLEMENTARY_EVIDENCE.name()
             ),
@@ -47,7 +46,7 @@ public class CsvWriterTest {
                 date,
                 time,
                 "bulkscan",
-                Event.DOC_PROCESSED.toString(),
+                DOC_UPLOADED.toString(),
                 Status.UPLOADED.toString(),
                 null
             )
@@ -83,7 +82,7 @@ public class CsvWriterTest {
                     time.toString(),
                     date.toString(),
                     time.toString(),
-                    DOC_PROCESSED.toString(),
+                    DOC_UPLOADED.toString(),
                     SUPPLEMENTARY_EVIDENCE.name()
                 ),
                 tuple(
@@ -93,7 +92,7 @@ public class CsvWriterTest {
                     time.toString(),
                     date.toString(),
                     time.toString(),
-                    DOC_PROCESSED.toString(),
+                    DOC_UPLOADED.toString(),
                     ""
                 )
             );


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create upload documents job](https://tools.hmcts.net/jira/browse/BPS-717)

### Change description ###

Status `PROCESSED` and event `DOC_PROCESSED` is no longer needed since #1206 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
