### PR TITLE
Revert "Clean-up main.tf"

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,1 +1,16 @@
 vault_section = "preprod"
+capacity = "2"
+scan_delay = "4000"
+scan_enabled = "true"
+
+orchestrator_notifications_task_enabled = "true"
+orchestrator_notifications_task_delay = "3000"
+
+delete_rejected_files_enabled = "true"
+delete_rejected_files_cron = "0 0/10 * * * *"
+
+allowed_client_certificate_thumbprints = ["2A1EE53E044632145C89FE428128080353127DF6"]
+
+incomplete_envelopes_cron = "0 0 * * * *"
+
+ocr_validation_url_bulkscan_sample_app = "http://bulk-scan-sample-app-aat.service.core-compute-aat.internal"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,1 +1,11 @@
+token_validity = "5184000" #60 days in seconds
 vault_section = "preprod"
+scan_enabled = "true"
+
+orchestrator_notifications_task_enabled = "true"
+orchestrator_notifications_task_delay = "3000"
+
+allowed_client_certificate_thumbprints = ["2A1EE53E044632145C89FE428128080353127DF6"]
+
+ocr_validation_url_bulkscan_sample_app = "http://bulk-scan-sample-app-demo.service.core-compute-demo.internal"
+ocr_validation_url_probate = "http://probate-back-office-demo.service.core-compute-demo.internal"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -2,6 +2,23 @@ provider "azurerm" {
   features {}
 }
 
