### PR TITLE
send trace id for envelope queue messages

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -144,6 +144,13 @@ public class ServiceBusHelperTest {
         assertThat(busMessage.getLabel()).isNullOrEmpty();
     }
 
+    @Test
+    public void should_add_parent_id_to_properties_in_standard_message() {
+        Msg msg = new EnvelopeMsg(envelope);
+        Message busMessage = serviceBusHelper.mapToBusMessage(msg);
+        assertThat(busMessage.getProperties().get("ParentId")).isNotBlank();
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void should_send_message_with_envelope_data() throws Exception {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1201

### Change description ###

send trace id for envelope queue messages.
aid is track that message in appinsight until is completely finished.
we can use any name, in their example they used  "ParentId".
https://docs.microsoft.com/en-us/azure/azure-monitor/app/custom-operations-tracking

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
