### PR TITLE
ReceivedZipFileConverter

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ReceivedZipFileRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ReceivedZipFileRepositoryTest.java
@@ -7,10 +7,10 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ReceivedZipFile;
-import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ReceivedZipFileItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ReceivedZipFileRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.ReceivedZipFileItem;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverter.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ReceivedZipFile;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ReceivedZipFileData;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileIdentifier;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+public class ReceivedZipFileConverter {
+
+    public List<ReceivedZipFileData> convertReceivedZipFiles(List<ReceivedZipFile> receivedZipFiles) {
+        return receivedZipFiles.stream()
+            .collect(groupingBy(file ->
+                                    new ZipFileIdentifier(
+                                        file.getZipFileName(),
+                                        file.getContainer()
+                                    )
+            ))
+            .values().stream()
+            .map(this::getReceivedZipFileData)
+            .collect(toList());
+    }
+
+    private ReceivedZipFileData getReceivedZipFileData(List<ReceivedZipFile> receivedZipFilesList) {
+        Set<String> scannableItemDcns = new HashSet<>();
+        Set<String> paymentDcns = new HashSet<>();
+        receivedZipFilesList.forEach(
+            receivedZipFile -> {
+                if (receivedZipFile.getScannableItemDcn() != null) {
+                    scannableItemDcns.add(receivedZipFile.getScannableItemDcn());
+                }
+                if (receivedZipFile.getPaymentDcn() != null) {
+                    paymentDcns.add(receivedZipFile.getPaymentDcn());
+                }
+            }
+        );
+        return new ReceivedZipFileData(
+            new ZipFileIdentifier(
+                receivedZipFilesList.get(0).getZipFileName(),
+                receivedZipFilesList.get(0).getContainer()
+            ),
+            new ArrayList<>(scannableItemDcns),
+            new ArrayList<>(paymentDcns)
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ReceivedZipFileData.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ReceivedZipFileData.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models;
+
+import java.util.List;
+
+public class ReceivedZipFileData {
+    public final ZipFileIdentifier zipFileIdentifier;
+    public final List<String> scannableItemDcns;
+    public final List<String> paymentDcns;
+
+    public ReceivedZipFileData(
+        ZipFileIdentifier zipFileIdentifier,
+        List<String> scannableItemDcns,
+        List<String> paymentDcns
+    ) {
+        this.zipFileIdentifier = zipFileIdentifier;
+        this.scannableItemDcns = scannableItemDcns;
+        this.paymentDcns = paymentDcns;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileIdentifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ZipFileIdentifier.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models;
+
+import java.util.Objects;
+
+public class ZipFileIdentifier {
+    private final String zipFileName;
+    private final String container;
+
+    public ZipFileIdentifier(String zipFileName, String container) {
+        this.zipFileName = zipFileName;
+        this.container = container;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ZipFileIdentifier that = (ZipFileIdentifier) o;
+        return Objects.equals(zipFileName, that.zipFileName)
+            && Objects.equals(container, that.container);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(zipFileName, container);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverterTest.java
@@ -1,0 +1,158 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ReceivedZipFile;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ReceivedZipFileData;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ZipFileIdentifier;
+
+import java.time.Instant;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class ReceivedZipFileConverterTest {
+    private ReceivedZipFileConverter receivedZipFileConverter;
+
+    @BeforeEach
+    public void setUp() {
+        receivedZipFileConverter = new ReceivedZipFileConverter();
+    }
+
+    @Test
+    void should_convert_files_without_scannable_documents_and_payments() {
+        // given
+        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, null);
+        ReceivedZipFile file2 = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, null);
+
+        // when
+        List<ReceivedZipFileData> res = receivedZipFileConverter.convertReceivedZipFiles(asList(file1, file2));
+
+        // then
+        assertThat(res)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new ReceivedZipFileData(new ZipFileIdentifier("file1", "c1"), emptyList(), emptyList()),
+                new ReceivedZipFileData(new ZipFileIdentifier("file2", "c2"), emptyList(), emptyList())
+            );
+    }
+
+    @Test
+    void should_convert_files_with_scannable_documents() {
+        // given
+        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", null);
+        ReceivedZipFile file2 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", null);
+        ReceivedZipFile file3 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", null);
+        ReceivedZipFile file4 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", null);
+
+        // when
+        List<ReceivedZipFileData> res =
+            receivedZipFileConverter.convertReceivedZipFiles(asList(file1, file2, file3, file4));
+
+        // then
+        assertThat(res)
+            .extracting(file ->
+                            tuple(
+                                file.zipFileIdentifier,
+                                file.scannableItemDcns.stream().sorted().collect(toList()),
+                                file.paymentDcns.stream().sorted().collect(toList())
+                            )
+            )
+            .containsExactlyInAnyOrder(
+                tuple(
+                    new ZipFileIdentifier("file1", "c1"),
+                    asList("doc-1", "doc-2"),
+                    emptyList()
+                ),
+                tuple(
+                    new ZipFileIdentifier("file2", "c2"),
+                    asList("doc-3", "doc-4"),
+                    emptyList()
+                )
+            );
+    }
+
+    @Test
+    void should_convert_files_with_payments() {
+        // given
+        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, "pay-1");
+        ReceivedZipFile file2 = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, "pay-2");
+        ReceivedZipFile file3 = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, "pay-3");
+        ReceivedZipFile file4 = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, "pay-4");
+
+        // when
+        List<ReceivedZipFileData> res =
+            receivedZipFileConverter.convertReceivedZipFiles(asList(file1, file2, file3, file4));
+
+        // then
+        assertThat(res)
+            .extracting(file ->
+                            tuple(
+                                file.zipFileIdentifier,
+                                file.scannableItemDcns.stream().sorted().collect(toList()),
+                                file.paymentDcns.stream().sorted().collect(toList())
+                            )
+            )
+            .containsExactlyInAnyOrder(
+                tuple(
+                    new ZipFileIdentifier("file1", "c1"),
+                    emptyList(),
+                    asList("pay-1", "pay-2")
+                ),
+                tuple(
+                    new ZipFileIdentifier("file2", "c2"),
+                    emptyList(),
+                    asList("pay-3", "pay-4")
+                )
+            );
+    }
+
+    @Test
+    void should_convert_files_with_scannable_documents_and_payments() {
+        // given
+        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", "pay-1");
+        ReceivedZipFile file2 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", "pay-2");
+        ReceivedZipFile file3 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", "pay-2");
+        ReceivedZipFile file4 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", "pay-2");
+        ReceivedZipFile file5 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", "pay-3");
+        ReceivedZipFile file6 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", "pay-3");
+        ReceivedZipFile file7 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", "pay-4");
+        ReceivedZipFile file8 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", "pay-4");
+
+        // when
+        List<ReceivedZipFileData> res =
+            receivedZipFileConverter.convertReceivedZipFiles(
+                asList(file1, file2, file3, file4, file5, file6, file7, file8)
+            );
+
+        // then
+        assertThat(res.get(1).scannableItemDcns).containsExactlyInAnyOrder("doc-1", "doc-2");
+        assertThat(res.get(0).scannableItemDcns).containsExactlyInAnyOrder("doc-3", "doc-4");
+        assertThat(res.get(1).paymentDcns).containsExactlyInAnyOrder("pay-1", "pay-2");
+        assertThat(res.get(0).paymentDcns).containsExactlyInAnyOrder("pay-3", "pay-4");
+        assertThat(res)
+            .extracting(file ->
+                            tuple(
+                                file.zipFileIdentifier,
+                                file.scannableItemDcns.stream().sorted().collect(toList()),
+                                file.paymentDcns.stream().sorted().collect(toList())
+                            )
+            )
+            .containsExactlyInAnyOrder(
+                tuple(
+                    new ZipFileIdentifier("file1", "c1"),
+                    asList("doc-1", "doc-2"),
+                    asList("pay-1", "pay-2")
+                ),
+                tuple(
+                    new ZipFileIdentifier("file2", "c2"),
+                    asList("doc-3", "doc-4"),
+                    asList("pay-3", "pay-4")
+                )
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileItem.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileItem.java
@@ -1,4 +1,6 @@
-package uk.gov.hmcts.reform.bulkscanprocessor.entity.reports;
+package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
+
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ReceivedZipFile;
 
 import java.time.Instant;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1363 - reconciliation in processor


### Change description ###
ReceivedZipFileRepository fetches multiple entries for each envelope (containing cartesian product of all scannable item and payment dcns). This is difficult to compare with the content of the request from router.

ReceivedZipFileConverter converts the result from ReceivedZipFileRepository into the list of instances of ReceivedZipFileData which is much handier for further comparison.

Also moved ReceivedZipFileItem class to tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
