### PR TITLE
upgrade blob lib part 3 - use in Rejected files report

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -116,7 +116,7 @@ public class EnvelopeControllerTest {
     public void setup() throws Exception {
         CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
         CloudBlobClient cloudBlobClient = account.createCloudBlobClient();
-        BlobManager blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
+        BlobManager blobManager = new BlobManager(null, cloudBlobClient, blobManagementProperties);
         EnvelopeValidator envelopeValidator = new EnvelopeValidator();
         EnvelopeProcessor envelopeProcessor = new EnvelopeProcessor(
             schemaValidator,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -47,7 +47,7 @@ public class CleanUpRejectedFilesTaskTest {
         CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
         CloudBlobClient cloudBlobClient = account.createCloudBlobClient();
 
-        this.blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
+        this.blobManager = new BlobManager(null, cloudBlobClient, blobManagementProperties);
 
         this.rejectedContainer = cloudBlobClient.getContainerReference("test-rejected");
         this.rejectedContainer.createIfNotExists();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -122,7 +122,7 @@ public abstract class ProcessorTestSuite {
         CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
         CloudBlobClient cloudBlobClient = account.createCloudBlobClient();
 
-        blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
+        blobManager = new BlobManager(null, cloudBlobClient, blobManagementProperties);
 
         documentProcessor = new DocumentProcessor(
             documentManagementService,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
@@ -36,7 +36,7 @@ public class RejectedFilesReportService {
 
     private Stream<BlobItem> getBlobs(BlobContainerClient container) {
         ListBlobsOptions listOptions = new ListBlobsOptions();
-        listOptions.getDetails().setRetrieveSnapshots(false);
+        listOptions.getDetails().setRetrieveSnapshots(true);
         return container
                 .listBlobs(listOptions, null).stream();
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
@@ -1,18 +1,15 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.ListBlobItem;
-import org.apache.commons.io.FilenameUtils;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.ListBlobsOptions;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.RejectedFile;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 
-import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import static com.microsoft.azure.storage.blob.BlobListingDetails.SNAPSHOTS;
 import static java.util.stream.Collectors.toList;
 
 @Service
@@ -26,23 +23,21 @@ public class RejectedFilesReportService {
 
     public List<RejectedFile> getRejectedFiles() {
         return blobManager
-            .listRejectedContainers()
+            .getRejectedContainers()
             .stream()
             .flatMap(container ->
                 getBlobs(container)
                     .map(listItem -> new RejectedFile(
-                        FilenameUtils.getName(listItem.getUri().toString()),
-                        container.getName()
+                        listItem.getName(),
+                        container.getBlobContainerName()
                     )))
             .collect(toList());
     }
 
-    private Stream<ListBlobItem> getBlobs(CloudBlobContainer container) {
-        return StreamSupport.stream(
-            container
-                .listBlobs(null, true, EnumSet.of(SNAPSHOTS), null, null)
-                .spliterator(),
-            false
-        );
+    private Stream<BlobItem> getBlobs(BlobContainerClient container) {
+        ListBlobsOptions listOptions = new ListBlobsOptions();
+        listOptions.getDetails().setRetrieveSnapshots(false);
+        return container
+                .listBlobs(listOptions, null).stream();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
+import com.azure.storage.blob.BlobServiceClient;
 import com.microsoft.azure.storage.AccessCondition;
 import com.microsoft.azure.storage.StorageErrorCodeStrings;
 import com.microsoft.azure.storage.StorageException;
@@ -59,6 +60,9 @@ public class BlobManagerTest {
     private CloudBlobClient cloudBlobClient;
 
     @Mock
+    private BlobServiceClient blobServiceClient;
+
+    @Mock
     private CloudBlockBlob inputBlob;
 
     @Mock
@@ -83,7 +87,7 @@ public class BlobManagerTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        blobManager = new BlobManager(cloudBlobClient, blobManagementProperties);
+        blobManager = new BlobManager(blobServiceClient, cloudBlobClient, blobManagementProperties);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-222

### Change description ###

upgrade blob lib part 3 - use in Rejected files report

new Blob Client `BlobServiceClient` added to `BlobManager` so constructor changed and to make the PR small I added new method `getRejectedContainers` same as  `listRejectedContainers` (still using in `CleanUpRejectedFilesTask`, will remove in next PR and rename method `get` to `list`)

As  `BlobManager` change cause changes in related tests.
Just `RejectedFilesReportTest` is using the new client, others assigned with null.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
