### PR TITLE
change method names -blob lib upgrade 9.2

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTaskTest.java
@@ -66,7 +66,7 @@ public class DeleteCompleteFilesTaskTest {
         final BlobContainerClient container1 = mock(BlobContainerClient.class);
         final BlobClient blobClient = mock(BlobClient.class);
         given(container1.getBlobContainerName()).willReturn(containerName1);
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container1));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container1));
 
         doAnswer(invocation -> {
             var okAction = (Consumer) invocation.getArgument(1);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileRejector.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileRejector.java
@@ -35,6 +35,6 @@ public class FileRejector {
             eventId,
             cause.getErrorCode()
         );
-        blobManager.newTryMoveFileToRejectedContainer(zipFilename, containerName, leaseId);
+        blobManager.tryMoveFileToRejectedContainer(zipFilename, containerName, leaseId);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsService.java
@@ -72,7 +72,7 @@ public class UploadEnvelopeDocumentsService {
         );
 
         try {
-            BlobContainerClient blobContainer = blobManager.getContainerClient(containerName);
+            BlobContainerClient blobContainer = blobManager.listContainerClient(containerName);
 
             envelopes.forEach(envelope -> processEnvelope(blobContainer, envelope));
         } catch (Exception exception) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportService.java
@@ -23,7 +23,7 @@ public class RejectedFilesReportService {
 
     public List<RejectedFile> getRejectedFiles() {
         return blobManager
-            .getRejectedContainers()
+            .listRejectedContainers()
             .stream()
             .flatMap(container ->
                 getBlobs(container)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -116,13 +116,13 @@ public class BlobProcessorTask {
 
     private void leaseAndProcessZipFile(
         BlobContainerClient container,
-        BlobClient cloudBlockBlob,
+        BlobClient blobClient,
         String zipFilename
     ) {
 
         leaseAcquirer.ifAcquiredOrElse(
-            cloudBlockBlob,
-            leaseId -> processZipFile(container, cloudBlockBlob, zipFilename, leaseId),
+            blobClient,
+            leaseId -> processZipFile(container, blobClient, zipFilename, leaseId),
             s -> {},
             true
         );
@@ -131,7 +131,7 @@ public class BlobProcessorTask {
 
     private void processZipFile(
         BlobContainerClient container,
-        BlobClient cloudBlockBlob,
+        BlobClient blobClient,
         String zipFilename,
         String leaseId
     ) {
@@ -140,7 +140,7 @@ public class BlobProcessorTask {
 
         if (envelope == null) {
             // Zip file will include metadata.json and collection of pdf documents
-            try (ZipInputStream zis = loadIntoMemory(cloudBlockBlob, zipFilename)) {
+            try (ZipInputStream zis = loadIntoMemory(blobClient, zipFilename)) {
                 envelopeProcessor.createEvent(
                     ZIPFILE_PROCESSING_STARTED,
                     container.getBlobContainerName(),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -65,7 +65,7 @@ public class BlobProcessorTask {
     public void processBlobs() {
         log.info("Started blob processing job");
 
-        for (BlobContainerClient container : blobManager.getInputContainerClients()) {
+        for (BlobContainerClient container : blobManager.listInputContainerClients()) {
             processZipFiles(container);
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTask.java
@@ -55,7 +55,7 @@ public class CleanUpRejectedFilesTask {
         log.info("Started {} job", TASK_NAME);
 
         blobManager
-            .getRejectedContainers()
+            .listRejectedContainers()
             .forEach(this::deleteFilesInRejectedContainer);
 
         log.info("Finished {} job", TASK_NAME);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTask.java
@@ -49,7 +49,7 @@ public class DeleteCompleteFilesTask {
     public void run() {
         log.info("Started {} job", TASK_NAME);
 
-        for (BlobContainerClient container : blobManager.getInputContainerClients()) {
+        for (BlobContainerClient container : blobManager.listInputContainerClients()) {
             try {
                 processCompleteFiles(container);
             } catch (Exception ex) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManager.java
@@ -43,11 +43,11 @@ public class BlobManager {
         this.properties = properties;
     }
 
-    public BlobContainerClient getContainerClient(String containerName) {
+    public BlobContainerClient listContainerClient(String containerName) {
         return blobServiceClient.getBlobContainerClient(containerName);
     }
 
-    public List<BlobContainerClient> getInputContainerClients() {
+    public List<BlobContainerClient> listInputContainerClients() {
         List<BlobContainerClient> blobContainerClientList =
             blobServiceClient
                 .listBlobContainers()
@@ -68,7 +68,7 @@ public class BlobManager {
             || selectedContainer.equals(container.getName());
     }
 
-    public List<BlobContainerClient> getRejectedContainers() {
+    public List<BlobContainerClient> listRejectedContainers() {
         return blobServiceClient.listBlobContainers()
             .stream()
             .filter(c -> c.getName().endsWith(REJECTED_CONTAINER_NAME_SUFFIX))
@@ -76,11 +76,11 @@ public class BlobManager {
             .collect(toList());
     }
 
-    public void newTryMoveFileToRejectedContainer(String fileName, String inputContainerName, String leaseId) {
+    public void tryMoveFileToRejectedContainer(String fileName, String inputContainerName, String leaseId) {
         String rejectedContainerName = getRejectedContainerName(inputContainerName);
 
         try {
-            newMoveFileToRejectedContainer(
+            moveFileToRejectedContainer(
                 fileName,
                 inputContainerName,
                 rejectedContainerName,
@@ -97,7 +97,7 @@ public class BlobManager {
         }
     }
 
-    private void newMoveFileToRejectedContainer(
+    private void moveFileToRejectedContainer(
         String fileName,
         String inputContainerName,
         String rejectedContainerName,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileRejectorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileRejectorTest.java
@@ -60,7 +60,7 @@ class FileRejectorTest {
                 ERR_METAFILE_INVALID
             );
         verify(blobManager)
-            .newTryMoveFileToRejectedContainer(
+            .tryMoveFileToRejectedContainer(
                 FILE_NAME,
                 CONTAINER,
                 LEASE_ID

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsServiceTest.java
@@ -74,7 +74,7 @@ class UploadEnvelopeDocumentsServiceTest {
     @Test
     void should_do_nothing_when_blob_manager_fails_to_retrieve_container_representation() throws Exception {
         // given
-        willThrow(new RuntimeException("i failed")).given(blobManager).getContainerClient(CONTAINER_1);
+        willThrow(new RuntimeException("i failed")).given(blobManager).listContainerClient(CONTAINER_1);
 
         // when
         uploadService.processByContainer(CONTAINER_1, getEnvelopes());
@@ -90,7 +90,7 @@ class UploadEnvelopeDocumentsServiceTest {
     @Test
     void should_do_nothing_when_failing_to_get_block_blob_reference() throws Exception {
         // given
-        given(blobManager.getContainerClient(CONTAINER_1)).willReturn(blobContainer);
+        given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
 
         // and
         willThrow(new RuntimeException("Error getting BlobClient"))
@@ -106,7 +106,7 @@ class UploadEnvelopeDocumentsServiceTest {
     @Test
     void should_do_nothing_when_failing_to_acquire_lease() throws Exception {
         // given
-        given(blobManager.getContainerClient(CONTAINER_1)).willReturn(blobContainer);
+        given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
         given(blobContainer.getBlobContainerName()).willReturn(CONTAINER_1);
         given(blobContainer.getBlobClient(ZIP_FILE_NAME)).willReturn(blobClient);
 
@@ -124,7 +124,7 @@ class UploadEnvelopeDocumentsServiceTest {
     @Test
     void should_do_nothing_when_failing_to_download_blob() throws Exception {
         // given
-        given(blobManager.getContainerClient(CONTAINER_1)).willReturn(blobContainer);
+        given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
         given(blobContainer.getBlobContainerName()).willReturn(CONTAINER_1);
         given(blobContainer.getBlobClient(ZIP_FILE_NAME)).willReturn(blobClient);
 
@@ -143,7 +143,7 @@ class UploadEnvelopeDocumentsServiceTest {
     @Test
     void should_do_nothing_when_failing_to_read_blob_input_stream() throws Exception {
         // given
-        given(blobManager.getContainerClient(CONTAINER_1)).willReturn(blobContainer);
+        given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
         given(blobContainer.getBlobContainerName()).willReturn(CONTAINER_1);
         given(blobContainer.getBlobClient(ZIP_FILE_NAME)).willReturn(blobClient);
         leaseAcquired();
@@ -173,7 +173,7 @@ class UploadEnvelopeDocumentsServiceTest {
     @Test
     void should_mark_as_doc_upload_failure_when_unable_to_upload_pdfs() throws Exception {
         // given
-        given(blobManager.getContainerClient(CONTAINER_1)).willReturn(blobContainer);
+        given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
         given(blobContainer.getBlobContainerName()).willReturn(CONTAINER_1);
         given(blobContainer.getBlobClient(ZIP_FILE_NAME)).willReturn(blobClient);
         leaseAcquired();
@@ -209,7 +209,7 @@ class UploadEnvelopeDocumentsServiceTest {
     @Test
     void should_mark_as_uploaded_when_everything_went_well() throws Exception {
         // given
-        given(blobManager.getContainerClient(CONTAINER_1)).willReturn(blobContainer);
+        given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
         given(blobContainer.getBlobContainerName()).willReturn(CONTAINER_1);
         given(blobContainer.getBlobClient(ZIP_FILE_NAME)).willReturn(blobClient);
         leaseAcquired();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
@@ -32,7 +32,7 @@ public class RejectedFilesReportServiceTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        given(blobManager.getRejectedContainers())
+        given(blobManager.listRejectedContainers())
             .willReturn(asList(containerA, containerB));
 
         service = new RejectedFilesReportService(blobManager);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -65,7 +65,7 @@ class BlobProcessorTaskTest {
     @Test
     void processBlobs_should_not_call_envelopeProcessor_if_failed_to_load_file() throws Exception {
         // given
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container));
 
         PagedIterable<BlobItem> pagedIterable = mock(PagedIterable.class);
         given(container.listBlobs()).willReturn(pagedIterable);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -51,7 +51,7 @@ public class CleanUpRejectedFilesTaskTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        given(blobManager.getRejectedContainers()).willReturn(singletonList(containerClient));
+        given(blobManager.listRejectedContainers()).willReturn(singletonList(containerClient));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTaskTest.java
@@ -79,7 +79,7 @@ class DeleteCompleteFilesTaskTest {
 
         final Envelope envelope11 = EnvelopeCreator.envelope("X", COMPLETED, CONTAINER_NAME_1);
 
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container1));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container1));
         given(envelopeRepository.findByContainerAndStatusAndZipDeleted(CONTAINER_NAME_1, COMPLETED, false))
             .willReturn(singletonList(envelope11));
         prepareGivensForEnvelope(container1, blobClient, envelope11);
@@ -101,7 +101,7 @@ class DeleteCompleteFilesTaskTest {
     @Test
     void should_handle_zero_complete_files() {
         // given
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container1));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container1));
         given(envelopeRepository.findByContainerAndStatusAndZipDeleted(CONTAINER_NAME_1, COMPLETED, false))
             .willReturn(emptyList());
 
@@ -119,7 +119,7 @@ class DeleteCompleteFilesTaskTest {
         final BlobClient blobClient = mock(BlobClient.class);
 
         final Envelope envelope11 = prepareEnvelope("X", blobClient, container1);
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container1));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container1));
         given(blobClient.exists()).willReturn(false);
         assertThat(envelope11.isZipDeleted()).isFalse();
 
@@ -150,7 +150,7 @@ class DeleteCompleteFilesTaskTest {
 
         given(container1.getBlobClient(zipFileName)).willReturn(blobClient);
 
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container1));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container1));
         given(blobClient.exists()).willReturn(true);
 
         doThrow(mock(BlobStorageException.class))
@@ -186,7 +186,7 @@ class DeleteCompleteFilesTaskTest {
         Envelope envelope = mock(Envelope.class);
         given(envelope.getZipFileName()).willReturn(zipFileName);
 
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container1));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container1));
         given(envelopeRepository.findByContainerAndStatusAndZipDeleted(CONTAINER_NAME_1, COMPLETED, false))
             .willReturn(singletonList(envelope));
         given(container1.getBlobClient(zipFileName))
@@ -210,7 +210,7 @@ class DeleteCompleteFilesTaskTest {
         final BlobContainerClient container2 = mock(BlobContainerClient.class);
         given(container2.getBlobContainerName()).willReturn(CONTAINER_NAME_2);
 
-        given(blobManager.getInputContainerClients()).willReturn(asList(container1, container2));
+        given(blobManager.listInputContainerClients()).willReturn(asList(container1, container2));
         given(envelopeRepository.findByContainerAndStatusAndZipDeleted(CONTAINER_NAME_1, COMPLETED, false))
             .willThrow(new RuntimeException("msg"));
 
@@ -247,7 +247,7 @@ class DeleteCompleteFilesTaskTest {
         final Envelope envelope21 = EnvelopeCreator.envelope("Y", COMPLETED, CONTAINER_NAME_2);
         final Envelope envelope22 = EnvelopeCreator.envelope("Y", COMPLETED, CONTAINER_NAME_2);
 
-        given(blobManager.getInputContainerClients()).willReturn(asList(container1, container2));
+        given(blobManager.listInputContainerClients()).willReturn(asList(container1, container2));
         given(container2.getBlobContainerName()).willReturn(CONTAINER_NAME_2);
         given(envelopeRepository.findByContainerAndStatusAndZipDeleted(CONTAINER_NAME_1, COMPLETED, false))
             .willReturn(asList(envelope11, envelope12));
@@ -293,7 +293,7 @@ class DeleteCompleteFilesTaskTest {
 
         given(container1.getBlobClient(zipFileName)).willReturn(blobClient);
 
-        given(blobManager.getInputContainerClients()).willReturn(singletonList(container1));
+        given(blobManager.listInputContainerClients()).willReturn(singletonList(container1));
         given(blobClient.exists()).willReturn(true);
 
         doThrow(mock(BlobStorageException.class))


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###

Change method names back to old ones.
There were 2 same methods with old and new version. 
New version ones using some different names, now changing them to old ones as old methods are removed now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
