### PR TITLE
Add content type to headers for OCR validation client call

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/client/OcrValidationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/ocrvalidation/client/OcrValidationClient.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -25,6 +26,7 @@ public class OcrValidationClient {
     ) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("ServiceAuthorization", s2sToken);
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
 
         String url =
             UriComponentsBuilder


### PR DESCRIPTION
### Change description ###

e2e tests continuously fails. checked latest build and this caught my attention:

> 415 Unsupported Media Type: [{"timestamp":"2020-08-09T09:47:07.206+0000","status":415,"error":"Unsupported Media Type","message":"Content type 'application/xml;charset=UTF-8' not supported","path":"/forms/D8/validate-ocr"}]

**note**: application/xml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
