### PR TITLE
add ccd id and envelope ccd action fields to zip-files endpoint response

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEnvelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEnvelope.java
@@ -13,11 +13,19 @@ public class ZipFileEnvelope {
     @JsonProperty("status")
     public final String status;
 
+    @JsonProperty("ccd_id")
+    public final String ccdId;
+
+    @JsonProperty("envelope_ccd_action")
+    public final String envelopeCcdAction;
+
     // region constructor
-    public ZipFileEnvelope(String id, String container, String status) {
+    public ZipFileEnvelope(String id, String container, String status, String ccdId, String envelopeCcdAction) {
         this.id = id;
         this.container = container;
         this.status = status;
+        this.ccdId = ccdId;
+        this.envelopeCcdAction = envelopeCcdAction;
     }
     // endregion
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEnvelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEnvelope.java
@@ -21,11 +21,11 @@ public class ZipFileEnvelope {
 
     // region constructor
     public ZipFileEnvelope(
-    String id, 
-    String container, 
-    String status, 
-    String ccdId, 
-    String envelopeCcdAction
+        String id,
+        String container,
+        String status,
+        String ccdId,
+        String envelopeCcdAction
     ) {
         this.id = id;
         this.container = container;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEnvelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/zipfilestatus/ZipFileEnvelope.java
@@ -20,7 +20,13 @@ public class ZipFileEnvelope {
     public final String envelopeCcdAction;
 
     // region constructor
-    public ZipFileEnvelope(String id, String container, String status, String ccdId, String envelopeCcdAction) {
+    public ZipFileEnvelope(
+    String id, 
+    String container, 
+    String status, 
+    String ccdId, 
+    String envelopeCcdAction
+    ) {
         this.id = id;
         this.container = container;
         this.status = status;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusService.java
@@ -43,7 +43,9 @@ public class ZipFileStatusService {
         return new ZipFileEnvelope(
             envelope.getId().toString(),
             envelope.getContainer(),
-            envelope.getStatus().name()
+            envelope.getStatus().name(),
+            envelope.getCcdId(),
+            envelope.getEnvelopeCcdAction()
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ZipStatusControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ZipStatusControllerTest.java
@@ -38,8 +38,8 @@ public class ZipStatusControllerTest {
     public void should_return_data_returned_from_the_service() throws Exception {
 
         List<ZipFileEnvelope> envelopes = asList(
-            new ZipFileEnvelope("0", "container0", "status0"),
-            new ZipFileEnvelope("1", "container1", "status1")
+            new ZipFileEnvelope("0", "container0", "status0", "9832132131312", "AUTO_ATTACHED_TO_CASE"),
+            new ZipFileEnvelope("1", "container1", "status1", "3210329752313", "EXCEPTION_RECORD")
         );
 
         List<ZipFileEvent> events = asList(
@@ -58,9 +58,13 @@ public class ZipStatusControllerTest {
             .andExpect(jsonPath("$.envelopes[0].id").value(envelopes.get(0).id))
             .andExpect(jsonPath("$.envelopes[0].container").value(envelopes.get(0).container))
             .andExpect(jsonPath("$.envelopes[0].status").value(envelopes.get(0).status))
+            .andExpect(jsonPath("$.envelopes[0].ccd_id").value(envelopes.get(0).ccdId))
+            .andExpect(jsonPath("$.envelopes[0].envelope_ccd_action").value(envelopes.get(0).envelopeCcdAction))
             .andExpect(jsonPath("$.envelopes[1].id").value(envelopes.get(1).id))
             .andExpect(jsonPath("$.envelopes[1].container").value(envelopes.get(1).container))
             .andExpect(jsonPath("$.envelopes[1].status").value(envelopes.get(1).status))
+            .andExpect(jsonPath("$.envelopes[1].ccd_id").value(envelopes.get(1).ccdId))
+            .andExpect(jsonPath("$.envelopes[1].envelope_ccd_action").value(envelopes.get(1).envelopeCcdAction))
             .andExpect(jsonPath("$.events", hasSize(2)))
             .andExpect(jsonPath("$.events[0].type").value(events.get(0).eventType))
             .andExpect(jsonPath("$.events[0].container").value(events.get(0).container))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/zipfilestatus/ZipFileStatusServiceTest.java
@@ -65,12 +65,16 @@ public class ZipFileStatusServiceTest {
                 new ZipFileEnvelope(
                     envelopes.get(0).getId().toString(),
                     envelopes.get(0).getContainer(),
-                    envelopes.get(0).getStatus().name()
+                    envelopes.get(0).getStatus().name(),
+                    envelopes.get(0).getCcdId(),
+                    envelopes.get(0).getEnvelopeCcdAction()
                 ),
                 new ZipFileEnvelope(
                     envelopes.get(1).getId().toString(),
                     envelopes.get(1).getContainer(),
-                    envelopes.get(1).getStatus().name()
+                    envelopes.get(1).getStatus().name(),
+                    envelopes.get(1).getCcdId(),
+                    envelopes.get(1).getEnvelopeCcdAction()
                 )
             );
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1259

### Change description ###

add ccd id and envelope ccd action fields to zip-files endpoint response

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
