### PR TITLE
EnvelopeOcrValidator

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeOcrValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeOcrValidator.java
@@ -1,0 +1,179 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.validation;
+
+import io.vavr.control.Try;
+import joptsimple.internal.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.util.Optionals;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrValidationException;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.OcrValidationClient;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.req.FormData;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.req.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.res.ValidationResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.model.OcrValidationWarnings;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.EXCEPTION;
+
+@Component
+@EnableConfigurationProperties(ContainerMappings.class)
+public class EnvelopeOcrValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(EnvelopeOcrValidator.class);
+
+    private final OcrValidationClient client;
+    private final ContainerMappings containerMappings;
+    private final AuthTokenGenerator authTokenGenerator;
+
+    //region constructor
+    public EnvelopeOcrValidator(
+        OcrValidationClient client,
+        ContainerMappings containerMappings,
+        AuthTokenGenerator authTokenGenerator
+    ) {
+        this.client = client;
+        this.containerMappings = containerMappings;
+        this.authTokenGenerator = authTokenGenerator;
+    }
+    //endregion
+
+    /**
+     * If required, validates the OCR data of the given envelope.
+     *
+     * @return Warnings for valid OCR data, to be displayed to the caseworker. Empty if
+     *         no validation took place.
+     * @throws OcrValidationException if the OCR data is invalid
+     */
+    public Optional<OcrValidationWarnings> assertOcrDataIsValid(Envelope envelope) {
+        if (envelope.getClassification() == EXCEPTION) {
+            return Optional.empty();
+        }
+
+        return Optionals.mapIfAllPresent(
+            findDocWithOcr(envelope.getScannableItems()),
+            findValidationUrl(envelope.getPoBox()),
+            (docWithOcr, validationUrl) ->
+                Try
+                    .of(() -> client.validate(
+                        validationUrl,
+                        toFormData(docWithOcr),
+                        getFormType(docWithOcr),
+                        authTokenGenerator.generate()
+                    ))
+                    .onSuccess(res -> handleValidationResponse(res, envelope, docWithOcr))
+                    .onFailure(exc -> handleRestClientException(exc, validationUrl, envelope, docWithOcr))
+                    .map(response -> ocrValidationWarnings(docWithOcr, response.warnings))
+                    .getOrElseGet(exc ->
+                        ocrValidationWarnings(
+                            docWithOcr,
+                            singletonList("OCR validation was not performed due to errors")
+                        )
+                    )
+        );
+    }
+
+    private OcrValidationWarnings ocrValidationWarnings(ScannableItem scannableItem, List<String> warnings) {
+        return new OcrValidationWarnings(
+            scannableItem.getDocumentControlNumber(),
+            warnings != null ? warnings : emptyList()
+        );
+    }
+
+    private void handleValidationResponse(
+        ValidationResponse res,
+        Envelope envelope,
+        ScannableItem docWithOcr
+    ) {
+        log.info("Validation result for envelope {}: {}", envelope.getZipFileName(), res.status);
+        switch (res.status) {
+            case ERRORS:
+                String message = "OCR validation service returned OCR-specific errors. "
+                    + "Document control number: " + docWithOcr.getDocumentControlNumber() + ". "
+                    + "Envelope: " + envelope.getZipFileName() + ".";
+                throw new OcrValidationException(
+                    message,
+                    "OCR fields validation failed. Validation errors: " + res.errors
+                );
+            case WARNINGS:
+                log.info(
+                    "Validation ended with warnings. File name: {}",
+                    envelope.getZipFileName()
+                );
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleRestClientException(
+        Throwable exc,
+        String validationUrl,
+        Envelope envelope,
+        ScannableItem docWithOcr
+    ) {
+        log.error(
+            "Error calling validation endpoint. Url: {}, DCN: {}, doc type: {}, doc subtype: {}, envelope: {}",
+            validationUrl,
+            docWithOcr.getDocumentControlNumber(),
+            docWithOcr.getDocumentType(),
+            docWithOcr.getDocumentSubtype(),
+            envelope.getZipFileName(),
+            exc
+        );
+
+        if (exc instanceof NotFound) {
+            throw new OcrValidationException("Unrecognised document subtype " + docWithOcr.getDocumentSubtype());
+        }
+    }
+
+    private Optional<String> findValidationUrl(String poBox) {
+        Optional<String> validationUrl = containerMappings
+            .getMappings()
+            .stream()
+            .filter(mapping -> Objects.equals(mapping.getPoBox(), poBox))
+            .findFirst()
+            .map(ContainerMappings.Mapping::getOcrValidationUrl)
+            .filter(url -> !Strings.isNullOrEmpty(url));
+
+        if (validationUrl.isEmpty()) {
+            log.info("OCR validation URL for po box {} not configured. Skipping validation.", poBox);
+        }
+
+        return validationUrl;
+    }
+
+    private Optional<ScannableItem> findDocWithOcr(List<ScannableItem> docs) {
+        return docs
+            .stream()
+            .filter(it -> it.getOcrData() != null)
+            .findFirst();
+    }
+
+    private FormData toFormData(ScannableItem doc) {
+        return new FormData(
+            doc
+                .getOcrData()
+                .fields
+                .stream()
+                .map(it -> new OcrDataField(it.name.asText(), it.value.textValue()))
+                .collect(toList())
+        );
+    }
+
+    private String getFormType(ScannableItem item) {
+        return item.getDocumentSubtype();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.UUID.randomUUID;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CREATED;
 
 public final class EnvelopeCreator {
 
@@ -113,6 +114,35 @@ public final class EnvelopeCreator {
             status, scannableItems,
             "SSCS"
         );
+    }
+
+    public static Envelope envelope(
+        String jurisdiction,
+        String poBox,
+        Classification classification,
+        List<ScannableItem> scannableItems
+    ) {
+        Instant timestamp = getInstant();
+
+        Envelope envelope = new Envelope(
+            poBox,
+            jurisdiction,
+            timestamp,
+            timestamp,
+            timestamp,
+            "file1.zip",
+            "1111222233334446",
+            "123654789",
+            classification,
+            scannableItems,
+            payments(),
+            nonScannableItems(),
+            "cont"
+        );
+
+        envelope.setStatus(CREATED);
+
+        return envelope;
     }
 
     public static Envelope envelope(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeOcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/EnvelopeOcrValidatorTest.java
@@ -1,0 +1,437 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.validation;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
+import io.github.netmikey.logunit.api.LogCapturer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings.Mapping;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrValidationException;
+import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrData;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.OcrValidationClient;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.req.FormData;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.res.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.res.ValidationResponse;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.model.OcrValidationWarnings;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.EXCEPTION;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.SUPPLEMENTARY_EVIDENCE;
+
+@ExtendWith(MockitoExtension.class)
+class EnvelopeOcrValidatorTest {
+
+    private static final String VALIDATION_URL = "https://example.com/validate-ocr";
+    private static final String S2S_TOKEN = "sample-s2s-token";
+    private static final String PO_BOX = "sample PO box";
+
+    @RegisterExtension
+    LogCapturer capturer = LogCapturer.create().captureForType(EnvelopeOcrValidator.class);
+
+    @Mock private OcrValidationClient client;
+    @Mock private ContainerMappings containerMappings;
+    @Mock private AuthTokenGenerator authTokenGenerator;
+
+    @Captor
+    private ArgumentCaptor<FormData> argCaptor;
+
+    private EnvelopeOcrValidator ocrValidator;
+
+    @BeforeEach
+    void setUp() {
+        this.ocrValidator = new EnvelopeOcrValidator(client, containerMappings, authTokenGenerator);
+    }
+
+    @Test
+    void should_call_rest_client_with_correct_parameters() {
+        // given
+        String url = VALIDATION_URL;
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, url, true, true)
+            ));
+
+        given(client.validate(eq(url), any(), any(), any()))
+            .willReturn(new ValidationResponse(Status.SUCCESS, emptyList(), emptyList()));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        // and
+        ScannableItem docWithOcr = doc(DocumentType.FORM, "sample_document_subtype", sampleOcr());
+        List<ScannableItem> docs =
+            asList(
+                docWithOcr,
+                doc(DocumentType.OTHER, "other", null)
+            );
+        Envelope envelope = envelope(
+            PO_BOX,
+            docs,
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        // when
+        ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        verify(client).validate(eq(url), argCaptor.capture(), eq(docWithOcr.getDocumentSubtype()), eq(S2S_TOKEN));
+        assertThat(argCaptor.getValue().ocrDataFields)
+            .extracting(it -> tuple(it.name, it.value))
+            .containsExactlyElementsOf(
+                sampleOcr()
+                    .fields
+                    .stream()
+                    .map(it -> tuple(it.name.textValue(), it.value.textValue()))
+                    .collect(toList())
+            );
+    }
+
+    @Test
+    void should_handle_sscs1_forms_without_subtype() {
+        // given
+        String url = VALIDATION_URL;
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, url, true, true)
+            ));
+
+        given(client.validate(eq(url), any(), any(), any()))
+            .willReturn(new ValidationResponse(Status.SUCCESS, emptyList(), emptyList()));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        // and
+        ScannableItem docWithOcr = doc(DocumentType.FORM, DocumentSubtype.SSCS1, sampleOcr());
+        List<ScannableItem> docs =
+            asList(
+                docWithOcr,
+                doc(DocumentType.OTHER, "other", null)
+            );
+        Envelope envelope = envelope(
+            PO_BOX,
+            docs,
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        // when
+        ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        // an appropriate subtype is being used (instead of null)
+        verify(client).validate(eq(url), any(), eq("sscs1"), eq(S2S_TOKEN));
+    }
+
+    @Test
+    void should_not_call_rest_client_for_exception_journey_classification() {
+        // given
+        ScannableItem docWithOcr = doc(DocumentType.FORM, "sample_document_subtype", sampleOcr());
+        List<ScannableItem> docs =
+            asList(
+                docWithOcr,
+                doc(DocumentType.OTHER, "other", null)
+            );
+        Envelope envelope = envelope(
+            PO_BOX,
+            docs,
+            EXCEPTION
+        );
+
+        // when
+        Optional<OcrValidationWarnings> res = ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        verifyNoInteractions(client);
+        assertThat(res.isPresent()).isFalse();
+    }
+
+    @Test
+    void should_return_warnings_from_successful_validation_result() {
+        // given
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, VALIDATION_URL, true, true)
+            ));
+
+        List<String> expectedWarnings = ImmutableList.of("warning 1", "warning 2");
+
+        given(client.validate(any(), any(), any(), any()))
+            .willReturn(new ValidationResponse(Status.SUCCESS, expectedWarnings, emptyList()));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        ScannableItem scannableItem = doc(DocumentType.FORM, "subtype1", sampleOcr());
+        Envelope envelope = envelope(
+            PO_BOX,
+            singletonList(scannableItem),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        // when
+        Optional<OcrValidationWarnings> warnings = ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        assertThat(warnings).isPresent();
+        assertThat(warnings.get().documentControlNumber).isEqualTo(scannableItem.getDocumentControlNumber());
+        assertThat(warnings.get().warnings).isEqualTo(expectedWarnings);
+    }
+
+    @Test
+    void should_handle_null_warnings_from_successful_validation_result() {
+        // given
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, VALIDATION_URL, true, true)
+            ));
+
+        given(client.validate(any(), any(), any(), any()))
+            .willReturn(new ValidationResponse(Status.SUCCESS, null, emptyList()));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        Envelope envelope = envelope(
+            PO_BOX,
+            singletonList(doc(DocumentType.FORM, "z", sampleOcr())),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        // when
+        Optional<OcrValidationWarnings> warnings = ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        assertThat(warnings).isPresent();
+        assertThat(warnings.get().warnings).isEmpty();
+    }
+
+    @Test
+    void should_not_call_validation_if_url_is_not_configured() {
+        // given
+        Envelope envelope = envelope(
+            "samplePoBox",
+            asList(
+                doc(DocumentType.FORM, "D8", sampleOcr()),
+                doc(DocumentType.OTHER, "other", null)
+            ),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        given(containerMappings.getMappings()).willReturn(emptyList()); // url not configured
+
+        // when
+        ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        verify(client, never()).validate(any(), any(), any(), any());
+    }
+
+    @Test
+    void should_not_call_validation_there_are_no_documents_with_ocr() {
+        // given
+        Envelope envelope = envelope(
+            PO_BOX,
+            asList(
+                doc(DocumentType.OTHER, "other", null),
+                doc(DocumentType.OTHER, "other", null)
+            ),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("c", "j", envelope.getPoBox(), "https://example.com", true, true)
+            ));
+
+        // when
+        ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        verify(client, never()).validate(any(), any(), any(), any());
+    }
+
+    @Test
+    void should_throw_an_exception_if_service_responded_with_error_response() {
+        // given
+        Envelope envelope = envelope(
+            PO_BOX,
+            asList(
+                doc(DocumentType.FORM, "y", sampleOcr()),
+                doc(DocumentType.OTHER, "other", null)
+            ),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, VALIDATION_URL, true, true)
+            ));
+
+        given(client.validate(any(), any(), any(), any()))
+            .willReturn(new ValidationResponse(Status.ERRORS, emptyList(), singletonList("Error!")));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        // when
+        Throwable err = catchThrowable(() -> ocrValidator.assertOcrDataIsValid(envelope));
+
+        // then
+        assertThat(err)
+            .isInstanceOf(OcrValidationException.class)
+            .hasMessageContaining("OCR validation service returned OCR-specific errors");
+    }
+
+    @Test
+    void should_throw_an_exception_if_service_responded_with_404() {
+        // given
+        Envelope envelope = envelope(
+            PO_BOX,
+            asList(
+                doc(DocumentType.FORM, "x", sampleOcr()),
+                doc(DocumentType.OTHER, "other", null)
+            ),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("container", "jurisdiction", PO_BOX, VALIDATION_URL, true, true)
+            ));
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        given(client.validate(any(), any(), any(), any()))
+            .willThrow(NotFound.class);
+
+        // when
+        Throwable err = catchThrowable(() -> ocrValidator.assertOcrDataIsValid(envelope));
+
+        // then
+        assertThat(err)
+            .isInstanceOf(OcrValidationException.class);
+    }
+
+    @Test
+    void should_continue_if_calling_validation_endpoint_fails() {
+        // given
+        ScannableItem scannableItemWithOcr = doc(DocumentType.FORM, "form", sampleOcr());
+        Envelope envelope = envelope(
+            PO_BOX,
+            asList(
+                scannableItemWithOcr,
+                doc(DocumentType.OTHER, "other", null)
+            ),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        given(containerMappings.getMappings())
+            .willReturn(singletonList(
+                new Mapping("c", "j", envelope.getPoBox(), VALIDATION_URL, true, true)
+            ));
+
+        given(client.validate(any(), any(), any(), any()))
+            .willThrow(new RuntimeException());
+
+        given(authTokenGenerator.generate()).willReturn(S2S_TOKEN);
+
+        // when
+        Optional<OcrValidationWarnings> warnings = ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        assertThat(warnings).isPresent();
+        assertThat(warnings.get().documentControlNumber).isEqualTo(scannableItemWithOcr.getDocumentControlNumber());
+        assertThat(warnings.get().warnings).containsExactly("OCR validation was not performed due to errors");
+        verify(client).validate(any(), any(), any(), any());
+    }
+
+    @Test
+    void should_log_info_when_ocr_is_present_but_there_is_no_service_configured_to_validate_it() {
+        // given
+        Envelope envelope = envelope(
+            PO_BOX,
+            asList(
+                doc(DocumentType.FORM, "form", sampleOcr()),
+                doc(DocumentType.OTHER, "other", null)
+            ),
+            SUPPLEMENTARY_EVIDENCE
+        );
+
+        given(containerMappings.getMappings()).willReturn(emptyList());
+
+        // when
+        ocrValidator.assertOcrDataIsValid(envelope);
+
+        // then
+        capturer.assertContains("OCR validation URL for po box " + envelope.getPoBox() + " not configured");
+    }
+
+    private OcrData sampleOcr() {
+        return new OcrData(
+            asList(
+                new OcrDataField(new TextNode("hello"), new TextNode("world")),
+                new OcrDataField(new TextNode("foo"), new TextNode("bar"))
+            )
+        );
+    }
+
+    private Envelope envelope(
+        String poBox,
+        List<ScannableItem> scannableItems,
+        Classification classification
+    ) {
+        return EnvelopeCreator.envelope(
+            "BULKSCAN",
+            poBox,
+            classification,
+            scannableItems
+        );
+    }
+
+    private ScannableItem doc(DocumentType docType, String subtype, OcrData ocrData) {
+        return new ScannableItem(
+            UUID.randomUUID().toString(),
+            Instant.now(),
+            null,
+            null,
+            null,
+            null,
+            ocrData,
+            null,
+            null,
+            docType,
+            subtype,
+            new String[0]
+        );
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1386


### Change description ###
`EnvelopeOcrValidator` will be executed in the new OcrValidationTask for the envelopes created created in the database by the main job. At the moment of creation of the envelope OcrPresenceValidator has already checked that the OCRs are properly set in the file that is why `EnvelopeOcrValidator::findDocWithOcr` method contains only short extract from `OcrPresenceValidator::assertHasProperlySetOcr` method.

`EnvelopeOcrValidatorTest` class contains all test methods from `OcrValidatorTest` class apart from `should_validate_the_presence_of_ocr_data` which checks exception thrown from `OcrPresenceValidator`.

Existing `OcrValidator` class will keep only the call to `OcrPresenceValidator::findDocWithOcr` method, everything else will go as soon as the new job becomes active.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
