### PR TITLE
Delete DOC_PROCESSED events

### DIFF
--- a/src/main/resources/db/migration/V057__Delete_Processed_status_and_DOC_PROCESSED_event.sql
+++ b/src/main/resources/db/migration/V057__Delete_Processed_status_and_DOC_PROCESSED_event.sql
@@ -1,0 +1,2 @@
+DELETE FROM process_events
+WHERE event = 'DOC_PROCESSED';


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-517


### Change description ###
DOC_PROCESSED event is no longer used in the processor. 
Delete all entries with `DOC_PROCESSED` event type from `process_events` table. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
