### PR TITLE
Fix metadata not acquiring lease issue

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -200,6 +200,12 @@ public class EnvelopeControllerTest {
             );
 
         blobProcessorTask.processBlobs();
+
+
+        List<Envelope> envelopes = envelopeRepository.findEnvelopesToUpload(10);
+        assertThat(envelopes).hasSize(1);
+        envelopes = envelopeRepository.findAll();
+        assertThat(envelopes).hasSize(1);
         uploadTask.run();
 
         given(tokenValidator.getServiceName("testServiceAuthHeader")).willReturn("test_service");
@@ -213,7 +219,7 @@ public class EnvelopeControllerTest {
             // Envelope id is checked explicitly as it is dynamically generated.
             .andExpect(MockMvcResultMatchers.jsonPath("envelopes[0].id").exists());
 
-        List<Envelope> envelopes = envelopeRepository.findAll();
+        envelopes = envelopeRepository.findAll();
         assertThat(envelopes).hasSize(1);
         assertThat(envelopes.get(0).getStatus()).isEqualTo(UPLOADED);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirer.java
@@ -59,6 +59,8 @@ public class LeaseAcquirer {
             } finally {
                 if (!isReady) {
                     release(leaseClient, blobClient);
+                    //it means lease did not acquired let the failure function decide
+                    onFailure.accept(LEASE_ALREADY_PRESENT);
                 }
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/DeleteCompleteFilesTask.java
@@ -106,6 +106,7 @@ public class DeleteCompleteFilesTask {
                 leaseAcquirer.ifAcquiredOrElse(
                     blobClient,
                     leaseId -> deleteBlob(blobClient, leaseId),
+                    //should throw this if deletion or lease acquiring fails envelope should not be marked as deleted
                     DeleteCompleteFilesTask::throwBlobDeleteException,
                     false
                 );


### PR DESCRIPTION


### Change description ###

Fix metadata not acquiring lease issue.
for deletion we depend on exception to not to mark envelope. if we can not get the lease anyway we need to call onFailure.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
