### PR TITLE
Check the lease acquired time when acquiring the lease for blob

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/BlobManagementProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/config/BlobManagementProperties.java
@@ -13,6 +13,8 @@ public class BlobManagementProperties {
 
     private String blobSelectedContainer;
 
+    private Integer blobLeaseAcquireDelayInSeconds;
+
     public Integer getBlobCopyTimeoutInMillis() {
         return blobCopyTimeoutInMillis;
     }
@@ -43,5 +45,13 @@ public class BlobManagementProperties {
 
     public void setBlobSelectedContainer(String blobSelectedContainer) {
         this.blobSelectedContainer = blobSelectedContainer;
+    }
+
+    public Integer getBlobLeaseAcquireDelayInSeconds() {
+        return blobLeaseAcquireDelayInSeconds;
+    }
+
+    public void setBlobLeaseAcquireDelayInSeconds(Integer blobLeaseAcquireDelayInSeconds) {
+        this.blobLeaseAcquireDelayInSeconds = blobLeaseAcquireDelayInSeconds;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -77,7 +77,7 @@ public class BlobManager {
 
             String leaseId = cloudBlockBlob.acquireLease(properties.getBlobLeaseTimeout(), null);
             log.info("Acquired lease on file {} in container {}. Lease ID: {}", zipFilename, containerName, leaseId);
-            // add lease acquired time to the blob metadata
+            // add lease expire time to the blob metadata
             cloudBlockBlob.getMetadata().put(
                 LEASE_EXPIRE_TIME,
                 LocalDateTime.now(EUROPE_LONDON_ZONE_ID)
@@ -108,7 +108,7 @@ public class BlobManager {
         try {
             log.info("Releasing lease on file {} in container {}. Lease ID: {}", zipFileName, containerName, leaseId);
             cloudBlockBlob.releaseLease(AccessCondition.generateLeaseCondition(leaseId));
-            // clear lease acquired time from blob metadata
+            // clear lease expire time from blob metadata
             cloudBlockBlob.getMetadata().remove(LEASE_EXPIRE_TIME);
             log.info("Released lease on file {} in container {}. Lease ID: {}", zipFileName, containerName, leaseId);
         } catch (Exception exc) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -38,7 +38,7 @@ public class BlobManager {
     private static final String SELECT_ALL_CONTAINER = "ALL";
     private static final String LEASE_ALREADY_ACQUIRED_MESSAGE =
         "Can't acquire lease on file {} in container {} - already acquired";
-    public static final String LEASE_EXPIRE_TIME = "lease-expire-time";
+    public static final String LEASE_EXPIRATION_TIME = "lease-expiration-time";
 
     private final CloudBlobClient cloudBlobClient;
     private final BlobManagementProperties properties;
@@ -77,9 +77,9 @@ public class BlobManager {
 
             String leaseId = cloudBlockBlob.acquireLease(properties.getBlobLeaseTimeout(), null);
             log.info("Acquired lease on file {} in container {}. Lease ID: {}", zipFilename, containerName, leaseId);
-            // add lease expire time to the blob metadata
+            // add lease expiration time to the blob metadata
             cloudBlockBlob.getMetadata().put(
-                LEASE_EXPIRE_TIME,
+                LEASE_EXPIRATION_TIME,
                 LocalDateTime.now(EUROPE_LONDON_ZONE_ID)
                     .plusSeconds(properties.getBlobLeaseAcquireDelayInSeconds()).toString()
             );
@@ -108,8 +108,8 @@ public class BlobManager {
         try {
             log.info("Releasing lease on file {} in container {}. Lease ID: {}", zipFileName, containerName, leaseId);
             cloudBlockBlob.releaseLease(AccessCondition.generateLeaseCondition(leaseId));
-            // clear lease expire time from blob metadata
-            cloudBlockBlob.getMetadata().remove(LEASE_EXPIRE_TIME);
+            // clear lease expiration time from blob metadata
+            cloudBlockBlob.getMetadata().remove(LEASE_EXPIRATION_TIME);
             log.info("Released lease on file {} in container {}. Lease ID: {}", zipFileName, containerName, leaseId);
         } catch (Exception exc) {
             log.error(
@@ -245,7 +245,7 @@ public class BlobManager {
     }
 
     private boolean readyToAcquireLease(CloudBlockBlob cloudBlockBlob) {
-        String leaseAcquiredAt = cloudBlockBlob.getMetadata().get(LEASE_EXPIRE_TIME);
+        String leaseAcquiredAt = cloudBlockBlob.getMetadata().get(LEASE_EXPIRATION_TIME);
         if (StringUtils.isBlank(leaseAcquiredAt)) {
             return true;
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -249,7 +249,7 @@ public class BlobManager {
             return true;
         } else {
             LocalDateTime leaseAcquiredAtTime = LocalDateTime.parse(leaseAcquiredAt);
-            Duration timeDifference = Duration.between(LocalDateTime.now(), leaseAcquiredAtTime);
+            Duration timeDifference = Duration.between(LocalDateTime.now(EUROPE_LONDON_ZONE_ID), leaseAcquiredAtTime);
             // returns true if lease acquired for longer than configured duration
             return Math.abs(timeDifference.getSeconds()) > properties.getBlobLeaseAcquireDelayInSeconds();
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.blob.CopyStatus;
 import com.microsoft.azure.storage.blob.DeleteSnapshotsOption;
 import com.microsoft.azure.storage.blob.LeaseStatus;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.RejectedBlobCopyException;
 
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +28,7 @@ import java.util.stream.StreamSupport;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscanprocessor.util.TimeZones.EUROPE_LONDON_ZONE_ID;
 
 @Component
 @EnableConfigurationProperties(BlobManagementProperties.class)
@@ -36,6 +39,7 @@ public class BlobManager {
     private static final String SELECT_ALL_CONTAINER = "ALL";
     private static final String LEASE_ALREADY_ACQUIRED_MESSAGE =
         "Can't acquire lease on file {} in container {} - already acquired";
+    public static final String LEASE_ACQUIRED_TIME = "lease-acquired-time";
 
     private final CloudBlobClient cloudBlobClient;
     private final BlobManagementProperties properties;
@@ -61,10 +65,24 @@ public class BlobManager {
             if (cloudBlockBlob.getProperties().getLeaseStatus() == LeaseStatus.LOCKED) {
                 log.info(LEASE_ALREADY_ACQUIRED_MESSAGE, zipFilename, containerName);
                 return Optional.empty();
+            } else if (!readyToAcquireLease(cloudBlockBlob)) {
+                log.info(
+                    "Can't acquire lease on file {} in container {} "
+                        + "because lease was acquired less than {} seconds ago.",
+                    zipFilename,
+                    containerName,
+                    properties.getBlobLeaseAcquireDelayInSeconds()
+                );
+                return Optional.empty();
             }
 
             String leaseId = cloudBlockBlob.acquireLease(properties.getBlobLeaseTimeout(), null);
             log.info("Acquired lease on file {} in container {}. Lease ID: {}", zipFilename, containerName, leaseId);
+            // add lease acquired time to the blob metadata
+            cloudBlockBlob.getMetadata().put(
+                LEASE_ACQUIRED_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).toString()
+            );
+
             return Optional.of(leaseId);
         } catch (StorageException storageException) {
             if (storageException.getHttpStatusCode() == HttpStatus.CONFLICT.value()) {
@@ -89,6 +107,8 @@ public class BlobManager {
         try {
             log.info("Releasing lease on file {} in container {}. Lease ID: {}", zipFileName, containerName, leaseId);
             cloudBlockBlob.releaseLease(AccessCondition.generateLeaseCondition(leaseId));
+            // clear lease acquired time from blob metadata
+            cloudBlockBlob.getMetadata().remove(LEASE_ACQUIRED_TIME);
             log.info("Released lease on file {} in container {}. Lease ID: {}", zipFileName, containerName, leaseId);
         } catch (Exception exc) {
             log.error(
@@ -221,5 +241,17 @@ public class BlobManager {
             containerName,
             exception
         );
+    }
+
+    private boolean readyToAcquireLease(CloudBlockBlob cloudBlockBlob) {
+        String leaseAcquiredAt = cloudBlockBlob.getMetadata().get(LEASE_ACQUIRED_TIME);
+        if (StringUtils.isBlank(leaseAcquiredAt)) {
+            return true;
+        } else {
+            LocalDateTime leaseAcquiredAtTime = LocalDateTime.parse(leaseAcquiredAt);
+            Duration timeDifference = Duration.between(LocalDateTime.now(), leaseAcquiredAtTime);
+            // returns true if lease acquired for longer than configured duration
+            return Math.abs(timeDifference.getSeconds()) > properties.getBlobLeaseAcquireDelayInSeconds();
+        }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,6 +82,7 @@ storage:
   proxy_host: proxyout.reform.hmcts.net
   proxy_port: 8080
   blob_selected_container: ${STORAGE_BLOB_SELECTED_CONTAINER}
+  blob_lease_acquire_delay_in_seconds: 300 #TODO: add flux config
 
 queues:
   envelopes:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager.LEASE_EXPIRE_TIME;
+import static uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager.LEASE_EXPIRATION_TIME;
 import static uk.gov.hmcts.reform.bulkscanprocessor.util.TimeZones.EUROPE_LONDON_ZONE_ID;
 
 @ExtendWith(MockitoExtension.class)
@@ -96,7 +96,7 @@ public class BlobManagerTest {
     }
 
     @Test
-    public void acquireLease_acquires_lease_when_lease_expire_time_is_before_now() throws Exception {
+    public void acquireLease_acquires_lease_when_lease_expiration_time_is_before_now() throws Exception {
         // given
         given(blobProperties.getLeaseStatus()).willReturn(LeaseStatus.UNLOCKED);
         given(blobManagementProperties.getBlobLeaseAcquireDelayInSeconds()).willReturn(30);
@@ -104,7 +104,7 @@ public class BlobManagerTest {
 
         HashMap<String, String> metadata = new HashMap<>();
         LocalDateTime initialLeaseExpireTime = LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(60);
-        metadata.put(LEASE_EXPIRE_TIME, initialLeaseExpireTime.toString()); // lease expired
+        metadata.put(LEASE_EXPIRATION_TIME, initialLeaseExpireTime.toString()); // lease expired
         given(inputBlob.getMetadata()).willReturn(metadata);
         given(inputBlob.acquireLease(any(), any())).willReturn(LEASE_ID);
 
@@ -114,7 +114,7 @@ public class BlobManagerTest {
         // then
         assertThat(result).isEqualTo(Optional.of(LEASE_ID));
         verify(inputBlob).acquireLease(any(), any());
-        String newLeaseAcquiredTime = inputBlob.getMetadata().get(LEASE_EXPIRE_TIME);
+        String newLeaseAcquiredTime = inputBlob.getMetadata().get(LEASE_EXPIRATION_TIME);
         assertThat(LocalDateTime.parse(newLeaseAcquiredTime))
             .isAfter(initialLeaseExpireTime); // check if metadata is updated after acquiring new lease
     }
@@ -127,7 +127,7 @@ public class BlobManagerTest {
         given(blobManagementProperties.getBlobLeaseAcquireDelayInSeconds()).willReturn(30);
         given(inputBlob.getProperties()).willReturn(blobProperties);
         HashMap<String, String> metadata = new HashMap<>();
-        metadata.put(LEASE_EXPIRE_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).plusSeconds(60).toString());
+        metadata.put(LEASE_EXPIRATION_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).plusSeconds(60).toString());
         given(inputBlob.getMetadata()).willReturn(metadata); // lease not expired yet
 
         // when
@@ -154,7 +154,7 @@ public class BlobManagerTest {
         String leaseId = "lease-id-123";
 
         HashMap<String, String> metadata = new HashMap<>();
-        metadata.put(LEASE_EXPIRE_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(10).toString());
+        metadata.put(LEASE_EXPIRATION_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(10).toString());
         given(inputBlob.getMetadata()).willReturn(metadata);
         blobManager.tryReleaseLease(inputBlob, "container-name", "zip-filename.zip", leaseId);
 
@@ -162,7 +162,7 @@ public class BlobManagerTest {
         verify(inputBlob).releaseLease(accessConditionCaptor.capture());
         assertThat(accessConditionCaptor.getValue()).isNotNull();
         assertThat(accessConditionCaptor.getValue().getLeaseID()).isEqualTo(leaseId);
-        assertThat(inputBlob.getMetadata()).doesNotContainKey(LEASE_EXPIRE_TIME);
+        assertThat(inputBlob.getMetadata()).doesNotContainKey(LEASE_EXPIRATION_TIME);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager.LEASE_ACQUIRED_TIME;
+import static uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager.LEASE_EXPIRE_TIME;
 import static uk.gov.hmcts.reform.bulkscanprocessor.util.TimeZones.EUROPE_LONDON_ZONE_ID;
 
 @ExtendWith(MockitoExtension.class)
@@ -96,37 +96,44 @@ public class BlobManagerTest {
     }
 
     @Test
-    public void acquireLease_acquires_lease_when_already_acquired_lease_duration_is_expired() throws Exception {
+    public void acquireLease_acquires_lease_when_lease_expire_time_is_before_now() throws Exception {
+        // given
         given(blobProperties.getLeaseStatus()).willReturn(LeaseStatus.UNLOCKED);
         given(blobManagementProperties.getBlobLeaseAcquireDelayInSeconds()).willReturn(30);
         given(inputBlob.getProperties()).willReturn(blobProperties);
+
         HashMap<String, String> metadata = new HashMap<>();
-        LocalDateTime initialLeaseAcquiredTime = LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(60);
-        metadata.put(LEASE_ACQUIRED_TIME, initialLeaseAcquiredTime.toString());
+        LocalDateTime initialLeaseExpireTime = LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(60);
+        metadata.put(LEASE_EXPIRE_TIME, initialLeaseExpireTime.toString()); // lease expired
         given(inputBlob.getMetadata()).willReturn(metadata);
         given(inputBlob.acquireLease(any(), any())).willReturn(LEASE_ID);
 
+        // when
         Optional<String> result = blobManager.acquireLease(inputBlob, "container-name", "zip-filename.zip");
 
+        // then
         assertThat(result).isEqualTo(Optional.of(LEASE_ID));
         verify(inputBlob).acquireLease(any(), any());
-        String newLeaseAcquiredTime = inputBlob.getMetadata().get(LEASE_ACQUIRED_TIME);
+        String newLeaseAcquiredTime = inputBlob.getMetadata().get(LEASE_EXPIRE_TIME);
         assertThat(LocalDateTime.parse(newLeaseAcquiredTime))
-            .isAfter(initialLeaseAcquiredTime); // check if metadata is updated after acquiring new lease
+            .isAfter(initialLeaseExpireTime); // check if metadata is updated after acquiring new lease
     }
 
     @Test
-    public void acquireLease_does_not_acquire_lease_when_already_acquired_lease_duration_is_not_expired()
+    public void acquireLease_does_not_acquire_lease_when_already_acquired_lease_is_not_expired()
         throws Exception {
+        // given
         given(blobProperties.getLeaseStatus()).willReturn(LeaseStatus.UNLOCKED);
         given(blobManagementProperties.getBlobLeaseAcquireDelayInSeconds()).willReturn(30);
         given(inputBlob.getProperties()).willReturn(blobProperties);
         HashMap<String, String> metadata = new HashMap<>();
-        metadata.put(LEASE_ACQUIRED_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(10).toString());
-        given(inputBlob.getMetadata()).willReturn(metadata);
+        metadata.put(LEASE_EXPIRE_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).plusSeconds(60).toString());
+        given(inputBlob.getMetadata()).willReturn(metadata); // lease not expired yet
 
+        // when
         Optional<String> result = blobManager.acquireLease(inputBlob, "container-name", "zip-filename.zip");
 
+        // then
         assertThat(result).isEqualTo(Optional.empty());
         verify(inputBlob, never()).acquireLease(any(), any());
     }
@@ -147,7 +154,7 @@ public class BlobManagerTest {
         String leaseId = "lease-id-123";
 
         HashMap<String, String> metadata = new HashMap<>();
-        metadata.put(LEASE_ACQUIRED_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(10).toString());
+        metadata.put(LEASE_EXPIRE_TIME, LocalDateTime.now(EUROPE_LONDON_ZONE_ID).minusSeconds(10).toString());
         given(inputBlob.getMetadata()).willReturn(metadata);
         blobManager.tryReleaseLease(inputBlob, "container-name", "zip-filename.zip", leaseId);
 
@@ -155,7 +162,7 @@ public class BlobManagerTest {
         verify(inputBlob).releaseLease(accessConditionCaptor.capture());
         assertThat(accessConditionCaptor.getValue()).isNotNull();
         assertThat(accessConditionCaptor.getValue().getLeaseID()).isEqualTo(leaseId);
-        assertThat(inputBlob.getMetadata()).doesNotContainKey(LEASE_ACQUIRED_TIME);
+        assertThat(inputBlob.getMetadata()).doesNotContainKey(LEASE_EXPIRE_TIME);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1246

### Change description ###
When acquiring the lease for a blob:
- set the lease acquired time to the blob metadata
- check if the lease was acquired for longer than configured duration (for now, it is set to 300 seconds)

When releasing the lease for the blob:
- clear the lease acquired time from blob metadata

**TODO:** Flux config for "lease acquire delay" time 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
