### PR TITLE
Using OcrValidationRetryManager

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedAndRecoveredOcrValidation.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedAndRecoveredOcrValidation.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.google.common.io.Resources;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.req.FormData;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.res.ValidationResponse;
+
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static com.google.common.io.Resources.getResource;
+import static com.jayway.jsonpath.JsonPath.parse;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CREATED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.res.Status.SUCCESS;
+
+@IntegrationTest
+@TestPropertySource(properties = {
+    "scheduling.task.scan.enabled=true"
+})
+class BlobProcessorTaskTestForFailedAndRecoveredOcrValidation extends ProcessorTestSuiteForOcrValidation {
+    @Test
+    void should_process_envelope_without_warnings_if_ocr_validation_returns_server_side_error_and_then_passes()
+        throws Exception {
+        // given
+        uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/supplementary_evidence_with_ocr"));
+
+        given(authTokenGenerator.generate()).willReturn("token");
+        given(ocrValidationClient.validate(anyString(), any(FormData.class), anyString(), anyString()))
+            .willThrow(getServerSideException())
+            .willReturn(new ValidationResponse(SUCCESS, emptyList(), emptyList()))
+        ;
+
+        // when
+        processor.processBlobs();
+
+        retryAfterDelay();
+
+        // then
+        Envelope actualEnvelope = getSingleEnvelopeFromDb();
+
+        String originalMetaFile = Resources.toString(
+            getResource("zipcontents/supplementary_evidence_with_ocr/metadata.json"),
+            Charset.defaultCharset()
+        );
+
+        assertThat(parse(actualEnvelope)).isEqualToIgnoringGivenFields(
+            parse(originalMetaFile),
+            "id", "amount", "amount_in_pence", "configuration", "json"
+        );
+        assertThat(actualEnvelope.getStatus()).isEqualTo(CREATED);
+        assertThat(actualEnvelope.getScannableItems()).hasSize(1);
+        assertThat(actualEnvelope.getScannableItems().get(0).getOcrValidationWarnings().length).isEqualTo(0);
+
+        // and
+        List<ProcessEvent> processEvents = processEventRepository.findAll();
+        assertThat(processEvents.stream().map(ProcessEvent::getEvent).collect(toList()))
+            .containsExactlyInAnyOrder(
+                ZIPFILE_PROCESSING_STARTED,
+                ZIPFILE_PROCESSING_STARTED
+            );
+
+        assertThat(processEvents).allMatch(pe -> pe.getReason() == null);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForOcrValidationFailedOnServerSide.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForOcrValidationFailedOnServerSide.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.google.common.io.Resources;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEvent;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.model.req.FormData;
+
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static com.google.common.io.Resources.getResource;
+import static com.jayway.jsonpath.JsonPath.parse;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.CREATED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.helper.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.ZIPFILE_PROCESSING_STARTED;
+
+@IntegrationTest
+@TestPropertySource(properties = {
+    "scheduling.task.scan.enabled=true"
+})
+class BlobProcessorTaskTestForOcrValidationFailedOnServerSide extends ProcessorTestSuiteForOcrValidation {
+    @Test
+    void should_process_envelope_with_warnings_if_ocr_validation_returns_server_side_error() throws Exception {
+        // given
+        uploadToBlobStorage(SAMPLE_ZIP_FILE_NAME, zipDir("zipcontents/supplementary_evidence_with_ocr"));
+
+        given(authTokenGenerator.generate()).willReturn("token");
+        given(ocrValidationClient.validate(anyString(), any(FormData.class), anyString(), anyString()))
+            .willThrow(getServerSideException())
+            .willThrow(getServerSideException())
+        ;
+
+        // when
+        processor.processBlobs();
+
+        retryAfterDelay();
+
+        retryAfterDelay();
+
+        // then
+        Envelope actualEnvelope = getSingleEnvelopeFromDb();
+
+        String originalMetaFile = Resources.toString(
+            getResource("zipcontents/supplementary_evidence_with_ocr/metadata.json"),
+            Charset.defaultCharset()
+        );
+
+        assertThat(parse(actualEnvelope)).isEqualToIgnoringGivenFields(
+            parse(originalMetaFile),
+            "id", "amount", "amount_in_pence", "configuration", "json"
+        );
+        assertThat(actualEnvelope.getStatus()).isEqualTo(CREATED);
+        assertThat(actualEnvelope.getScannableItems()).hasSize(1);
+        assertThat(actualEnvelope.getScannableItems().get(0).getOcrValidationWarnings().length).isEqualTo(1);
+        assertThat(actualEnvelope.getScannableItems().get(0).getOcrValidationWarnings()[0])
+            .isEqualTo("OCR validation was not performed due to errors");
+
+        // and
+        List<ProcessEvent> processEvents = processEventRepository.findAll();
+        assertThat(processEvents.stream().map(ProcessEvent::getEvent).collect(toList()))
+            .containsExactlyInAnyOrder(
+                ZIPFILE_PROCESSING_STARTED,
+                ZIPFILE_PROCESSING_STARTED,
+                ZIPFILE_PROCESSING_STARTED
+            );
+
+        assertThat(processEvents).allMatch(pe -> pe.getReason() == null);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuiteForOcrValidation.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuiteForOcrValidation.java
@@ -1,0 +1,191 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.HttpServerErrorException;
+import org.testcontainers.containers.DockerComposeContainer;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.ContainerMappings;
+import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.ProcessEventRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.ocrvalidation.client.OcrValidationClient;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.servicebus.ServiceBusHelper;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.storage.OcrValidationRetryManager;
+import uk.gov.hmcts.reform.bulkscanprocessor.util.TestStorageHelper;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrPresenceValidator;
+import uk.gov.hmcts.reform.bulkscanprocessor.validation.OcrValidator;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@IntegrationTest
+@TestPropertySource(properties = {
+    "scheduling.task.scan.enabled=true"
+})
+abstract class ProcessorTestSuiteForOcrValidation {
+    static final String SAMPLE_ZIP_FILE_NAME = "1_24-06-2018-00-00-00.zip";
+
+    static final String CONTAINER_NAME = "bulkscan";
+
+    @Autowired
+    BlobProcessorTask processor;
+
+    @Autowired
+    ContainerMappings containerMappings;
+
+    @Autowired
+    EnvelopeRepository envelopeRepository;
+
+    @Autowired
+    ProcessEventRepository processEventRepository;
+
+    @Autowired
+    OcrValidationRetryManager ocrValidationRetryManager;
+
+    @Autowired
+    OcrPresenceValidator ocrPresenceValidator;
+
+    @MockBean
+    AuthTokenGenerator authTokenGenerator;
+
+    @MockBean
+    OcrValidationClient ocrValidationClient;
+
+    OcrValidator ocrValidator;
+
+    BlobContainerClient testContainer;
+
+    static DockerComposeContainer dockerComposeContainer;
+    static String dockerHost;
+
+    @BeforeEach
+    void setUp() {
+
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+            .connectionString(String.format(TestStorageHelper.STORAGE_CONN_STRING, dockerHost, 10000))
+            .buildClient();
+
+        ocrValidator = new OcrValidator(
+            ocrValidationClient,
+            ocrPresenceValidator,
+            containerMappings,
+            authTokenGenerator,
+            ocrValidationRetryManager
+        );
+
+        testContainer = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+        if (!testContainer.exists()) {
+            testContainer.create();
+        }
+    }
+
+    @AfterEach
+    void cleanUp() {
+        if (testContainer.exists()) {
+            testContainer.delete();
+        }
+
+        envelopeRepository.deleteAll();
+        processEventRepository.deleteAll();
+    }
+
+    @BeforeAll
+    static void initialize() {
+        File dockerComposeFile = new File("src/integrationTest/resources/docker-compose.yml");
+
+        dockerComposeContainer = new DockerComposeContainer(dockerComposeFile)
+            .withExposedService("azure-storage", 10000)
+            .withLocalCompose(true);
+
+        dockerComposeContainer.start();
+        dockerHost = dockerComposeContainer.getServiceHost("azure-storage", 10000);
+    }
+
+    @AfterAll
+    static void tearDownContainer() {
+        dockerComposeContainer.stop();
+    }
+
+    @NotNull
+    HttpServerErrorException getServerSideException() {
+        return HttpServerErrorException.create(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "internal server error message",
+            HttpHeaders.EMPTY,
+            null,
+            null
+        );
+    }
+
+    void uploadToBlobStorage(String fileName, byte[] fileContent) {
+        var blockBlobReference = testContainer.getBlobClient(fileName);
+
+        // Blob need to be deleted as same blob may exists if previously uploaded blob was not deleted
+        // due to doc upload failure
+        if (blockBlobReference.exists()) {
+            blockBlobReference.delete();
+        }
+
+        // A Put Blob operation may succeed against a blob that exists in the storage emulator with an active lease,
+        // even if the lease ID has not been specified in the request.
+        blockBlobReference.upload(new ByteArrayInputStream(fileContent), fileContent.length);
+    }
+
+    Envelope getSingleEnvelopeFromDb() {
+        // We expect only one envelope which was uploaded
+        List<Envelope> envelopes = envelopeRepository.findAll();
+        assertThat(envelopes).hasSize(1);
+
+        return envelopes.get(0);
+    }
+
+    void assertNoEnvelopesInDb() {
+        // We expect only one envelope which was uploaded
+        List<Envelope> envelopes = envelopeRepository.findAll();
+        assertThat(envelopes).hasSize(0);
+    }
+
+    void doSleep(long l) {
+        try {
+            Thread.sleep(l);
+        } catch (InterruptedException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    void retryAfterDelay() {
+        assertNoEnvelopesInDb();
+
+        doSleep(5000L);
+
+        processor.processBlobs();
+    }
+
+    @TestConfiguration
+    public static class MockConfig {
+
+        @Bean(name = "notifications-helper")
+        public ServiceBusHelper notificationsQueueHelper() {
+            return mock(ServiceBusHelper.class);
+        }
+    }
+}

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -16,10 +16,12 @@ containers.mappings[0].container=bulkscan
 containers.mappings[0].jurisdiction=BULKSCAN
 containers.mappings[0].poBox=BULKSCANPO
 containers.mappings[0].paymentsEnabled=true
+containers.mappings[0].ocrValidationUrl=http://bulkscan/validation
 containers.mappings[1].container=sscs
 containers.mappings[1].jurisdiction=SSCS
 containers.mappings[1].poBox=SSCSPO
 containers.mappings[1].paymentsEnabled=true
+containers.mappings[1].ocrValidationUrl=http://sscs/validation
 
 idam.s2s-auth.url=false
 storage.blob_copy_timeout_in_millis=30000

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrValidationServerSideException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/exceptions/OcrValidationServerSideException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.exceptions;
+
+public class OcrValidationServerSideException extends RuntimeException {
+
+    public OcrValidationServerSideException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/FileContentProcessor.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.EnvelopeRejectionException;
+import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.OcrValidationServerSideException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.PaymentsDisabledException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.PreviouslyFailedToUploadException;
 import uk.gov.hmcts.reform.bulkscanprocessor.exceptions.ServiceDisabledException;
@@ -96,6 +97,14 @@ public class FileContentProcessor {
         } catch (PreviouslyFailedToUploadException ex) {
             log.warn("Rejected file {} from container {} - failed previously", zipFilename, containerName, ex);
             createEvent(DOC_UPLOAD_FAILURE, containerName, zipFilename, ex.getMessage());
+        } catch (OcrValidationServerSideException ex) {
+            log.error("Failed to process file {} from container {}, "
+                          + "message from OCR validation endpoint {} - will retry",
+                      zipFilename,
+                      containerName,
+                      ex.getMessage(),
+                      ex
+            );
         } catch (Exception ex) {
             log.error("Failed to process file {} from container {}", zipFilename, containerName, ex);
             createEvent(DOC_FAILURE, containerName, zipFilename, ex.getMessage());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-709


### Change description ###
The main changes are in `OcrValidator` (calling `ocrValidationRetryManager.setRetryDelayIfPossible`):

if this method returns `true` - new `OcrValidationServerSideException` is thrown which is caught in `FileContentProcessor` thus stopping processing the zip file until the next retry
if this method returns `false` - the process falls back to the current workflow - raising a warning that OCR validation was not performed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
