### PR TITLE
Check for incomplete envelopes more often

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -117,7 +117,7 @@ variable "reports_cron" {
 # region incomplete envelopes monitoring
 
 variable "incomplete_envelopes_cron" {
-  default     = "0 0 9 ? * MON-FRI"
+  default     = "0 0 * * * *"
   description = "Cron signature for job to log amount of incomplete envelopes currently present in service"
 }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,7 +58,7 @@ spring:
 # setting env vars + defaults as env vars will be overridden otherwise
 monitoring:
   incomplete-envelopes:
-    cron: ${INCOMPLETE_ENVELOPES_TASK_CRON:0 0 9 ? * MON-FRI} # can be discussed later
+    cron: ${INCOMPLETE_ENVELOPES_TASK_CRON:0 0 * * * *}
     enabled: ${INCOMPLETE_ENVELOPES_TASK_ENABLED:true}
   no-new-envelopes:
     enabled: ${NO_NEW_ENVELOPES_TASK_ENABLED}


### PR DESCRIPTION
Every hour, not once a day.

helm `values.yaml` already has this cron.
No references to `INCOMPLETE_ENVELOPES_TASK_CRON` in shared-infra repo.