### PR TITLE
Remove ServiceBus connection strings from chart config

### DIFF
--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-processor
 apiVersion: v1
 home: https://github.com/hmcts/bulk-scan-processor
-version: 0.3.5
+version: 0.3.6
 description: HMCTS Bulk scan processor service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-processor/values.aat.template.yaml
+++ b/charts/bulk-scan-processor/values.aat.template.yaml
@@ -5,9 +5,6 @@ java:
         - processor-staging-db-password
         - s2s-secret
         - flyway-password
-        - envelopes-staging-queue-send-connection-string
-        - notifications-queue-send-connection-string
-        - processed-envelopes-staging-queue-listen-connection-string
         - envelopes-staging-queue-send-shared-access-key
         - notifications-queue-send-shared-access-key
         - processed-envelopes-staging-queue-listen-shared-access-key

--- a/charts/bulk-scan-processor/values.preview.template.yaml
+++ b/charts/bulk-scan-processor/values.preview.template.yaml
@@ -1,8 +1,5 @@
 java:
   secrets:
-    SB_CONN_STRING:
-      secretRef: servicebus-secret-namespace-{{ .Release.Name }}
-      key: connectionString
     SB_ACCESS_KEY:
       secretRef: servicebus-secret-namespace-{{ .Release.Name }}
       key: primaryKey
@@ -29,15 +26,11 @@ java:
     STORAGE_URL: "https://$(STORAGE_ACCOUNT_NAME).blob.core.windows.net"
     QUEUE_ACCESS_KEY_LISTEN_NAME: "RootManageSharedAccessKey"
     QUEUE_ACCESS_KEY_SEND_NAME: "RootManageSharedAccessKey"
-    QUEUE_ENVELOPE_SEND: "$(SB_CONN_STRING);EntityPath=envelopes"
     QUEUE_ENVELOPE_SEND_ACCESS_KEY: "$(SB_ACCESS_KEY)"
     QUEUE_NAMESPACE: "$(SB_NAMESPACE)"
     QUEUE_NOTIFICATIONS_NAMESPACE: "$(SB_NAMESPACE)"
-    QUEUE_NOTIFICATIONS_SEND: "$(SB_CONN_STRING);EntityPath=notifications"
     QUEUE_NOTIFICATIONS_SEND_ACCESS_KEY: "$(SB_ACCESS_KEY)"
-    QUEUE_PROCESSED_ENVELOPES_READ: "$(SB_CONN_STRING);EntityPath=processed-envelopes"
     QUEUE_PROCESSED_ENVELOPES_READ_ACCESS_KEY: "$(SB_ACCESS_KEY)"
-    PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING: "${SB_CONN_STRING};EntityPath=processed-envelopes"
     BULK_SCANNING_DB_USER_NAME: "{{ .Values.postgresql.postgresqlUsername}}"
     BULK_SCANNING_DB_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     BULK_SCANNING_DB_NAME: "{{ .Values.postgresql.postgresqlDatabase}}"

--- a/charts/bulk-scan-processor/values.yaml
+++ b/charts/bulk-scan-processor/values.yaml
@@ -51,9 +51,6 @@ java:
         - processor-POSTGRES-PASS
         - s2s-secret
         - flyway-password
-        - envelopes-queue-send-connection-string
-        - notifications-queue-send-connection-string
-        - processed-envelopes-queue-listen-connection-string
         - envelopes-queue-send-shared-access-key
         - notifications-queue-send-shared-access-key
         - processed-envelopes-queue-listen-shared-access-key

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,22 +85,23 @@ storage:
   blob_selected_container: ${STORAGE_BLOB_SELECTED_CONTAINER}
   blob_lease_acquire_delay_in_seconds: ${LEASE_ACQUIRE_DELAY_IN_SECONDS}
 
+# will remove conn strings when chart is released
 queues:
   default-namespace: ${QUEUE_NAMESPACE}
   envelopes:
     access-key: ${QUEUE_ENVELOPE_SEND_ACCESS_KEY}
     access-key-name: ${QUEUE_ACCESS_KEY_SEND_NAME}
-    connection-string: ${QUEUE_ENVELOPE_SEND}
+    connection-string: ${QUEUE_ENVELOPE_SEND:}
     queue-name: ${QUEUE_ENVELOPE_NAME}
   processed-envelopes:
     access-key: ${QUEUE_PROCESSED_ENVELOPES_READ_ACCESS_KEY}
     access-key-name: ${QUEUE_ACCESS_KEY_LISTEN_NAME}
-    connection-string: ${QUEUE_PROCESSED_ENVELOPES_READ}
+    connection-string: ${QUEUE_PROCESSED_ENVELOPES_READ:}
     queue-name: ${QUEUE_PROCESSED_ENVELOPES_NAME}
   notifications:
     access-key: ${QUEUE_NOTIFICATIONS_SEND_ACCESS_KEY}
     access-key-name: ${QUEUE_ACCESS_KEY_SEND_NAME}
-    connection-string: ${QUEUE_NOTIFICATIONS_SEND}
+    connection-string: ${QUEUE_NOTIFICATIONS_SEND:}
     queue-name: ${QUEUE_NOTIFICATIONS_NAME}
     namespace-override: ${QUEUE_NOTIFICATIONS_NAMESPACE}
 

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -8,15 +8,10 @@ spring:
         processor-staging-db-password: BULK_SCANNING_DB_PASSWORD
         s2s-secret: S2S_SECRET
         flyway-password: flyway.password
-        envelopes-queue-send-connection-string: QUEUE_ENVELOPE_SEND
         envelopes-queue-send-shared-access-key: QUEUE_ENVELOPE_SEND_ACCESS_KEY
-        envelopes-staging-queue-send-connection-string: QUEUE_ENVELOPE_SEND
         envelopes-staging-queue-send-shared-access-key: QUEUE_ENVELOPE_SEND_ACCESS_KEY
-        notifications-queue-send-connection-string: QUEUE_NOTIFICATIONS_SEND
         notifications-queue-send-shared-access-key: QUEUE_NOTIFICATIONS_SEND_ACCESS_KEY
-        processed-envelopes-queue-listen-connection-string: QUEUE_PROCESSED_ENVELOPES_READ
         processed-envelopes-queue-listen-shared-access-key: QUEUE_PROCESSED_ENVELOPES_READ_ACCESS_KEY
-        processed-envelopes-staging-queue-listen-connection-string: QUEUE_PROCESSED_ENVELOPES_READ
         processed-envelopes-staging-queue-listen-shared-access-key: QUEUE_PROCESSED_ENVELOPES_READ_ACCESS_KEY
         storage-account-name: storage.account_name
         storage-account-staging-name: storage.account_name


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Improve the way Service Bus clients are created](https://tools.hmcts.net/jira/browse/BPS-771)

### Change description ###

After #1509 connection strings are no longer used. Processor is now in "removal" stage and this is 1st PR

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
