### PR TITLE
Update functional tests to use unique file names

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BlobProcessorTest.java
@@ -23,7 +23,7 @@ public class BlobProcessorTest extends BaseFunctionalTest {
     public void should_process_zipfile_after_upload_and_set_status() {
         List<String> files = asList("1111006.pdf", "1111002.pdf");
         String metadataFile = "exception_with_ocr_metadata.json";
-        String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
+        String destZipFilename = testHelper.getRandomFilename();
 
         // valid zip file
         uploadZipFile(files, metadataFile, destZipFilename);
@@ -40,7 +40,7 @@ public class BlobProcessorTest extends BaseFunctionalTest {
     public void should_process_zipfile_with_supplementary_evidence_with_oce_classification() {
         List<String> files = Collections.singletonList("1111006.pdf");
         String metadataFile = "supplementary_evidence_with_ocr_metadata.json";
-        String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
+        String destZipFilename = testHelper.getRandomFilename();
 
         uploadZipFile(files, metadataFile, destZipFilename);
         EnvelopeResponse envelope = waitForEnvelopeToBeInStatus(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -47,7 +47,7 @@ public class EnvelopeDeletionTest extends BaseFunctionalTest {
 
     @Test
     public void should_move_invalid_zip_file_to_rejected_container() throws Exception {
-        String destZipFilename = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
+        String destZipFilename = testHelper.getRandomFilename();
 
         testHelper.uploadZipFile(
             inputContainer,
@@ -73,7 +73,7 @@ public class EnvelopeDeletionTest extends BaseFunctionalTest {
         // given
         final int numberOfUploads = 2;
 
-        String fileName = testHelper.getRandomFilename("24-06-2018-00-00-00.test.zip");
+        String fileName = testHelper.getRandomFilename();
         filesToDeleteAfterTest.add(fileName);
 
         // when

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
@@ -43,8 +43,6 @@ public class GetSasTokenTest {
 
     private String destZipFilename;
 
-    private static final String zipFilename = "24-06-2018-00-00-00.test.zip";
-
     @BeforeEach
     public void setUp() {
         this.testUrl = conf.getString("test-url");
@@ -101,7 +99,7 @@ public class GetSasTokenTest {
         CloudBlobContainer testSasContainer =
             testHelper.getCloudContainer(sasToken, testContainerName, this.blobContainerUrl);
 
-        destZipFilename = testHelper.getRandomFilename(zipFilename);
+        destZipFilename = testHelper.getRandomFilename();
         testHelper.uploadAndLeaseZipFile(
             testSasContainer,
             Arrays.asList(
@@ -120,7 +118,7 @@ public class GetSasTokenTest {
         CloudBlobContainer testSasContainer =
             testHelper.getCloudContainer(sasToken, "test", this.blobContainerUrl);
 
-        destZipFilename = testHelper.getRandomFilename(zipFilename);
+        destZipFilename = testHelper.getRandomFilename();
         assertThrows(
             StorageException.class,
             () -> testHelper.uploadAndLeaseZipFile(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
@@ -93,7 +93,7 @@ public class ProcessedEnvelopeMessageHandlingTest extends BaseFunctionalTest {
     }
 
     private String uploadEnvelope() {
-        String zipFilename = testHelper.getRandomFilename("12-02-2019-00-00-00.test.zip");
+        String zipFilename = testHelper.getRandomFilename();
 
         testHelper.uploadZipFile(
             inputContainer,

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscanprocessor/TestHelper.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscanprocessor/TestHelper.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.microsoft.azure.storage.OperationContext;
@@ -26,6 +25,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -43,6 +44,9 @@ public class TestHelper {
 
     private static final String TEST_SOURCE_NAME = "Bulk Scan Processor tests";
     private static final Random RANDOM = new Random();
+
+    private static final DateTimeFormatter FILE_NAME_DATE_TIME_FORMAT =
+        DateTimeFormatter.ofPattern("dd-MM-yyyy-HH-mm-ss");
 
     public String s2sSignIn(String s2sName, String s2sSecret, String s2sUrl) {
         Map<String, Object> params = ImmutableMap.of(
@@ -133,13 +137,12 @@ public class TestHelper {
         return new CloudBlobContainer(PathUtility.addToQuery(containerUri, sasToken));
     }
 
-    public String getRandomFilename(String suffix) {
-        StringBuilder strBuffer = new StringBuilder();
-        strBuffer
-            .append(ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE))
-            .append(Strings.isNullOrEmpty(suffix) ? "" : "_")
-            .append(Strings.isNullOrEmpty(suffix) ? "" : suffix);
-        return strBuffer.toString();
+    public String getRandomFilename() {
+        return String.format(
+            "%s_%s.test.zip",
+            ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE),
+            LocalDateTime.now().format(FILE_NAME_DATE_TIME_FORMAT)
+        );
     }
 
     public byte[] createZipArchiveWithRandomName(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1291


### Change description ###
At the moment, the functional tests are uploading test files with duplicate names. This is causing to generate duplicate notification message ids in the notification-service.
Updated the `TestHelper` to generate file names with current date-time.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
