### PR TITLE
Remove troublesome and not useful log capture from integration tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 
@@ -20,9 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 public class EnvelopeTest {
-
-    @Rule
-    public OutputCapture capture = new OutputCapture();
 
     @Autowired
     private EnvelopeRepository repository;
@@ -57,11 +52,6 @@ public class EnvelopeTest {
         Envelope dbEnvelope = repository.saveAndFlush(envelope);
 
         // then
-        assertThat(capture.toString()).containsPattern(
-                ".+ WARN.+" + Envelope.class.getSimpleName() + " Missing required container for .+\\.zip"
-        );
-
-        // and
         assertThat(dbEnvelope.getId()).isNotNull();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 
-import java.io.IOException;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +27,7 @@ public class EnvelopeTest {
     }
 
     @Test
-    public void should_insert_into_db_and_retrieve_the_same_envelope() throws IOException {
+    public void should_insert_into_db_and_retrieve_the_same_envelope() {
         // given
         Envelope envelope = EnvelopeCreator.envelope();
 
@@ -43,7 +42,7 @@ public class EnvelopeTest {
     }
 
     @Test
-    public void should_log_a_warning_when_container_is_not_set() throws IOException {
+    public void should_log_a_warning_when_container_is_not_set() {
         // given
         Envelope envelope = EnvelopeCreator.envelope();
         envelope.setContainer(null);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -2,12 +2,9 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableMap;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
@@ -29,9 +26,6 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDi
 @RunWith(SpringRunner.class)
 public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<BlobProcessorTask> {
 
-    @Rule
-    public OutputCapture outputCapture = new OutputCapture();
-
     @Before
     public void setUp() throws Exception {
         super.setUp();
@@ -48,12 +42,6 @@ public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<Bl
             serviceBusHelper,
             paymentsEnabled
         );
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        super.cleanUp();
-        outputCapture.flush();
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

- Not useful
- Incompatible with logging library
- Deprecated junit feature (kind of "blocker" to migrate to junit5)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
