### PR TITLE
Set SSCS OCR validation url

### DIFF
--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-processor
 apiVersion: v1
 home: https://github.com/hmcts/bulk-scan-processor
-version: 0.2.29
+version: 0.2.30
 description: HMCTS Bulk scan processor service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-processor/values.yaml
+++ b/charts/bulk-scan-processor/values.yaml
@@ -13,7 +13,7 @@ java:
     OCR_VALIDATION_URL_PROBATE: http://probate-back-office-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     OCR_VALIDATION_URL_DIVORCE: http://div-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     OCR_VALIDATION_URL_FINREM: http://finrem-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    OCR_VALIDATION_URL_SSCS: ""
+    OCR_VALIDATION_URL_SSCS: http://sscs-bulk-scan-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     SCAN_ENABLED: "true"
     SCAN_DELAY: "4000"
     LEASE_ACQUIRE_DELAY_IN_SECONDS: "300"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1241

### Change description ###
SSCS OCR validation URL is set to empty in Prod (https://github.com/hmcts/cnp-flux-config/pull/3993)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
