### PR TITLE
Upgrade blob lib part 8.2 use in blob processor change copyfrom url

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/BaseFunctionalTest.java
@@ -92,7 +92,7 @@ public abstract class BaseFunctionalTest {
         String s2sToken = testHelper.s2sSignIn(S2S_NAME, S2S_SECRET, S2S_URL);
 
         await("File " + fileName + " should be processed")
-            .atMost(SCAN_DELAY + 40_000, TimeUnit.MILLISECONDS)
+            .atMost(SCAN_DELAY + 60_000, TimeUnit.MILLISECONDS)
             .pollInterval(500, TimeUnit.MILLISECONDS)
             .until(() ->
                        testHelper.getEnvelopeByZipFileName(TEST_URL, s2sToken, fileName)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeDeletionTest.java
@@ -60,7 +60,7 @@ public class EnvelopeDeletionTest extends BaseFunctionalTest {
         filesToDeleteAfterTest.add(destZipFilename);
 
         await(destZipFilename + " file should be deleted")
-            .atMost(SCAN_DELAY + 40_000, TimeUnit.MILLISECONDS)
+            .atMost(SCAN_DELAY + 60_000, TimeUnit.MILLISECONDS)
             .pollInterval(2, TimeUnit.SECONDS)
             .until(() -> testHelper.storageHasFile(inputContainer, destZipFilename), is(false));
 
@@ -87,7 +87,7 @@ public class EnvelopeDeletionTest extends BaseFunctionalTest {
             );
 
             await(fileName + " file should be deleted")
-                .atMost(SCAN_DELAY + 40_000, TimeUnit.MILLISECONDS)
+                .atMost(SCAN_DELAY + 60_000, TimeUnit.MILLISECONDS)
                 .pollInterval(2, TimeUnit.SECONDS)
                 .until(() -> testHelper.storageHasFile(inputContainer, fileName), is(false));
         });

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ProcessedEnvelopeMessageHandlingTest.java
@@ -28,9 +28,9 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.config.TestConfiguration.TES
 
 public class ProcessedEnvelopeMessageHandlingTest extends BaseFunctionalTest {
 
-    private static final long MESSAGE_PROCESSING_TIMEOUT_MILLIS = 40_000;
-    private static final long ENVELOPE_FINALISATION_TIMEOUT_MILLIS = 40_000;
-    private static final int DELETE_TIMEOUT_MILLIS = 40_000;
+    private static final long MESSAGE_PROCESSING_TIMEOUT_MILLIS = 60_000;
+    private static final long ENVELOPE_FINALISATION_TIMEOUT_MILLIS = 60_000;
+    private static final int DELETE_TIMEOUT_MILLIS = 60_000;
 
     private String s2sToken;
     private QueueClient queueClient;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
@@ -157,7 +156,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite {
         processor.processBlobs();
 
         // then
-        CloudBlockBlob blob = testContainer.getBlockBlobReference(SAMPLE_ZIP_FILE_NAME);
+        var blob = testContainer.getBlobClient(SAMPLE_ZIP_FILE_NAME);
         await("file should not be deleted")
             .atMost(5, SECONDS)
             .until(blob::exists, is(true));
@@ -166,7 +165,7 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite {
     private void dbContainsEnvelopeThatWasNotYetDeleted(String zipFileName, Status status) throws Exception {
         Envelope existingEnvelope = EnvelopeCreator.envelope("A", status);
         existingEnvelope.setZipFileName(zipFileName);
-        existingEnvelope.setContainer(testContainer.getName());
+        existingEnvelope.setContainer(testContainer.getBlobContainerName());
         existingEnvelope.setZipDeleted(false);
         envelopeRepository.saveAndFlush(existingEnvelope);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledPayments.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForDisabledPayments.java
@@ -25,6 +25,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_P
 })
 public class BlobProcessorTaskTestForDisabledPayments extends ProcessorTestSuite {
 
+
     @Test
     public void should_reject_file_with_payments_when_payments_are_disabled() throws Exception {
         // given

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -17,6 +17,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_P
 @IntegrationTest
 public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite {
 
+
     @Test
     public void should_record_validation_failure_when_zip_does_not_contain_metadata_json() throws Exception {
         // given

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailingNotification.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailingNotification.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
@@ -33,7 +32,7 @@ public class BlobProcessorTaskTestForFailingNotification extends ProcessorTestSu
         envelopeWasNotCreated();
         eventsWereCreated(ZIPFILE_PROCESSING_STARTED, FILE_VALIDATION_FAILURE);
         errorWasSent(SAMPLE_ZIP_FILE_NAME, ErrorCode.ERR_METAFILE_INVALID);
-        CloudBlockBlob blob = testContainer.getBlockBlobReference(SAMPLE_ZIP_FILE_NAME);
+        var blob = testContainer.getBlobClient(SAMPLE_ZIP_FILE_NAME);
         assertThat(blob.exists()).isTrue();
         verify(serviceBusHelper).sendMessage(any(ErrorMsg.class));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.FileContentProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.FileRejector;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.document.DocumentManagementService;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.ServiceBusHelper;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.storage.LeaseAcquirer;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.DocumentProcessor;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
@@ -36,6 +37,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.validation.EnvelopeValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.MetafileJsonValidator;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.List;
 
@@ -99,6 +101,9 @@ public abstract class ProcessorTestSuite {
     @Autowired
     private BlobManagementProperties blobManagementProperties;
 
+    @Autowired
+    private LeaseAcquirer leaseAcquirer;
+
     @Mock
     protected DocumentManagementService documentManagementService;
 
@@ -111,18 +116,19 @@ public abstract class ProcessorTestSuite {
     @Value("${process-payments.enabled}")
     protected boolean paymentsEnabled;
 
-    protected CloudBlobContainer testContainer;
-    protected CloudBlobContainer rejectedContainer;
+    protected BlobContainerClient testContainer;
+    protected BlobContainerClient rejectedContainer;
 
     private static DockerComposeContainer dockerComposeContainer;
 
     @BeforeEach
     public void setUp() throws Exception {
 
-        CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
-        CloudBlobClient cloudBlobClient = account.createCloudBlobClient();
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+            .connectionString("UseDevelopmentStorage=true")
+            .buildClient();
 
-        blobManager = new BlobManager(null, cloudBlobClient, blobManagementProperties);
+        blobManager = new BlobManager(blobServiceClient, null, blobManagementProperties);
 
         documentProcessor = new DocumentProcessor(
             documentManagementService,
@@ -162,23 +168,32 @@ public abstract class ProcessorTestSuite {
             fileRejector
         );
 
-        testContainer = cloudBlobClient.getContainerReference(CONTAINER_NAME);
-        testContainer.createIfNotExists();
+        testContainer = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+        if (!testContainer.exists()) {
+            testContainer.create();
+        }
 
-        rejectedContainer = cloudBlobClient.getContainerReference(REJECTED_CONTAINER_NAME);
-        rejectedContainer.createIfNotExists();
+        rejectedContainer = blobServiceClient.getBlobContainerClient(REJECTED_CONTAINER_NAME);
+        if (!rejectedContainer.exists()) {
+            rejectedContainer.create();
+        }
 
         processor = new BlobProcessorTask(
             blobManager,
             envelopeProcessor,
-            fileContentProcessor
+            fileContentProcessor,
+            leaseAcquirer
         );
     }
 
     @AfterEach
     public void cleanUp() throws Exception {
-        testContainer.deleteIfExists();
-        rejectedContainer.deleteIfExists();
+        if (testContainer.exists()) {
+            testContainer.delete();
+        }
+        if (rejectedContainer.exists()) {
+            rejectedContainer.delete();
+        }
         envelopeRepository.deleteAll();
         processEventRepository.deleteAll();
     }
@@ -205,18 +220,17 @@ public abstract class ProcessorTestSuite {
     }
 
     public void uploadToBlobStorage(String fileName, byte[] fileContent) throws Exception {
-        CloudBlockBlob blockBlobReference = testContainer.getBlockBlobReference(fileName);
+        var blockBlobReference = testContainer.getBlobClient(fileName);
 
         // Blob need to be deleted as same blob may exists if previously uploaded blob was not deleted
         // due to doc upload failure
         if (blockBlobReference.exists()) {
-            blockBlobReference.breakLease(0);
             blockBlobReference.delete();
         }
 
         // A Put Blob operation may succeed against a blob that exists in the storage emulator with an active lease,
         // even if the lease ID has not been specified in the request.
-        blockBlobReference.uploadFromByteArray(fileContent, 0, fileContent.length);
+        blockBlobReference.upload(new ByteArrayInputStream(fileContent), fileContent.length);
     }
 
     // TODO: add repo method to read single envelope by zip file name and jurisdiction.
@@ -233,8 +247,8 @@ public abstract class ProcessorTestSuite {
             .hasSize(2)
             .extracting(e -> tuple(e.getContainer(), e.getEvent()))
             .containsExactlyInAnyOrder(
-                tuple(testContainer.getName(), event1),
-                tuple(testContainer.getName(), event2)
+                tuple(testContainer.getBlobContainerName(), event1),
+                tuple(testContainer.getBlobContainerName(), event2)
             );
     }
 
@@ -268,8 +282,8 @@ public abstract class ProcessorTestSuite {
         assertThat(envelopesInDb).isEmpty();
     }
 
-    protected void fileWasDeleted(String fileName) throws Exception {
-        CloudBlockBlob blob = testContainer.getBlockBlobReference(fileName);
-        await("file should be deleted").timeout(2, SECONDS).until(blob::exists, is(false));
+    protected void fileWasDeleted(String fileName) {
+        BlobClient blobClient = testContainer.getBlobClient(fileName);
+        await("file should be deleted").timeout(2, SECONDS).until(blobClient::exists, is(false));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessor.java
@@ -78,17 +78,17 @@ public class FileContentProcessor {
                 "Rejected file {} from container {} - Payments processing is disabled", zipFilename, containerName
             );
             Long eventId = createEvent(FILE_VALIDATION_FAILURE, containerName, zipFilename, ex.getMessage());
-            fileRejector.handleInvalidFile(eventId, containerName, zipFilename, leaseId, ex);
+            fileRejector.handleInvalidBlob(eventId, containerName, zipFilename, leaseId, ex);
         } catch (ServiceDisabledException ex) {
             log.error(
                 "Rejected file {} from container {} - Service is disabled", zipFilename, containerName
             );
             Long eventId = createEvent(DISABLED_SERVICE_FAILURE, containerName, zipFilename, ex.getMessage());
-            fileRejector.handleInvalidFile(eventId, containerName, zipFilename, leaseId, ex);
+            fileRejector.handleInvalidBlob(eventId, containerName, zipFilename, leaseId, ex);
         } catch (EnvelopeRejectionException ex) {
             log.warn("Rejected file {} from container {} - invalid", zipFilename, containerName, ex);
             Long eventId = createEvent(FILE_VALIDATION_FAILURE, containerName, zipFilename, ex.getMessage());
-            fileRejector.handleInvalidFile(eventId, containerName, zipFilename, leaseId, ex);
+            fileRejector.handleInvalidBlob(eventId, containerName, zipFilename, leaseId, ex);
         } catch (PreviouslyFailedToUploadException ex) {
             log.warn("Rejected file {} from container {} - failed previously", zipFilename, containerName, ex);
             createEvent(DOC_UPLOAD_FAILURE, containerName, zipFilename, ex.getMessage());

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileNamesExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileNamesExtractor.java
@@ -1,14 +1,15 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobItem;
 import com.google.common.base.Strings;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 public final class FileNamesExtractor {
     private static final Logger log = LoggerFactory.getLogger(FileNamesExtractor.class);
@@ -17,22 +18,26 @@ public final class FileNamesExtractor {
         // Utility class
     }
 
-    public static List<String> getShuffledZipFileNames(CloudBlobContainer container) {
+    public static List<String> getShuffledZipFileNames(BlobContainerClient container) {
         // Randomise iteration order to minimise lease acquire contention
         // For this purpose it's more efficient to have a collection that
         // implements RandomAccess (e.g. ArrayList)
-        List<String> zipFilenames = new ArrayList<>();
-        container
+        List<String> zipFilenames = container
             .listBlobs()
-            .forEach(b -> {
-                String fileName = FilenameUtils.getName(b.getUri().toString());
-                if (Strings.isNullOrEmpty(fileName)) {
-                    log.error("Cannot extract filename from list blob item. URI: {}", b.getUri());
-                } else {
-                    zipFilenames.add(fileName);
-                }
-            });
+            .stream()
+            .map(BlobItem::getName)
+            .filter(FileNamesExtractor::isNotEmptyName)
+            .collect(toList());
+
         Collections.shuffle(zipFilenames);
         return zipFilenames;
+    }
+
+    private static boolean isNotEmptyName(String fileName) {
+        if (Strings.isNullOrEmpty(fileName)) {
+            log.error("Filename name is empty or null.");
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
-import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.BlobInputStream;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,17 +11,16 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ZipFileLoadException;
 import uk.gov.hmcts.reform.bulkscanprocessor.services.FileContentProcessor;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.storage.LeaseAcquirer;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.BlobManager;
 import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Optional;
 import java.util.zip.ZipInputStream;
 
-import static org.apache.commons.io.IOUtils.toByteArray;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.FileNamesExtractor.getShuffledZipFileNames;
 
@@ -50,124 +47,127 @@ public class BlobProcessorTask {
 
     private final FileContentProcessor fileContentProcessor;
 
+    private final  LeaseAcquirer leaseAcquirer;
+
     public BlobProcessorTask(
         BlobManager blobManager,
         EnvelopeProcessor envelopeProcessor,
-        FileContentProcessor fileContentProcessor
+        FileContentProcessor fileContentProcessor,
+        LeaseAcquirer leaseAcquirer
     ) {
         this.blobManager = blobManager;
         this.envelopeProcessor = envelopeProcessor;
         this.fileContentProcessor = fileContentProcessor;
+        this.leaseAcquirer = leaseAcquirer;
     }
 
     @Scheduled(fixedDelayString = "${scheduling.task.scan.delay}")
     public void processBlobs() {
         log.info("Started blob processing job");
 
-        for (CloudBlobContainer container : blobManager.listInputContainers()) {
+        for (BlobContainerClient container : blobManager.getInputContainerClients()) {
             processZipFiles(container);
         }
 
         log.info("Finished blob processing job");
     }
 
-    private void processZipFiles(CloudBlobContainer container) {
-        log.info("Processing blobs for container {}", container.getName());
+    private void processZipFiles(BlobContainerClient container) {
+        log.info("Processing blobs for container {}", container.getBlobContainerName());
         List<String> zipFilenames = getShuffledZipFileNames(container);
 
         for (String zipFilename : zipFilenames) {
             tryProcessZipFile(container, zipFilename);
         }
 
-        log.info("Finished processing blobs for container {}", container.getName());
+        log.info("Finished processing blobs for container {}", container.getBlobContainerName());
     }
 
-    private void tryProcessZipFile(CloudBlobContainer container, String zipFilename) {
+    private void tryProcessZipFile(BlobContainerClient container, String zipFilename) {
         try {
             processZipFileIfEligible(container, zipFilename);
         } catch (Exception ex) {
-            log.error("Failed to process file {} from container {}", zipFilename, container.getName(), ex);
+            log.error("Failed to process file {} from container {}", zipFilename, container.getBlobContainerName(), ex);
         }
     }
 
-    private void processZipFileIfEligible(CloudBlobContainer container, String zipFilename)
-        throws IOException, StorageException, URISyntaxException {
+    private void processZipFileIfEligible(BlobContainerClient container, String zipFilename) {
         // this log entry is used in alerting. Ticket: BPS-541
-        log.info("Processing zip file {} from container {}", zipFilename, container.getName());
+        log.info("Processing zip file {} from container {}", zipFilename, container.getBlobContainerName());
 
-        CloudBlockBlob cloudBlockBlob = container.getBlockBlobReference(zipFilename);
+        BlobClient blobClient = container.getBlobClient(zipFilename);
 
         Envelope existingEnvelope =
-            envelopeProcessor.getEnvelopeByFileAndContainer(container.getName(), zipFilename);
+            envelopeProcessor.getEnvelopeByFileAndContainer(container.getBlobContainerName(), zipFilename);
 
         if (existingEnvelope != null) {
             log.warn(
                 "Envelope for zip file {} (container {}) already exists. Aborting its processing. Envelope ID: {}",
                 zipFilename,
-                container.getName(),
+                container.getBlobContainerName(),
                 existingEnvelope.getId()
             );
-        } else if (!cloudBlockBlob.exists()) {
-            logAbortedProcessingNonExistingFile(zipFilename, container.getName());
+        } else if (Boolean.FALSE.equals(blobClient.exists())) {
+            logAbortedProcessingNonExistingFile(zipFilename, container.getBlobContainerName());
         } else {
-            cloudBlockBlob.downloadAttributes();
-            leaseAndProcessZipFile(container, cloudBlockBlob, zipFilename);
+            leaseAndProcessZipFile(container, blobClient, zipFilename);
         }
     }
 
     private void leaseAndProcessZipFile(
-        CloudBlobContainer container,
-        CloudBlockBlob cloudBlockBlob,
+        BlobContainerClient container,
+        BlobClient cloudBlockBlob,
         String zipFilename
-    ) throws StorageException, IOException {
-        Optional<String> leaseIdOption = blobManager.acquireLease(cloudBlockBlob, container.getName(), zipFilename);
+    ) {
 
-        if (leaseIdOption.isPresent()) {
-            String leaseId = leaseIdOption.get();
+        leaseAcquirer.ifAcquiredOrElse(
+            cloudBlockBlob,
+            leaseId -> processZipFile(container, cloudBlockBlob, zipFilename, leaseId),
+            s -> {},
+            true
+        );
 
-            try {
-                processZipFile(container, cloudBlockBlob, zipFilename, leaseId);
-            } finally {
-                blobManager.tryReleaseLease(cloudBlockBlob, container.getName(), zipFilename, leaseId);
-            }
-        }
     }
 
     private void processZipFile(
-        CloudBlobContainer container,
-        CloudBlockBlob cloudBlockBlob,
+        BlobContainerClient container,
+        BlobClient cloudBlockBlob,
         String zipFilename,
         String leaseId
-    ) throws StorageException, IOException {
-        Envelope envelope = envelopeProcessor.getEnvelopeByFileAndContainer(container.getName(), zipFilename);
+    ) {
+        Envelope envelope = envelopeProcessor
+            .getEnvelopeByFileAndContainer(container.getBlobContainerName(), zipFilename);
 
         if (envelope == null) {
             // Zip file will include metadata.json and collection of pdf documents
             try (ZipInputStream zis = loadIntoMemory(cloudBlockBlob, zipFilename)) {
                 envelopeProcessor.createEvent(
                     ZIPFILE_PROCESSING_STARTED,
-                    container.getName(),
+                    container.getBlobContainerName(),
                     zipFilename,
                     null,
                     null
                 );
 
-                fileContentProcessor.processZipFileContent(zis, zipFilename, container.getName(), leaseId);
+                fileContentProcessor.processZipFileContent(zis, zipFilename, container.getBlobContainerName(), leaseId);
+            } catch (IOException exception) {
+                throw new ZipFileLoadException("Error loading blob file " + zipFilename, exception);
             }
         } else {
             log.info(
                 "Envelope already exists for container {} and file {} - aborting its processing. Envelope ID: {}",
-                container.getName(),
+                container.getBlobContainerName(),
                 zipFilename,
                 envelope.getId()
             );
         }
     }
 
-    private ZipInputStream loadIntoMemory(CloudBlockBlob cloudBlockBlob, String zipFilename) throws StorageException {
+    private ZipInputStream loadIntoMemory(BlobClient blobClient, String zipFilename) {
         log.info("Loading file {} into memory.", zipFilename);
-        try (BlobInputStream blobInputStream = cloudBlockBlob.openInputStream()) {
-            byte[] array = toByteArray(blobInputStream);
+        try (var outputStream = new ByteArrayOutputStream()) {
+            blobClient.download(outputStream);
+            byte[] array = outputStream.toByteArray();
             log.info(
                 "Finished loading file {} into memory. {} loaded.",
                 zipFilename,
@@ -175,7 +175,7 @@ public class BlobProcessorTask {
             );
             return new ZipInputStream(new ByteArrayInputStream(array));
         } catch (IOException exception) {
-            throw new ZipFileLoadException("Error loading blob file " + zipFilename, exception);
+            throw new ZipFileLoadException("Error loading into memory, blob file " + zipFilename, exception);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -362,27 +362,28 @@ public class BlobManager {
         String sourceBlobUrl = sourceBlobClient.getBlobUrl();
         String targetBlobUrl = targetBlobClient.getBlobUrl();
         log.info("Copying from {} to {}", sourceBlobUrl, targetBlobUrl);
-
+        byte[] rawBlob;
         try (var outputStream = new ByteArrayOutputStream()) {
             sourceBlobClient.download(outputStream);
-            byte[] rawBlob = outputStream.toByteArray();
-
-            try (var uploadContent = new ByteArrayInputStream(rawBlob)) {
-                targetBlobClient.upload(uploadContent, rawBlob.length);
-            } catch (Exception ex) {
-                throw new BlobCopyException(
-                    "Copy blob failed in Upload, Upload  target: " + targetBlobUrl,
-                    ex
-                );
-            }
-
+            rawBlob = outputStream.toByteArray();
         } catch (Exception e) {
             throw new BlobCopyException(
                 "Copy blob failed in download, Downloading from : " + sourceBlobUrl,
                 e
             );
         }
+
+        try (var uploadContent = new ByteArrayInputStream(rawBlob)) {
+            targetBlobClient.upload(uploadContent, rawBlob.length, true);
+        } catch (Exception ex) {
+            throw new BlobCopyException(
+                "Copy blob failed in Upload, Upload  target: " + targetBlobUrl,
+                ex
+            );
+        }
     }
+
+
 
     private void waitUntilBlobIsCopied(CloudBlockBlob blob) throws StorageException {
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -326,7 +326,7 @@ public class BlobManager {
 
         try {
             inputBlob.deleteWithResponse(
-                DeleteSnapshotsOptionType.ONLY,
+                DeleteSnapshotsOptionType.INCLUDE,
                 new BlobRequestConditions().setLeaseId(leaseId),
                 null,
                 Context.NONE

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessorTest.java
@@ -150,7 +150,7 @@ class FileContentProcessorTest {
 
         // then
         verify(fileRejector)
-            .handleInvalidFile(
+            .handleInvalidBlob(
                 1L,
                 CONTAINER_NAME,
                 FILE_NAME,
@@ -191,7 +191,7 @@ class FileContentProcessorTest {
 
         // then
         verify(fileRejector)
-            .handleInvalidFile(
+            .handleInvalidBlob(
                 1L,
                 CONTAINER_NAME,
                 FILE_NAME,
@@ -223,7 +223,7 @@ class FileContentProcessorTest {
 
         // then
         verify(fileRejector)
-            .handleInvalidFile(
+            .handleInvalidBlob(
                 1L,
                 CONTAINER_NAME,
                 FILE_NAME,
@@ -255,7 +255,7 @@ class FileContentProcessorTest {
 
         // then
         verify(fileRejector)
-            .handleInvalidFile(
+            .handleInvalidBlob(
                 1L,
                 CONTAINER_NAME,
                 FILE_NAME,


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-222

### Change description ###

Use new version of blob lib blob processor.

Changes were reverted with #1489 as copyfromurl was not working in bulk-scan staging and this PR again trying to merge
same changes.
instead of copyfromurl, using copy blob which does download and upload .

previous pr stuck #1493 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
