### PR TITLE
Refactor/move incomplete envelope duration to config

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,6 +60,7 @@ monitoring:
   incomplete-envelopes:
     cron: ${INCOMPLETE_ENVELOPES_TASK_CRON:0 0 * * * *}
     enabled: ${INCOMPLETE_ENVELOPES_TASK_ENABLED:true}
+    stale-after: PT1H #ISO-8601
   no-new-envelopes:
     enabled: ${NO_NEW_ENVELOPES_TASK_ENABLED}
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/monitoring/IncompleteEnvelopesTaskTest.java
@@ -7,6 +7,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -21,7 +23,7 @@ public class IncompleteEnvelopesTaskTest {
 
     @BeforeEach
     public void setUp() {
-        task = new IncompleteEnvelopesTask(envelopeRepository);
+        task = new IncompleteEnvelopesTask(envelopeRepository, Duration.ofHours(1));
     }
 
     @Test


### PR DESCRIPTION
reopening https://github.com/hmcts/bulk-scan-processor/pull/1431 because of jenkins issues