### PR TITLE
Migrate integration tests to junit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
 task integration(type: Test, description: 'Runs the integration tests.', group: 'Verification') {
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
+  useJUnitPlatform()
 
   // set your environment variables here
    environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
@@ -255,7 +256,10 @@ dependencies {
     exclude group: 'com.github.tomakehurst', module: 'wiremock-jre8-standalone'
   }
   integrationTestImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.26.3'
-  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.14.3'
+  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.14.3', {
+    exclude group: 'junit', module: 'junit'
+  }
+  integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.14.3'
   integrationTestImplementation group: 'com.revinate', name: 'assertj-json', version: '1.2.0'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -6,18 +6,16 @@ import com.google.common.io.Resources;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -70,7 +68,6 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOADED;
 })
 @AutoConfigureMockMvc
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class EnvelopeControllerTest {
 
     @Autowired private MockMvc mockMvc;
@@ -96,7 +93,7 @@ public class EnvelopeControllerTest {
 
     private static DockerComposeContainer dockerComposeContainer;
 
-    @BeforeClass
+    @BeforeAll
     public static void initialize() {
         File dockerComposeFile = new File("src/integrationTest/resources/docker-compose.yml");
 
@@ -106,12 +103,12 @@ public class EnvelopeControllerTest {
         dockerComposeContainer.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownContainer() {
         dockerComposeContainer.stop();
     }
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
         CloudBlobClient cloudBlobClient = account.createCloudBlobClient();
@@ -136,7 +133,7 @@ public class EnvelopeControllerTest {
         testContainer.createIfNotExists();
     }
 
-    @After
+    @AfterEach
     public void cleanUp() throws Exception {
         testContainer.deleteIfExists();
         envelopeRepository.deleteAll();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.core.PathUtility;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
@@ -24,7 +22,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class SasTokenControllerTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
@@ -26,9 +26,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_UPLOA
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALIDATION_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class EnvelopeCountSummaryRepositoryTest {
 
     @Autowired private EnvelopeCountSummaryRepository reportRepo;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Instant;
 import java.util.List;
@@ -18,9 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class EnvelopeRepositoryTest {
 
     @Autowired
@@ -29,7 +29,7 @@ public class EnvelopeRepositoryTest {
     @Autowired
     private EntityManager entityManager;
 
-    @After
+    @AfterEach
     public void cleanUp() {
         repo.deleteAll();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
@@ -1,27 +1,27 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class EnvelopeTest {
 
     @Autowired
     private EnvelopeRepository repository;
 
-    @After
+    @AfterEach
     public void cleanUp() {
         repository.deleteAll();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ProcessEventRepositoryTest.java
@@ -1,21 +1,21 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class ProcessEventRepositoryTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItemTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ScannableItemTest.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 
 import java.io.IOException;
@@ -15,9 +15,9 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class ScannableItemTest {
 
     @Autowired
@@ -26,7 +26,7 @@ public class ScannableItemTest {
     @Autowired
     private ScannableItemRepository scannableItemRepository;
 
-    @After
+    @AfterEach
     public void cleanUp() {
         envelopeRepository.deleteAll();
         scannableItemRepository.deleteAll();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFileSummary;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ZipFilesSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.zipfilesummary.ZipFileSummaryItem;
@@ -29,9 +29,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALIDATION_FAILURE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class ZipFilesSummaryRepositoryTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/OcrDataSerializationJourneyTest.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
@@ -28,9 +28,9 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class OcrDataSerializationJourneyTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/SchedulerConfigTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/features/SchedulerConfigTest.java
@@ -2,14 +2,12 @@ package uk.gov.hmcts.reform.bulkscanprocessor.features;
 
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.core.LockProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.ServiceBusHelper;
 
@@ -19,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 @TestPropertySource(
     properties = {
         "scheduling.task.scan.enabled=true",

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/OcrValidationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/OcrValidationClientTest.java
@@ -2,12 +2,10 @@ package uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation;
 
 import com.github.tomakehurst.wiremock.core.Options;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationContextInitializer;
@@ -39,7 +37,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 })
 @AutoConfigureWireMock
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class OcrValidationClientTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeFinaliserServiceTest.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
 import com.fasterxml.jackson.databind.node.TextNode;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
@@ -35,9 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
-@RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
+@ExtendWith(SpringExtension.class)
 public class EnvelopeFinaliserServiceTest {
 
     @Autowired
@@ -48,7 +48,7 @@ public class EnvelopeFinaliserServiceTest {
 
     private EnvelopeFinaliserService envelopeFinaliserService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         envelopeFinaliserService = new EnvelopeFinaliserService(
             envelopeRepository,
@@ -56,7 +56,7 @@ public class EnvelopeFinaliserServiceTest {
         );
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         envelopeRepository.deleteAll();
         processEventRepository.deleteAll();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeRetrieverTest.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
@@ -24,7 +22,6 @@ import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class EnvelopeRetrieverTest {
 
     @Autowired private EnvelopeRepository envelopeRepo;
@@ -32,7 +29,7 @@ public class EnvelopeRetrieverTest {
 
     private EnvelopeRetrieverService service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.service = new EnvelopeRetrieverService(envelopeRepo, accessService);
     }
@@ -146,7 +143,7 @@ public class EnvelopeRetrieverTest {
             .hasMessageContaining(envelopeForServiceB.getId().toString());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         envelopeRepo.deleteAll();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderDisabledTest.java
@@ -1,17 +1,14 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 @TestPropertySource(
     properties = {
         "spring.mail.host=false"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/email/ReportSenderTest.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.email;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 
 import javax.mail.internet.MimeMessage;
@@ -14,7 +12,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class ReportSenderTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
@@ -3,10 +3,10 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.testcontainers.containers.DockerComposeContainer;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
@@ -28,7 +28,7 @@ public class RejectedFilesReportServiceTest {
 
     private static DockerComposeContainer dockerComposeContainer;
 
-    @BeforeClass
+    @BeforeAll
     public static void initialize() {
         dockerComposeContainer =
             new DockerComposeContainer(new File("src/integrationTest/resources/docker-compose.yml"))
@@ -37,12 +37,12 @@ public class RejectedFilesReportServiceTest {
         dockerComposeContainer.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownContainer() {
         dockerComposeContainer.stop();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
         CloudBlobClient cloudBlobClient = account.createCloudBlobClient();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/servicebus/ServiceBusHelperTest.java
@@ -7,14 +7,12 @@ import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.Message;
 import com.microsoft.azure.servicebus.primitives.TimeoutException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Payment;
@@ -40,6 +38,7 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.when;
 
 @EnableJpaRepositories(basePackages = "uk.gov.hmcts.reform.bulkscanprocessor.entity")
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class ServiceBusHelperTest {
 
     @Autowired
@@ -74,7 +72,7 @@ public class ServiceBusHelperTest {
 
     private ServiceBusHelper serviceBusHelper;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         serviceBusHelper = new ServiceBusHelper(queueClient, this.objectMapper);
 
@@ -107,11 +105,12 @@ public class ServiceBusHelperTest {
             .contains(msg.getMsgId());
     }
 
-    @Test(expected = InvalidMessageException.class)
+    @Test
     public void should_throw_exception_for_empty_messageId() {
         when(envelope.getId()).thenReturn(null);
         Msg msg = new EnvelopeMsg(envelope);
-        serviceBusHelper.sendMessage(msg);
+        assertThatCode(() -> serviceBusHelper.sendMessage(msg))
+            .isInstanceOf(InvalidMessageException.class);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -3,10 +3,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
@@ -32,10 +30,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDi
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask> {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledPayments.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledPayments.java
@@ -2,11 +2,9 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
@@ -19,7 +17,6 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALI
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 @TestPropertySource(properties = {
     "containers.mappings[0].container=bulkscan",
     "containers.mappings[0].jurisdiction=BULKSCAN",
@@ -29,7 +26,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_P
 })
 public class BlobProcessorTaskTestForDisabledPayments extends ProcessorTestSuite<BlobProcessorTask> {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledService.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledService.java
@@ -2,11 +2,9 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.output.Pdf;
@@ -19,7 +17,6 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DISABLED_
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 @TestPropertySource(properties = {
     "containers.mappings[0].container=bulkscan",
     "containers.mappings[0].jurisdiction=BULKSCAN",
@@ -29,7 +26,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_P
 })
 public class BlobProcessorTaskTestForDisabledService extends ProcessorTestSuite<BlobProcessorTask> {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 
@@ -15,10 +13,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALI
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<BlobProcessorTask> {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailingNotification.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailingNotification.java
@@ -1,10 +1,8 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorMsg;
@@ -18,10 +16,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALI
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class BlobProcessorTaskTestForFailingNotification extends ProcessorTestSuite<BlobProcessorTask> {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -2,10 +2,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableMap;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
@@ -23,10 +21,9 @@ import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<BlobProcessorTask> {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -3,13 +3,11 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.DockerComposeContainer;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.BlobManagementProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
@@ -20,7 +18,6 @@ import java.io.File;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class CleanUpRejectedFilesTaskTest {
 
     @Autowired
@@ -31,7 +28,7 @@ public class CleanUpRejectedFilesTaskTest {
 
     private static DockerComposeContainer dockerComposeContainer;
 
-    @BeforeClass
+    @BeforeAll
     public static void initialize() {
         dockerComposeContainer =
             new DockerComposeContainer(new File("src/integrationTest/resources/docker-compose.yml"))
@@ -40,12 +37,12 @@ public class CleanUpRejectedFilesTaskTest {
         dockerComposeContainer.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownContainer() {
         dockerComposeContainer.stop();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
         CloudBlobClient cloudBlobClient = account.createCloudBlobClient();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTaskTest.java
@@ -2,12 +2,10 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
@@ -28,7 +26,6 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 @SuppressWarnings("PMD")
 public class DeleteCompleteFilesTaskTest {
     @Mock
@@ -42,7 +39,7 @@ public class DeleteCompleteFilesTaskTest {
 
     private DeleteCompleteFilesTask task;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.task = new DeleteCompleteFilesTask(
             blobManager,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/OrchestratorNotificationTaskTest.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
@@ -25,7 +23,6 @@ import static org.mockito.Mockito.doThrow;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator.envelope;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class OrchestratorNotificationTaskTest {
 
     @Autowired private EnvelopeRepository envelopeRepo;
@@ -35,7 +32,7 @@ public class OrchestratorNotificationTaskTest {
 
     private OrchestratorNotificationTask task;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.task = new OrchestratorNotificationTask(
             serviceBusHelper,
@@ -90,7 +87,7 @@ public class OrchestratorNotificationTaskTest {
 
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         processEventRepo.deleteAll();
         envelopeRepo.deleteAll();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -4,10 +4,10 @@ import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -126,7 +126,7 @@ public abstract class ProcessorTestSuite<T> {
         rejectedContainer.createIfNotExists();
     }
 
-    @After
+    @AfterEach
     public void cleanUp() throws Exception {
         testContainer.deleteIfExists();
         rejectedContainer.deleteIfExists();
@@ -134,13 +134,13 @@ public abstract class ProcessorTestSuite<T> {
         processEventRepository.deleteAll();
     }
 
-    @Before
+    @BeforeEach
     public void prepare() throws Exception {
         envelopeRepository.deleteAll();
         processEventRepository.deleteAll();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void initialize() {
         File dockerComposeFile = new File("src/integrationTest/resources/docker-compose.yml");
 
@@ -150,7 +150,7 @@ public abstract class ProcessorTestSuite<T> {
         dockerComposeContainer.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownContainer() {
         dockerComposeContainer.stop();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
@@ -2,15 +2,13 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
@@ -34,7 +32,6 @@ import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.UPLOADED;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 public class UploadEnvelopeDocumentsTaskTest {
 
     private static final TestStorageHelper STORAGE_HELPER = TestStorageHelper.getInstance();
@@ -47,24 +44,24 @@ public class UploadEnvelopeDocumentsTaskTest {
     @MockBean private AuthTokenGenerator tokenGenerator;
     @MockBean private DocumentManagementService documentManagementService;
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeStorage() {
         TestStorageHelper.initialize();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownContainer() {
         TestStorageHelper.stopDocker();
     }
 
-    @Before
+    @BeforeEach
     public void prepare() {
         STORAGE_HELPER.createBulkscanContainer();
         envelopeRepository.deleteAll();
         eventRepository.deleteAll();
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         STORAGE_HELPER.deleteBulkscanContainer();
         envelopeRepository.deleteAll();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesDisabledTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesDisabledTaskTest.java
@@ -1,17 +1,14 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.monitoring;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
-@RunWith(SpringRunner.class)
 @TestPropertySource(properties = {
     "monitoring.incomplete-envelopes.enabled=false"
 })


### PR DESCRIPTION
### Change description ###

I thought there won't be any helper PRs in #1351 but for some reason I fear migration to junit5 is bound to happen sooner than later.

After similar tasks in the past and some of the code changes already done months ago, this suppose to go smoother

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
