### PR TITLE
Added logs to processor

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsService.java
@@ -88,6 +88,8 @@ public class UploadEnvelopeDocumentsService {
         CloudBlockBlob blob = null;
         Optional<String> leaseId = Optional.empty();
 
+        log.info("Processing envelope. Container {}, File {}", containerName, zipFileName);
+
         try {
             blob = getCloudBlockBlob(blobContainer, zipFileName, envelopeId);
             leaseId = blobManager.acquireLease(blob, containerName, envelope.getZipFileName());
@@ -100,6 +102,8 @@ public class UploadEnvelopeDocumentsService {
 
                 envelopeProcessor.handleEvent(envelope, DOC_UPLOADED);
             }
+
+            log.info("Processed envelope. Container {}, File {}", containerName, zipFileName);
         } catch (Exception exception) {
             log.error(
                 "An error occurred when trying to upload documents. Container: {}, File: {}, Envelope ID: {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/ZipFileProcessor.java
@@ -30,7 +30,12 @@ public class ZipFileProcessor {
         ZipInputStream zis,
         String zipFileName
     ) throws IOException {
+        log.info("Processing zip file {}", zipFileName);
+
         ZipInputStream extractedZis = zipExtractor.extract(zis);
+
+        log.info("Extracted zip entries from {}", zipFileName);
+
         ZipEntry zipEntry;
 
         List<Pdf> pdfs = new ArrayList<>();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1297


### Change description ###
There is 'PDFs found in ...' log entry marking the end of processing zip file, but there is no log entry marking the beginning of the processing. This PR fills this gap make lease expiration problem better analysable.

Logs added to ZipFileProcessor and UploadEnvelopeDocumentsService


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
