### PR TITLE
Update query for finding envelopes to upload

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
@@ -35,7 +35,7 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
-    public void findEnvelopesToResend_should_not_return_envelopes_that_failed_to_be_sent_too_many_times() {
+    public void findEnvelopesToUpload_should_not_return_envelopes_that_failed_to_be_uploaded_too_many_times() {
         // given
         final int maxFailCount = 5;
 
@@ -48,31 +48,31 @@ public class EnvelopeRepositoryTest {
         );
 
         // when
-        List<Envelope> result = repo.findEnvelopesToResend(maxFailCount);
+        List<Envelope> result = repo.findEnvelopesToUpload(maxFailCount);
 
         // then
         assertThat(result).hasSize(2);
     }
 
     @Test
-    public void findEnvelopesToResend_should_filter_based_on_status() {
+    public void findEnvelopesToUpload_should_filter_based_on_status() {
         // given
-        dbHas(
-            envelope("A", Status.CREATED),
-            envelope("A", Status.UPLOAD_FAILURE),
-            envelope("B", Status.UPLOAD_FAILURE)
-        );
+        Envelope e1 = envelope("A", Status.CREATED);
+        Envelope e2 = envelope("A", Status.UPLOAD_FAILURE);
+        Envelope e3 = envelope("B", Status.UPLOADED);
+        Envelope e4 = envelope("B", Status.NOTIFICATION_SENT);
+
+        dbHas(e1, e2, e3, e4);
 
         // when
-        List<Envelope> result = repo.findEnvelopesToResend(1_000);
+        List<Envelope> result = repo.findEnvelopesToUpload(1_000);
 
         // then
         assertThat(result)
-            .hasSize(2)
-            .extracting(envelope -> tuple(envelope.getContainer(), envelope.getJurisdiction()))
-            .containsOnly(
-                tuple("SSCS", "A"),
-                tuple("SSCS", "B")
+            .extracting(Envelope::getZipFileName)
+            .containsExactlyInAnyOrder(
+                e1.getZipFileName(),
+                e2.getZipFileName()
             );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -74,11 +74,11 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
     );
 
     @Query("select e from Envelope e"
-        + " where e.status = 'UPLOAD_FAILURE'" // todo: use a constant
+        + " where e.status in ('CREATED', 'UPLOAD_FAILURE')" // todo: use a constant
         + "   and e.uploadFailureCount < :maxFailureCount"
         + " order by e.createdAt asc"
     )
-    List<Envelope> findEnvelopesToResend(@Param("maxFailureCount") int maxFailureCount);
+    List<Envelope> findEnvelopesToUpload(@Param("maxFailureCount") int maxFailureCount);
 
     @Query(
         nativeQuery = true,


### PR DESCRIPTION
modifying existing, but currently not used query:
`findEnvelopesToResend` to `findEnvelopesToUpload` that now also includes envelopes in 'CREATED' status.
Tests updated accordingly.

https://tools.hmcts.net/jira/browse/BPS-718