### PR TITLE
Add blockClient and leaseId parameters to OcrValidator

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
+import com.azure.storage.blob.BlobClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;
@@ -8,6 +9,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Status;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.validation.model.OcrValidationWarnings;
 
 import java.nio.charset.Charset;
@@ -22,6 +24,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CREATED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
@@ -138,7 +141,12 @@ public class BlobProcessorTaskTest extends ProcessorTestSuite {
             ImmutableList.of("warning 1", "warning 2")
         );
 
-        given(ocrValidator.assertOcrDataIsValid(any())).willReturn(Optional.of(ocrValidationWarnings));
+        given(ocrValidator.assertOcrDataIsValid(
+            any(InputEnvelope.class),
+            any(BlobClient.class),
+            anyString()
+        ))
+            .willReturn(Optional.of(ocrValidationWarnings));
 
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -1,14 +1,17 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
+import com.azure.storage.blob.BlobClient;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrValidationException;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.blob.InputEnvelope;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.ErrorCode;
 
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.FILE_VALIDATION_FAILURE;
@@ -99,11 +102,17 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite {
         // given
         uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/ok"));
 
-        given(ocrValidator.assertOcrDataIsValid(any())).willThrow(
-            new OcrValidationException(
-                "Ocr Validation Error.",
-                "Ocr Validation Error. Errors : [Error 1, Error2]")
-        );
+        given(ocrValidator.assertOcrDataIsValid(
+            any(InputEnvelope.class),
+            any(BlobClient.class),
+            anyString()
+        ))
+            .willThrow(
+                new OcrValidationException(
+                    "Ocr Validation Error.",
+                    "Ocr Validation Error. Errors : [Error 1, Error2]"
+                )
+            );
 
         // when
         processor.processBlobs();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import com.azure.storage.blob.BlobClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -65,7 +66,9 @@ public class EnvelopeHandler {
         String containerName,
         String zipFilename,
         List<Pdf> pdfs,
-        InputEnvelope inputEnvelope
+        InputEnvelope inputEnvelope,
+        BlobClient blobClient,
+        String leaseId
     ) {
         envelopeValidator.assertZipFilenameMatchesWithMetadata(inputEnvelope, zipFilename);
         envelopeValidator.assertContainerMatchesJurisdictionAndPoBox(
@@ -82,7 +85,11 @@ public class EnvelopeHandler {
 
         envelopeProcessor.assertDidNotFailToUploadBefore(inputEnvelope.zipFileName, containerName);
 
-        Optional<OcrValidationWarnings> ocrValidationWarnings = ocrValidator.assertOcrDataIsValid(inputEnvelope);
+        Optional<OcrValidationWarnings> ocrValidationWarnings = ocrValidator.assertOcrDataIsValid(
+            inputEnvelope,
+            blobClient,
+            leaseId
+        );
 
         Envelope dbEnvelope = toDbEnvelope(inputEnvelope, containerName, ocrValidationWarnings);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessor.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import com.azure.storage.blob.BlobClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -52,6 +53,7 @@ public class FileContentProcessor {
         ZipInputStream zis,
         String zipFilename,
         String containerName,
+        BlobClient blobClient,
         String leaseId
     ) {
         try {
@@ -71,7 +73,9 @@ public class FileContentProcessor {
                 containerName,
                 zipFilename,
                 result.getPdfs(),
-                inputEnvelope
+                inputEnvelope,
+                blobClient,
+                leaseId
             );
         } catch (PaymentsDisabledException ex) {
             log.error(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTask.java
@@ -149,7 +149,13 @@ public class BlobProcessorTask {
                     null
                 );
 
-                fileContentProcessor.processZipFileContent(zis, zipFilename, container.getBlobContainerName(), leaseId);
+                fileContentProcessor.processZipFileContent(
+                    zis,
+                    zipFilename,
+                    container.getBlobContainerName(),
+                    blobClient,
+                    leaseId
+                );
 
                 log.info(
                     "Zip content processed for file {}, container: {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/validation/OcrValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.validation;
 
+import com.azure.storage.blob.BlobClient;
 import io.vavr.control.Try;
 import joptsimple.internal.Strings;
 import org.slf4j.Logger;
@@ -61,7 +62,11 @@ public class OcrValidator {
      *         no validation took place.
      * @throws OcrValidationException if the OCR data is invalid
      */
-    public Optional<OcrValidationWarnings> assertOcrDataIsValid(InputEnvelope envelope) {
+    public Optional<OcrValidationWarnings> assertOcrDataIsValid(
+        InputEnvelope envelope,
+        BlobClient blobClient,
+        String leaseId
+    ) {
         if (envelope.classification == EXCEPTION) {
             return Optional.empty();
         }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/EnvelopeHandlerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import com.azure.storage.blob.BlobClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,6 +57,9 @@ class EnvelopeHandlerTest {
     @Mock
     private FileRejector fileRejector;
 
+    @Mock
+    private BlobClient blobClient;
+
     private List<ContainerMappings.Mapping> mappings = emptyList();
 
     private List<Pdf> pdfs = emptyList();
@@ -95,7 +99,7 @@ class EnvelopeHandlerTest {
 
     @Test
     void should_handle_and_save_envelope() {
-        given(ocrValidator.assertOcrDataIsValid(inputEnvelope)).willReturn(warnings);
+        given(ocrValidator.assertOcrDataIsValid(inputEnvelope, blobClient, LEASE_ID)).willReturn(warnings);
         given(containerMappings.getMappings()).willReturn(mappings);
 
         // when
@@ -103,7 +107,9 @@ class EnvelopeHandlerTest {
             CONTAINER_NAME,
             FILE_NAME,
             pdfs,
-            inputEnvelope
+            inputEnvelope,
+            blobClient,
+            LEASE_ID
         );
 
         // then

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services;
 
+import com.azure.storage.blob.BlobClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,6 +60,9 @@ class FileContentProcessorTest {
     @Mock
     private ZipFileProcessingResult result;
 
+    @Mock
+    private BlobClient blobClient;
+
     private byte[] metadata = new byte[]{};
 
     private List<ContainerMappings.Mapping> mappings = emptyList();
@@ -107,6 +111,7 @@ class FileContentProcessorTest {
             zis,
             FILE_NAME,
             CONTAINER_NAME,
+            blobClient,
             LEASE_ID
         );
 
@@ -115,7 +120,9 @@ class FileContentProcessorTest {
             CONTAINER_NAME,
             FILE_NAME,
             pdfs,
-            inputEnvelope
+            inputEnvelope,
+            blobClient,
+            LEASE_ID
         );
         verifyNoInteractions(fileRejector);
         verifyNoMoreInteractions(envelopeProcessor);
@@ -138,7 +145,9 @@ class FileContentProcessorTest {
                 CONTAINER_NAME,
                 FILE_NAME,
                 pdfs,
-                inputEnvelope
+                inputEnvelope,
+                blobClient,
+                LEASE_ID
             );
 
         // when
@@ -146,6 +155,7 @@ class FileContentProcessorTest {
             zis,
             FILE_NAME,
             CONTAINER_NAME,
+            blobClient,
             LEASE_ID
         );
 
@@ -179,7 +189,9 @@ class FileContentProcessorTest {
                 CONTAINER_NAME,
                 FILE_NAME,
                 pdfs,
-                inputEnvelope
+                inputEnvelope,
+                blobClient,
+                LEASE_ID
             );
 
         // when
@@ -187,6 +199,7 @@ class FileContentProcessorTest {
             zis,
             FILE_NAME,
             CONTAINER_NAME,
+            blobClient,
             LEASE_ID
         );
 
@@ -219,6 +232,7 @@ class FileContentProcessorTest {
             zis,
             FILE_NAME,
             CONTAINER_NAME,
+            blobClient,
             LEASE_ID
         );
 
@@ -251,6 +265,7 @@ class FileContentProcessorTest {
             zis,
             FILE_NAME,
             CONTAINER_NAME,
+            blobClient,
             LEASE_ID
         );
 
@@ -279,6 +294,7 @@ class FileContentProcessorTest {
             zis,
             FILE_NAME,
             CONTAINER_NAME,
+            blobClient,
             LEASE_ID
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-709


### Change description ###
These parameters will be used in the next PR when calling OcrValidationRetryManager.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
