### PR TITLE
EnvelopeValidator component

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -41,6 +41,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.UploadEnvelopeDocumentsTask;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipFileProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.EnvelopeValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
@@ -114,6 +115,7 @@ public class EnvelopeControllerTest {
         CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
         CloudBlobClient cloudBlobClient = account.createCloudBlobClient();
         BlobManager blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
+        EnvelopeValidator envelopeValidator = new EnvelopeValidator();
 
         blobProcessorTask = new BlobProcessorTask(
             blobManager,
@@ -125,6 +127,7 @@ public class EnvelopeControllerTest {
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             paymentsEnabled
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -42,6 +42,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite<BlobProcessorTask>
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             paymentsEnabled
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledPayments.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledPayments.java
@@ -36,6 +36,7 @@ public class BlobProcessorTaskTestForDisabledPayments extends ProcessorTestSuite
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             paymentsEnabled
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledService.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledService.java
@@ -36,6 +36,7 @@ public class BlobProcessorTaskTestForDisabledService extends ProcessorTestSuite<
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             paymentsEnabled
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -28,6 +28,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite<Blo
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             paymentsEnabled
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailingNotification.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailingNotification.java
@@ -28,6 +28,7 @@ public class BlobProcessorTaskTestForFailingNotification extends ProcessorTestSu
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             paymentsEnabled
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -33,6 +33,7 @@ public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite<Bl
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             paymentsEnabled
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipFileProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.EnvelopeValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
@@ -75,6 +76,8 @@ public abstract class ProcessorTestSuite<T> {
     protected ProcessEventRepository processEventRepository;
 
     protected ErrorNotificationSender errorNotificationSender;
+
+    protected EnvelopeValidator envelopeValidator;
 
     protected FileErrorHandler fileErrorHandler;
 
@@ -129,6 +132,8 @@ public abstract class ProcessorTestSuite<T> {
             serviceBusHelper,
             containerMappings
         );
+
+        envelopeValidator = new EnvelopeValidator();
 
         fileErrorHandler = new FileErrorHandler(
             blobManager,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -78,6 +78,8 @@ public class BlobProcessorTask {
 
     private final OcrValidator ocrValidator;
 
+    private final EnvelopeValidator envelopeValidator;
+
     private final FileErrorHandler fileErrorHandler;
 
     private final boolean paymentsEnabled;
@@ -88,6 +90,7 @@ public class BlobProcessorTask {
         ZipFileProcessor zipFileProcessor,
         ContainerMappings containerMappings,
         OcrValidator ocrValidator,
+        EnvelopeValidator envelopeValidator,
         FileErrorHandler fileErrorHandler,
         @Value("${process-payments.enabled}") boolean paymentsEnabled
     ) {
@@ -96,6 +99,7 @@ public class BlobProcessorTask {
         this.zipFileProcessor = zipFileProcessor;
         this.containerMappings = containerMappings;
         this.ocrValidator = ocrValidator;
+        this.envelopeValidator = envelopeValidator;
         this.fileErrorHandler = fileErrorHandler;
         this.paymentsEnabled = paymentsEnabled;
     }
@@ -246,18 +250,18 @@ public class BlobProcessorTask {
                 envelope.scannableItems.stream().map(doc -> doc.documentControlNumber).collect(joining(","))
             );
 
-            EnvelopeValidator.assertZipFilenameMatchesWithMetadata(envelope, zipFilename);
-            EnvelopeValidator.assertContainerMatchesJurisdictionAndPoBox(
+            envelopeValidator.assertZipFilenameMatchesWithMetadata(envelope, zipFilename);
+            envelopeValidator.assertContainerMatchesJurisdictionAndPoBox(
                 containerMappings.getMappings(), envelope, containerName
             );
-            EnvelopeValidator.assertServiceEnabled(envelope, containerMappings.getMappings());
-            EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope);
-            EnvelopeValidator.assertEnvelopeHasPdfs(envelope, result.getPdfs());
-            EnvelopeValidator.assertDocumentControlNumbersAreUnique(envelope);
-            EnvelopeValidator.assertPaymentsEnabledForContainerIfPaymentsArePresent(
+            envelopeValidator.assertServiceEnabled(envelope, containerMappings.getMappings());
+            envelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope);
+            envelopeValidator.assertEnvelopeHasPdfs(envelope, result.getPdfs());
+            envelopeValidator.assertDocumentControlNumbersAreUnique(envelope);
+            envelopeValidator.assertPaymentsEnabledForContainerIfPaymentsArePresent(
                 envelope, paymentsEnabled, containerMappings.getMappings()
             );
-            EnvelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope);
+            envelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope);
 
             envelopeProcessor.assertDidNotFailToUploadBefore(envelope.zipFileName, containerName);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeValidator.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ContainerJurisdictionPoBoxMismatchException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DisallowedDocumentTypesException;
@@ -35,6 +37,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
+@Component
+@ConditionalOnProperty(value = "scheduling.task.scan.enabled", matchIfMissing = true)
 public final class EnvelopeValidator {
 
     private static final InputDocumentType defaultOcrDocumentType = InputDocumentType.FORM;
@@ -51,17 +55,13 @@ public final class EnvelopeValidator {
             Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR, emptyList()
         );
 
-    private EnvelopeValidator() {
-        // util class
-    }
-
     /**
      * Assert envelope contains only scannable items of types that are allowed for the envelope's classification.
      * Otherwise, throws an exception.
      *
      * @param envelope to assert against
      */
-    public static void assertEnvelopeContainsDocsOfAllowedTypesOnly(InputEnvelope envelope) {
+    public void assertEnvelopeContainsDocsOfAllowedTypesOnly(InputEnvelope envelope) {
         List<String> disallowedDocTypesFound =
             envelope
                 .scannableItems
@@ -88,7 +88,7 @@ public final class EnvelopeValidator {
      *
      * @param envelope to assert against
      */
-    public static void assertEnvelopeContainsOcrDataIfRequired(InputEnvelope envelope) {
+    public void assertEnvelopeContainsOcrDataIfRequired(InputEnvelope envelope) {
 
         if (envelope.classification == Classification.NEW_APPLICATION
             || envelope.classification == Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR) {
@@ -130,7 +130,7 @@ public final class EnvelopeValidator {
      * @param envelope to assert against
      * @param pdfs     to assert against
      */
-    public static void assertEnvelopeHasPdfs(InputEnvelope envelope, List<Pdf> pdfs) {
+    public void assertEnvelopeHasPdfs(InputEnvelope envelope, List<Pdf> pdfs) {
         List<String> problems = new ArrayList<>();
 
         List<String> duplicateFileNames =
@@ -168,7 +168,7 @@ public final class EnvelopeValidator {
         }
     }
 
-    public static void assertDocumentControlNumbersAreUnique(InputEnvelope envelope) {
+    public void assertDocumentControlNumbersAreUnique(InputEnvelope envelope) {
         List<String> dcns = envelope.scannableItems.stream().map(it -> it.documentControlNumber).collect(toList());
         List<String> duplicateDcns = getDuplicates(dcns);
         if (!duplicateDcns.isEmpty()) {
@@ -178,7 +178,7 @@ public final class EnvelopeValidator {
         }
     }
 
-    public static void assertZipFilenameMatchesWithMetadata(InputEnvelope envelope, String zipFileName) {
+    public void assertZipFilenameMatchesWithMetadata(InputEnvelope envelope, String zipFileName) {
         if (!envelope.zipFileName.equals(zipFileName)) {
             throw new ZipNameNotMatchingMetaDataException(
                 "Name of the uploaded zip file does not match with field \"zip_file_name\" in the metadata"
@@ -194,7 +194,7 @@ public final class EnvelopeValidator {
      * @param envelope      to assert against
      * @param containerName container from which envelope was retrieved
      */
-    public static void assertContainerMatchesJurisdictionAndPoBox(
+    public void assertContainerMatchesJurisdictionAndPoBox(
         List<ContainerMappings.Mapping> mappings,
         InputEnvelope envelope,
         String containerName
@@ -218,7 +218,7 @@ public final class EnvelopeValidator {
         }
     }
 
-    public static void assertPaymentsEnabledForContainerIfPaymentsArePresent(
+    public void assertPaymentsEnabledForContainerIfPaymentsArePresent(
         InputEnvelope envelope,
         boolean paymentsEnabled,
         List<ContainerMappings.Mapping> mappings
@@ -236,7 +236,7 @@ public final class EnvelopeValidator {
         }
     }
 
-    public static void assertServiceEnabled(
+    public void assertServiceEnabled(
         InputEnvelope envelope,
         List<ContainerMappings.Mapping> mappings
     ) {
@@ -261,7 +261,7 @@ public final class EnvelopeValidator {
         }
     }
 
-    private static boolean isPaymentsEnabledForContainer(
+    private boolean isPaymentsEnabledForContainer(
         List<ContainerMappings.Mapping> mappings,
         InputEnvelope envelope
     ) {
@@ -276,7 +276,7 @@ public final class EnvelopeValidator {
             .orElse(false);
     }
 
-    private static List<String> getDuplicates(List<String> collection) {
+    private List<String> getDuplicates(List<String> collection) {
         return collection
             .stream()
             .collect(groupingBy(it -> it, counting()))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.FileErrorHandler;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.ZipFileProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.EnvelopeValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
 import java.io.IOException;
@@ -58,6 +59,9 @@ class BlobProcessorTaskTest {
     private BlobInputStream blobInputStream;
 
     @Mock
+    private EnvelopeValidator envelopeValidator;
+
+    @Mock
     private FileErrorHandler fileErrorHandler;
 
     @BeforeEach
@@ -68,6 +72,7 @@ class BlobProcessorTaskTest {
             zipFileProcessor,
             containerMappings,
             ocrValidator,
+            envelopeValidator,
             fileErrorHandler,
             false
         );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeProcessorValidationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeProcessorValidationTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings.Mapping;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ContainerJurisdictionPoBoxMismatchException;
@@ -29,11 +30,17 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.InputEnvelopeCreator.inputEnvelope;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.InputEnvelopeCreator.payment;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.InputEnvelopeCreator.scannableItem;
-import static uk.gov.hmcts.reform.bulkscanprocessor.validation.EnvelopeValidator.assertZipFilenameMatchesWithMetadata;
 
 public class EnvelopeProcessorValidationTest {
 
     private static final String SAMPLE_URL = "https://example.com/";
+
+    private EnvelopeValidator envelopeValidator;
+
+    @BeforeEach
+    public void setUp() {
+        envelopeValidator = new EnvelopeValidator();
+    }
 
     @Test
     public void should_throw_exception_when_zip_file_contains_fewer_pdfs() throws Exception {
@@ -50,7 +57,7 @@ public class EnvelopeProcessorValidationTest {
         List<Pdf> pdfs = singletonList(new Pdf("hello.pdf", null));
 
         // when
-        Throwable throwable = catchThrowable(() -> EnvelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
+        Throwable throwable = catchThrowable(() -> envelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
 
         // then
         assertThat(throwable)
@@ -77,7 +84,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         // when
-        Throwable throwable = catchThrowable(() -> EnvelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
+        Throwable throwable = catchThrowable(() -> envelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
 
         // then
         assertThat(throwable)
@@ -105,7 +112,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         // when
-        Throwable throwable = catchThrowable(() -> EnvelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
+        Throwable throwable = catchThrowable(() -> envelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
 
         // then
         assertThat(throwable)
@@ -133,7 +140,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         // when
-        Throwable throwable = catchThrowable(() -> EnvelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
+        Throwable throwable = catchThrowable(() -> envelopeValidator.assertEnvelopeHasPdfs(envelope, pdfs));
 
         // then
         assertThat(throwable)
@@ -157,7 +164,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable throwable = catchThrowable(
-            () -> EnvelopeValidator.assertDocumentControlNumbersAreUnique(envelope)
+            () -> envelopeValidator.assertDocumentControlNumbersAreUnique(envelope)
         );
 
         // then
@@ -179,7 +186,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         Throwable throwable = catchThrowable(() ->
-            EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
+            envelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
         );
 
         assertThat(throwable).isInstanceOf(OcrDataNotFoundException.class)
@@ -201,7 +208,7 @@ public class EnvelopeProcessorValidationTest {
                 );
 
                 Throwable throwable = catchThrowable(
-                    () -> EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
+                    () -> envelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
                 );
 
                 softly.assertThat(throwable)
@@ -225,7 +232,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         Throwable throwable = catchThrowable(() ->
-            EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
+            envelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
         );
 
         assertThat(throwable).isNull();
@@ -247,7 +254,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         Throwable throwable = catchThrowable(
-            () -> EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
+            () -> envelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
         );
 
         assertThat(throwable).isNull();
@@ -262,7 +269,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable err = catchThrowable(
-            () -> EnvelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
+            () -> envelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
         );
 
         // then
@@ -276,7 +283,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable throwable = catchThrowable(
-            () -> assertZipFilenameMatchesWithMetadata(envelope, "invalid-zip-filename.zip")
+            () -> envelopeValidator.assertZipFilenameMatchesWithMetadata(envelope, "invalid-zip-filename.zip")
         );
 
         // then
@@ -294,7 +301,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable err = catchThrowable(
-            () -> EnvelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
+            () -> envelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
         );
 
         // then
@@ -312,7 +319,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable err = catchThrowable(
-            () -> EnvelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
+            () -> envelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
         );
 
         // then
@@ -330,7 +337,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable err = catchThrowable(
-            () -> EnvelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
+            () -> envelopeValidator.assertContainerMatchesJurisdictionAndPoBox(mappings, envelope, container)
         );
 
         // then
@@ -352,7 +359,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable err = catchThrowable(
-            () -> EnvelopeValidator.assertPaymentsEnabledForContainerIfPaymentsArePresent(
+            () -> envelopeValidator.assertPaymentsEnabledForContainerIfPaymentsArePresent(
                 envelope, false, singletonList(new Mapping("abc", "ABC", "test_poBox", null, true, true))
             ));
 
@@ -375,7 +382,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable err = catchThrowable(
-            () -> EnvelopeValidator.assertPaymentsEnabledForContainerIfPaymentsArePresent(
+            () -> envelopeValidator.assertPaymentsEnabledForContainerIfPaymentsArePresent(
                 envelope, true, singletonList(new Mapping("abc", "ABC", "test_poBox", null, false, true))
             ));
 
@@ -396,7 +403,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         Throwable throwable = catchThrowable(() ->
-            EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
+            envelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
         );
 
         assertThat(throwable).isInstanceOf(OcrDataNotFoundException.class)
@@ -415,7 +422,7 @@ public class EnvelopeProcessorValidationTest {
         );
 
         Throwable throwable = catchThrowable(() ->
-            EnvelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
+            envelopeValidator.assertEnvelopeContainsOcrDataIfRequired(envelope)
         );
 
         assertThat(throwable).isInstanceOf(OcrDataNotFoundException.class)
@@ -433,7 +440,7 @@ public class EnvelopeProcessorValidationTest {
 
         // when
         Throwable exception = catchThrowable(
-            () -> EnvelopeValidator.assertServiceEnabled(envelope, mappings)
+            () -> envelopeValidator.assertServiceEnabled(envelope, mappings)
         );
 
         // then

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/envelope/DocumentTypesValidationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/envelope/DocumentTypesValidationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.validation.envelope;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.DisallowedDocumentTypesException;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputDocumentType;
@@ -18,6 +19,12 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.helper.InputEnvelopeCreator.
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.InputEnvelopeCreator.scannableItem;
 
 public class DocumentTypesValidationTest {
+    private EnvelopeValidator envelopeValidator;
+
+    @BeforeEach
+    public void setUp() {
+        envelopeValidator = new EnvelopeValidator();
+    }
 
     @Test
     public void should_throw_exception_when_supplementary_evidence_envelope_contains_form() {
@@ -32,7 +39,7 @@ public class DocumentTypesValidationTest {
 
         // when
         Throwable throwable = catchThrowable(
-            () -> EnvelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
+            () -> envelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
         );
 
         // then
@@ -57,7 +64,7 @@ public class DocumentTypesValidationTest {
 
         // when
         Throwable throwable = catchThrowable(
-            () -> EnvelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
+            () -> envelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
         );
 
         // then
@@ -82,7 +89,7 @@ public class DocumentTypesValidationTest {
 
         // when
         assertThatCode(
-            () -> EnvelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
+            () -> envelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
         ).doesNotThrowAnyException();
     }
 
@@ -99,7 +106,7 @@ public class DocumentTypesValidationTest {
 
         // when
         assertThatCode(
-            () -> EnvelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
+            () -> envelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
         ).doesNotThrowAnyException();
     }
 
@@ -116,7 +123,7 @@ public class DocumentTypesValidationTest {
 
         // when
         assertThatCode(
-            () -> EnvelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
+            () -> envelopeValidator.assertEnvelopeContainsDocsOfAllowedTypesOnly(envelope)
         ).doesNotThrowAnyException();
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-719


### Change description ###
Made EnvelopeValidator a component rather than utility class with static methods. This will solve issues with making BlobProcessorTask testable when doing further refactoring. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
