### PR TITLE
Add rescan_for column to envelopes table

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeTest.java
@@ -44,6 +44,24 @@ public class EnvelopeTest {
     }
 
     @Test
+    public void should_insert_into_db_with_rescan_for_value_null() {
+        // given
+        Envelope envelope = EnvelopeCreator.envelope();
+        envelope.setRescanFor(null);
+
+        // and
+        UUID envelopeId = repository.saveAndFlush(envelope).getId();
+
+        // when
+        Envelope readEnvelope = repository.getOne(envelopeId);
+
+        // then
+        assertThat(readEnvelope)
+            .usingRecursiveComparison()
+            .isEqualTo(envelope);
+    }
+
+    @Test
     public void should_log_a_warning_when_container_is_not_set() {
         // given
         Envelope envelope = EnvelopeCreator.envelope();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ReceivedZipFileRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ReceivedZipFileRepositoryTest.java
@@ -318,7 +318,8 @@ public class ReceivedZipFileRepositoryTest {
             emptyList(),
             emptyList(),
             emptyList(),
-            container
+            container,
+            null
         );
 
         envelope.setStatus(status);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ZipFilesSummaryRepositoryTest.java
@@ -197,7 +197,8 @@ public class ZipFilesSummaryRepositoryTest {
             emptyList(),
             emptyList(),
             emptyList(),
-            container
+            container,
+            null
         );
 
         envelope.setStatus(status);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Envelope.java
@@ -68,6 +68,8 @@ public class Envelope {
 
     private String envelopeCcdAction;
 
+    private String rescanFor;
+
     //We will need to retrieve all scannable item entities of Envelope every time hence fetch type is Eager
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, mappedBy = "envelope")
     @Fetch(FetchMode.SUBSELECT)
@@ -101,7 +103,8 @@ public class Envelope {
         List<ScannableItem> scannableItems,
         List<Payment> payments,
         List<NonScannableItem> nonScannableItems,
-        String container
+        String container,
+        String rescanFor
     ) {
         this.poBox = poBox;
         this.jurisdiction = jurisdiction;
@@ -116,6 +119,7 @@ public class Envelope {
         this.payments = payments;
         this.nonScannableItems = nonScannableItems;
         this.container = container;
+        this.rescanFor = rescanFor;
 
         assignSelfToChildren(this.scannableItems);
         assignSelfToChildren(this.payments);
@@ -212,6 +216,14 @@ public class Envelope {
 
     public void setZipDeleted(boolean zipDeleted) {
         this.zipDeleted = zipDeleted;
+    }
+
+    public String getRescanFor() {
+        return rescanFor;
+    }
+
+    public void setRescanFor(String rescanFor) {
+        this.rescanFor = rescanFor;
     }
 
     public boolean isTestOnly() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapper.java
@@ -57,7 +57,8 @@ public class EnvelopeMapper {
             toDbScannableItems(envelope.scannableItems, ocrValidationWarnings),
             toDbPayments(envelope.payments),
             toDbNonScannableItems(envelope.nonScannableItems),
-            containerName
+            containerName,
+            envelope.rescanFor
         );
     }
 

--- a/src/main/resources/db/migration/V058__Add_rescanFor_column_to_envelopes.sql
+++ b/src/main/resources/db/migration/V058__Add_rescanFor_column_to_envelopes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE envelopes
+  ADD COLUMN rescanFor VARCHAR(255) NULL;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/helper/EnvelopeCreator.java
@@ -67,11 +67,11 @@ public final class EnvelopeCreator {
         return EnvelopeResponseMapper.toEnvelopesResponse(envelopes());
     }
 
-    public static EnvelopeResponse envelopeResponse() throws Exception {
+    public static EnvelopeResponse envelopeResponse() {
         return EnvelopeResponseMapper.toEnvelopeResponse(envelope());
     }
 
-    public static List<Envelope> envelopes() throws Exception {
+    public static List<Envelope> envelopes() {
         return ImmutableList.of(envelope());
     }
 
@@ -137,7 +137,8 @@ public final class EnvelopeCreator {
             scannableItems,
             payments(),
             nonScannableItems(),
-            container
+            container,
+            "file1.zip"
         );
 
         envelope.setStatus(status);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/mapper/EnvelopeMapperTest.java
@@ -53,6 +53,7 @@ public class EnvelopeMapperTest {
         assertThat(dbEnvelope.getZipFileCreateddate()).isEqualTo(zipEnvelope.zipFileCreateddate);
         assertThat(dbEnvelope.getZipFileName()).isEqualTo(zipEnvelope.zipFileName);
         assertThat(dbEnvelope.getClassification()).isEqualTo(zipEnvelope.classification);
+        assertThat(dbEnvelope.getRescanFor()).isEqualTo(zipEnvelope.rescanFor);
 
         assertSamePayments(dbEnvelope, zipEnvelope);
         assertSameScannableItems(dbEnvelope, zipEnvelope);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeHandlerTest.java
@@ -31,6 +31,7 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.
 class EnvelopeHandlerTest {
 
     private static final String FILE_NAME = "file1.zip";
+    private static final String RESCAN_FOR_FILE_NAME = "file2.zip";
     private static final String CONTAINER_NAME = "container";
     private static final String LEASE_ID = "leaseID";
     private static final String DCN = "dcn";
@@ -83,7 +84,7 @@ class EnvelopeHandlerTest {
             now(),
             now(),
             FILE_NAME,
-            null,
+            RESCAN_FOR_FILE_NAME,
             CASE_NUMBER,
             CASE_REFERENCE,
             NEW_APPLICATION,
@@ -137,6 +138,7 @@ class EnvelopeHandlerTest {
         assertThat(envelope.getValue().getPayments()).isEqualTo(inputEnvelope.payments);
         assertThat(envelope.getValue().getNonScannableItems()).isEqualTo(inputEnvelope.nonScannableItems);
         assertThat(envelope.getValue().getContainer()).isEqualTo(CONTAINER_NAME);
+        assertThat(envelope.getValue().getRescanFor()).isEqualTo(RESCAN_FOR_FILE_NAME);
 
         verifyNoInteractions(fileRejector);
         verifyNoMoreInteractions(envelopeProcessor);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/UploadEnvelopeDocumentsServiceTest.java
@@ -72,7 +72,7 @@ class UploadEnvelopeDocumentsServiceTest {
     }
 
     @Test
-    void should_do_nothing_when_blob_manager_fails_to_retrieve_container_representation() throws Exception {
+    void should_do_nothing_when_blob_manager_fails_to_retrieve_container_representation() {
         // given
         willThrow(new RuntimeException("i failed")).given(blobManager).listContainerClient(CONTAINER_1);
 
@@ -88,7 +88,7 @@ class UploadEnvelopeDocumentsServiceTest {
 
 
     @Test
-    void should_do_nothing_when_failing_to_get_block_blob_reference() throws Exception {
+    void should_do_nothing_when_failing_to_get_block_blob_reference() {
         // given
         given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
 
@@ -104,7 +104,7 @@ class UploadEnvelopeDocumentsServiceTest {
     }
 
     @Test
-    void should_do_nothing_when_failing_to_acquire_lease() throws Exception {
+    void should_do_nothing_when_failing_to_acquire_lease() {
         // given
         given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
         given(blobContainer.getBlobContainerName()).willReturn(CONTAINER_1);
@@ -122,7 +122,7 @@ class UploadEnvelopeDocumentsServiceTest {
 
 
     @Test
-    void should_do_nothing_when_failing_to_download_blob() throws Exception {
+    void should_do_nothing_when_failing_to_download_blob() {
         // given
         given(blobManager.listContainerClient(CONTAINER_1)).willReturn(blobContainer);
         given(blobContainer.getBlobContainerName()).willReturn(CONTAINER_1);
@@ -255,7 +255,8 @@ class UploadEnvelopeDocumentsServiceTest {
             emptyList(),
             emptyList(),
             emptyList(),
-            CONTAINER_1
+            CONTAINER_1,
+            null
         ));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/UploadEnvelopeDocumentsTaskTest.java
@@ -95,7 +95,8 @@ class UploadEnvelopeDocumentsTaskTest {
             emptyList(),
             emptyList(),
             emptyList(),
-            containerName
+            containerName,
+            null
         );
         envelope.setUploadFailureCount(uploadFailures);
 

--- a/src/test/resources/metafiles/valid/with-scannable-items.json
+++ b/src/test/resources/metafiles/valid/with-scannable-items.json
@@ -7,6 +7,7 @@
   "opening_date": "2017-03-31T00:00:00.010Z",
   "zip_file_createddate": "2017-02-24T00:00:00.001Z",
   "zip_file_name": "1_24-02-2017-00-00-00.zip",
+  "rescan_for": "123_24-02-2017-00-00-00.zip",
   "envelope_classification": "new_application",
   "scannable_items": [
     {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1395


### Change description ###
Add `reform_scan` column to `envelopes` table. 
`rescan_for` value can be null.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