+locals {
+  local_env = (var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env
+
+  s2s_rg       = "rpe-service-auth-provider-${local.local_env}"
+  s2s_url      = "http://${local.s2s_rg}.service.core-compute-${local.local_env}.internal"
+  dm_store_url = "http://dm-store-${local.local_env}.service.core-compute-${local.local_env}.internal"
+
+  db_connection_options = "?sslmode=require"
+
+  sku_size                    = var.env == "prod" || var.env == "sprod" || var.env == "aat" ? "I2" : "I1"
+  storage_account_name        = data.azurerm_key_vault_secret.storage_account_name.value
+  storage_account_primary_key = data.azurerm_key_vault_secret.storage_account_primary_key.value
+  storage_account_url_prod    = "https://bulkscan.platform.hmcts.net"
+  storage_account_url_notprod = "https://bulkscan.${var.env}.platform.hmcts.net"
+  storage_account_url         = var.env == "prod" ? local.storage_account_url_prod : local.storage_account_url_notprod
+}
+
 module "bulk-scan-db" {
   source             = "git@github.com:hmcts/cnp-module-postgres?ref=master"
   product            = "${var.product}-${var.component}"
@@ -29,6 +46,85 @@ module "bulk-scan-staging-db" {
   sku_tier           = "GeneralPurpose"
   common_tags        = var.common_tags
   subscription       = var.subscription
+}
+
+module "bulk-scan" {
+  source                          = "git@github.com:hmcts/cnp-module-webapp?ref=master"
+  product                         = "${var.product}-${var.component}"
+  location                        = var.location
+  env                             = var.env
+  ilbIp                           = var.ilbIp
+  subscription                    = var.subscription
+  is_frontend                     = "false"
+  capacity                        = var.capacity
+  common_tags                     = var.common_tags
+  appinsights_instrumentation_key = var.appinsights_instrumentation_key
+  instance_size                   = local.sku_size
+  asp_name                        = "${var.product}-${var.env}"
+  asp_rg                          = "${var.product}-${var.env}"
+  java_container_version          = "9.0"
+  enable_ase                      = var.enable_ase
+
+  app_settings = {
+    // db
+    BULK_SCANNING_DB_HOST         = module.bulk-scan-db.host_name
+    BULK_SCANNING_DB_PORT         = module.bulk-scan-db.postgresql_listen_port
+    BULK_SCANNING_DB_USER_NAME    = module.bulk-scan-db.user_name
+    BULK_SCANNING_DB_PASSWORD     = module.bulk-scan-db.postgresql_password
+    BULK_SCANNING_DB_NAME         = module.bulk-scan-db.postgresql_database
+    BULK_SCANNING_DB_CONN_OPTIONS = local.db_connection_options
+    FLYWAY_URL                    = "jdbc:postgresql://${module.bulk-scan-db.host_name}:${module.bulk-scan-db.postgresql_listen_port}/${module.bulk-scan-db.postgresql_database}${local.db_connection_options}"
+    FLYWAY_USER                   = module.bulk-scan-db.user_name
+    FLYWAY_PASSWORD               = module.bulk-scan-db.postgresql_password
+    FLYWAY_NOOP_STRATEGY          = "true"
+
+    STORAGE_ACCOUNT_NAME  = local.storage_account_name
+    STORAGE_KEY           = local.storage_account_primary_key
+    STORAGE_URL           = local.storage_account_url
+    STORAGE_PROXY_ENABLED = var.storage_proxy_enabled
+    SAS_TOKEN_VALIDITY    = var.token_validity
+
+    DOCUMENT_MANAGEMENT_URL = local.dm_store_url
+
+    S2S_URL    = local.s2s_url
+    S2S_NAME   = var.s2s_name
+    S2S_SECRET = data.azurerm_key_vault_secret.s2s_secret.value
+
+    SCAN_DELAY         = var.scan_delay
+    SCAN_ENABLED       = var.scan_enabled
+
+    NOTIFICATIONS_TO_ORCHESTRATOR_TASK_ENABLED = var.orchestrator_notifications_task_enabled
+    NOTIFICATIONS_TO_ORCHESTRATOR_TASK_DELAY   = var.orchestrator_notifications_task_delay
+
+    DELETE_REJECTED_FILES_ENABLED = var.delete_rejected_files_enabled
+    DELETE_REJECTED_FILES_CRON    = var.delete_rejected_files_cron
+    DELETE_REJECTED_FILES_TTL     = var.delete_rejected_files_ttl
+
+    STORAGE_BLOB_LEASE_TIMEOUT               = var.blob_lease_timeout               // In seconds
+
+    STORAGE_BLOB_SELECTED_CONTAINER = var.blob_selected_container
+
+    SMTP_HOST          = var.smtp_host
+    SMTP_USERNAME      = data.azurerm_key_vault_secret.smtp_username.value
+    SMTP_PASSWORD      = data.azurerm_key_vault_secret.smtp_password.value
+    REPORTS_CRON       = var.reports_cron
+    REPORTS_RECIPIENTS = data.azurerm_key_vault_secret.reports_recipients.value
+
+    INCOMPLETE_ENVELOPES_TASK_CRON    = var.incomplete_envelopes_cron
+    INCOMPLETE_ENVELOPES_TASK_ENABLED = var.incomplete_envelopes_enabled
+
+    PROCESS_PAYMENTS_ENABLED          = var.process_payments_enabled
+
+    OCR_VALIDATION_URL_BULKSCAN_SAMPLE_APP = var.ocr_validation_url_bulkscan_sample_app
+    OCR_VALIDATION_URL_PROBATE             = var.ocr_validation_url_probate
+
+    NO_NEW_ENVELOPES_TASK_ENABLED     = "false"
+    PUBLICLAW_ENABLED                 = "true"
+
+    // silence the "bad implementation" logs
+    LOGBACK_REQUIRE_ALERT_LEVEL = "false"
+    LOGBACK_REQUIRE_ERROR_CODE  = "false"
+  }
 }
 
 data "azurerm_key_vault" "key_vault" {
@@ -119,6 +215,11 @@ data "azurerm_key_vault_secret" "s2s_secret" {
   name         = "microservicekey-bulk-scan-processor"
 }
 
+data "azurerm_key_vault_secret" "storage_account_name" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "storage-account-name"
+}
+
 data "azurerm_key_vault_secret" "storage_account_primary_key" {
   key_vault_id = data.azurerm_key_vault.key_vault.id
   name         = "storage-account-primary-key"
@@ -127,6 +228,21 @@ data "azurerm_key_vault_secret" "storage_account_primary_key" {
 data "azurerm_key_vault_secret" "notifications_queue_send_access_key" {
   key_vault_id = data.azurerm_key_vault.reform_scan_key_vault.id
   name         = "notification-queue-send-shared-access-key"
+}
+
+data "azurerm_key_vault_secret" "reports_recipients" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "reports-recipients"
+}
+
+data "azurerm_key_vault_secret" "smtp_username" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "reports-email-username"
+}
+
+data "azurerm_key_vault_secret" "smtp_password" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "reports-email-password"
 }
 
 # Copy postgres password for flyway migration

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,0 +1,28 @@
+output "app_namespace" {
+  value = "${var.deployment_namespace}"
+}
+
+output "TEST_SCAN_DELAY" {
+  value = "${var.scan_delay}"
+}
+
+output "TEST_STORAGE_ACCOUNT_NAME" {
+  value = "${local.storage_account_name}"
+}
+
+output "TEST_S2S_URL" {
+  value = "${local.s2s_url}"
+}
+
+output "TEST_S2S_NAME" {
+  sensitive = true
+  value     = "${var.test_s2s_name}"
+}
+
+output "TEST_STORAGE_ACCOUNT_URL" {
+  value = "${local.storage_account_url}"
+}
+
+output "test_storage_container_name" {
+  value = "bulkscan"
+}

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,1 +1,7 @@
 vault_section = "preprod"
+
+scan_enabled = "true"
+scan_delay = "4000"
+
+orchestrator_notifications_task_delay = "3000"
+orchestrator_notifications_task_enabled = "true"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,1 +1,15 @@
 vault_section = "prod"
+capacity = "2"
+
+scan_delay = "300000"
+scan_enabled = "true"
+
+orchestrator_notifications_task_enabled = "true"
+
+delete_rejected_files_enabled = "true"
+
+smtp_host = "smtp.office365.com"
+
+incomplete_envelopes_enabled = "true"
+
+process_payments_enabled = "false"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -26,6 +26,10 @@ variable "jenkins_AAD_objectId" {
   description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
 }
 
+variable "capacity" {
+  default = "1"
+}
+
 variable "deployment_namespace" {
   default = ""
 }
@@ -34,10 +38,115 @@ variable "account_name" {
   default = ""
 }
 
+variable "token_validity" {
+  default = "86400" #1 day in seconds
+}
+
 variable "vault_section" {
   default = "test"
 }
 
+variable "s2s_name" {
+  default = "bulk_scan_processor"
+}
+
+variable "test_s2s_name" {
+  default = "bulk_scan_processor_tests"
+}
+
 variable "common_tags" {
   type = map(string)
+}
+
+variable "scan_delay" {
+  default = "30000" # In milliseconds
+}
+
+variable "scan_enabled" {
+  default = "false"
+}
+
+variable "storage_proxy_enabled" {
+  default = "false"
+}
+
+variable "orchestrator_notifications_task_enabled" {
+  default = "false"
+}
+
+variable "orchestrator_notifications_task_delay" {
+  default = "30000" # in ms
+}
+
+# region delete rejected files
+variable "delete_rejected_files_enabled" {
+  default = "false"
+}
+
+variable "delete_rejected_files_cron" {
+  default = "0 0 7 * * *"
+}
+
+variable "delete_rejected_files_ttl" {
+  default = "PT72H"
+}
+
+# endregion
+
+# region reports
+variable "smtp_host" {
+  type        = "string"
+  default     = "false"
+  description = "SMTP host for sending out reports via JavaMailSender"
+}
+
+variable "reports_cron" {
+  default     = "0 0 18 ? * MON-FRI"
+  description = "Cron signature for job to send out reports to be executed. Default value is 6PM (server time) every workday"
+}
+
+# endregion
+
+# region incomplete envelopes monitoring
+
+variable "incomplete_envelopes_cron" {
+  default     = "0 */15 * * * *"
+  description = "Cron signature for job to log amount of incomplete envelopes currently present in service"
+}
+
+variable "incomplete_envelopes_enabled" {
+  default     = "false"
+  description = "Task is trivial and no need to run. Will be enabled in production only though"
+}
+
+# endregion
+
+variable "ocr_validation_url_bulkscan_sample_app" {
+  default = ""
+}
+
+variable "ocr_validation_url_probate" {
+  default = ""
+}
+
+# The value of the parameter 'blob_lease_timeout' should be between 15 and 60 seconds.
+variable "blob_lease_timeout" {
+  default = "15"
+}
+
+variable "blob_selected_container" {
+  default = "ALL"
+}
+
+variable "appinsights_instrumentation_key" {
+  description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
+  default     = ""
+}
+
+variable "process_payments_enabled" {
+  default = "true"
+}
+
+variable "enable_ase" {
+  default = false
 }


### PR DESCRIPTION
### Change description ###

Bringing back some data/resource/module cleanups made. some `locals` still removing - it's local var establishment

```
10:13:09  Error: Provider configuration not present
10:13:09  
10:13:09  To work with data.azurerm_key_vault_secret.reports_recipients its original
10:13:09  provider configuration at provider["registry.terraform.io/-/azurerm"] is
10:13:09  required, but it has been removed. This occurs when a provider configuration
10:13:09  is removed while objects created by that provider still exist in the state.
10:13:09  Re-add the provider configuration to destroy
10:13:09  data.azurerm_key_vault_secret.reports_recipients, after which you can remove
10:13:09  the provider configuration again.
```

this means that we are not missing a provider but rather it was configured with one provider version and we are upgrading. pro tip - perhaps first do cleanup and then upgrade. terraform state is annoying :(

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
