### PR TITLE
Cleanup envelope status and event types

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
@@ -10,7 +10,6 @@ public enum Status {
     CREATED,
     METADATA_FAILURE,   // when we are aware of envelope, but there are inconsistency among files and metadata info
     SIGNATURE_FAILURE,  // the zip archive failed signature verification
-    PROCESSED,          // after storing all docs in DM. TODO: remove once DB doesn't have this state
     UPLOADED,
     UPLOAD_FAILURE,
     NOTIFICATION_SENT,  // after notifying about a new envelope

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
@@ -10,9 +10,7 @@ public enum Event {
     DOC_SIGNATURE_FAILURE, // Signature verification failure while processing zip file
     DOC_UPLOADED,
     DOC_UPLOAD_FAILURE,
-    DOC_PROCESSED, // when blob is successfully processed after storing all docs in DM. TODO remove when DB is cleaned
     DOC_CONSUMED, // client service handled the documents
-    BLOB_DELETE_FAILURE, // when blob is not successfully deleted after processing is complete
     DOC_PROCESSED_NOTIFICATION_SENT, // when document processed notification is posted (to servicebus queue)
     DOC_PROCESSED_NOTIFICATION_FAILURE, // when document processed notification fails
     DOC_PROCESSING_ABORTED, // when envelope processing cannot be completed (used manually to set the event with reason)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-517


### Change description ###
- Remove unused envelope status `PROCESSED` 
and event types `DOC_PROCESSED` and `BLOB_DELETE_FAILURE`. 

- Raised https://tools.hmcts.net/jira/browse/RDO-8132 to check if there are any envelopes exist with `PROCESSED` status.

- `BLOB_DELETE_FAILURE` event type database entries were removed in https://github.com/hmcts/bulk-scan-processor/pull/1230


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
