### PR TITLE
fix date compare in sas token tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
@@ -11,10 +11,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -58,7 +59,7 @@ public class SasTokenControllerTest {
 
         Map<String, String[]> queryParams = PathUtility.parseQueryString(node.get("sas_token").asText());
 
-        String currentDate = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+        String currentDate = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(OffsetDateTime.now(UTC));
 
         assertThat(queryParams.get("sig")).isNotNull();//this is a generated hash of the resource string
         assertThat(queryParams.get("se")[0]).startsWith(currentDate);//the expiry date/time for the signature

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
@@ -12,10 +12,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.AccessTokenProperties;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceConfigNotFoundException;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,7 +49,7 @@ public class SasTokenGeneratorServiceTest {
     public void should_generate_sas_token_when_service_configuration_is_available() throws StorageException {
         String sasToken = tokenGeneratorService.generateSasToken("sscs");
 
-        String currentDate = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+        String currentDate = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(OffsetDateTime.now(UTC));
 
         Map<String, String[]> queryParams = PathUtility.parseQueryString(sasToken);
 


### PR DESCRIPTION

### Change description ###

sas token time is in UTC. 
in assert we create date default zone and it creates in BST time and at midnight tests can fail.

like below:
https://build.platform.hmcts.net/view/BSP/job/HMCTS_BSP/job/bulk-scan-processor/view/change-requests/job/PR-1459/1/console


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
