### PR TITLE
add rejected Discrepancy

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ReceivedZipFileRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/ReceivedZipFileRepositoryTest.java
@@ -63,7 +63,7 @@ public class ReceivedZipFileRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 singletonList(
-                    new ReceivedZipFileItem("test2.zip", "c2", createdDate2, null, null, null)
+                    new ReceivedZipFileItem("test2.zip", "c2", createdDate2, null, null, null, null)
                 )
             );
     }
@@ -81,8 +81,11 @@ public class ReceivedZipFileRepositoryTest {
             event("c3", "test3.zip", createdDate3, ZIPFILE_PROCESSING_STARTED)
         );
 
+        Envelope existingEnvelope;
         dbHasEnvelope(envelope("c1", "test1.zip", Status.COMPLETED, EXCEPTION, "ccd-id-1", "ccd-action-1", null));
-        dbHasEnvelope(envelope("c2", "test2.zip", Status.COMPLETED, EXCEPTION, "ccd-id-1", "ccd-action-1", "test5"));
+        existingEnvelope
+            = envelope("c2", "test2.zip", Status.COMPLETED, EXCEPTION, "ccd-id-1", "ccd-action-1", "test5");
+        dbHasEnvelope(existingEnvelope);
         dbHasEnvelope(envelope("c3", "test3.zip", Status.COMPLETED, EXCEPTION, "ccd-id-1", "ccd-action-1", null));
 
         // when
@@ -93,7 +96,15 @@ public class ReceivedZipFileRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 singletonList(
-                    new ReceivedZipFileItem("test2.zip", "c2", createdDate1, null, null, "test5")
+                    new ReceivedZipFileItem(
+                        "test2.zip",
+                        "c2",
+                        createdDate1,
+                        null,
+                        null,
+                        "test5",
+                        existingEnvelope.getId()
+                    )
                 )
             );
     }
@@ -122,7 +133,14 @@ public class ReceivedZipFileRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 singletonList(
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-1", "pay-1",  "test4.zip")
+                    new ReceivedZipFileItem(
+                        "test1.zip",
+                        "c1", createdDate,
+                        "doc-1",
+                        "pay-1",
+                        "test4.zip",
+                        envelope.getId()
+                    )
                 )
             );
     }
@@ -152,8 +170,8 @@ public class ReceivedZipFileRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 asList(
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-1", null,  null),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-2", null,  null)
+                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-1", null,  null, envelope.getId()),
+                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-2", null,  null, envelope.getId())
                 )
             );
     }
@@ -184,8 +202,24 @@ public class ReceivedZipFileRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 asList(
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, null, "pay-1",  "test5.zip"),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, null, "pay-2",  "test5.zip")
+                    new ReceivedZipFileItem(
+                        "test1.zip",
+                        "c1",
+                        createdDate,
+                        null,
+                        "pay-1",
+                        "test5.zip",
+                        envelope.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test1.zip",
+                        "c1",
+                        createdDate,
+                        null,
+                        "pay-2",
+                        "test5.zip",
+                        envelope.getId()
+                    )
                 )
             );
     }
@@ -199,7 +233,8 @@ public class ReceivedZipFileRepositoryTest {
             event("c1", "test1.zip", createdDate, ZIPFILE_PROCESSING_STARTED)
         );
 
-        Envelope envelope = envelope("c1", "test1.zip", Status.COMPLETED, EXCEPTION, "ccd-id-1", "ccd-action-1", null);
+        Envelope envelope
+            = envelope("c1", "test1.zip", Status.COMPLETED, EXCEPTION, "ccd-id-1", "ccd-action-1", null);
         dbHasEnvelope(envelope);
 
         dbHasScannableItems(
@@ -219,10 +254,10 @@ public class ReceivedZipFileRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 asList(
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-1", "pay-1",  null),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-1", "pay-2", null),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-2", "pay-1", null),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-2", "pay-2",  null)
+                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-1", "pay-1",  null, envelope.getId()),
+                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-1", "pay-2", null, envelope.getId()),
+                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-2", "pay-1", null, envelope.getId()),
+                    new ReceivedZipFileItem("test1.zip", "c1", createdDate, "doc-2", "pay-2",  null, envelope.getId())
                 )
             );
     }
@@ -265,14 +300,77 @@ public class ReceivedZipFileRepositoryTest {
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(
                 asList(
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate1, "doc-1", "pay-1",  "test5.zip"),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate1, "doc-1", "pay-2",  "test5.zip"),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate1, "doc-2", "pay-1",  "test5.zip"),
-                    new ReceivedZipFileItem("test1.zip", "c1", createdDate1, "doc-2", "pay-2",  "test5.zip"),
-                    new ReceivedZipFileItem("test2.zip", "c2", createdDate2, "doc-3", "pay-3",  null),
-                    new ReceivedZipFileItem("test2.zip", "c2", createdDate2, "doc-3", "pay-4",  null),
-                    new ReceivedZipFileItem("test2.zip", "c2", createdDate2, "doc-4", "pay-3",  null),
-                    new ReceivedZipFileItem("test2.zip", "c2", createdDate2, "doc-4", "pay-4",  null)
+                    new ReceivedZipFileItem(
+                        "test1.zip",
+                        "c1",
+                        createdDate1,
+                        "doc-1",
+                        "pay-1",
+                        "test5.zip",
+                        envelope1.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test1.zip",
+                        "c1",
+                        createdDate1,
+                        "doc-1",
+                        "pay-2",
+                        "test5.zip",
+                        envelope1.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test1.zip",
+                        "c1", createdDate1,
+                        "doc-2",
+                        "pay-1",
+                        "test5.zip",
+                        envelope1.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test1.zip",
+                        "c1",
+                        createdDate1,
+                        "doc-2",
+                        "pay-2",
+                        "test5.zip",
+                        envelope1.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test2.zip",
+                        "c2",
+                        createdDate2,
+                        "doc-3",
+                        "pay-3",
+                        null,
+                        envelope2.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test2.zip",
+                        "c2",
+                        createdDate2,
+                        "doc-3",
+                        "pay-4",
+                        null,
+                        envelope2.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test2.zip",
+                        "c2",
+                        createdDate2,
+                        "doc-4",
+                        "pay-3",
+                        null,
+                        envelope2.getId()
+                    ),
+                    new ReceivedZipFileItem(
+                        "test2.zip",
+                        "c2",
+                        createdDate2,
+                        "doc-4",
+                        "pay-4",
+                        null,
+                        envelope2.getId()
+                    )
                 )
             );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ReceivedZipFile.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ReceivedZipFile.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.entity.reports;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public interface ReceivedZipFile {
     String getZipFileName();
@@ -14,4 +15,7 @@ public interface ReceivedZipFile {
     String getPaymentDcn();
 
     String getRescanFor();
+
+    UUID getEnvelopeId();
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ReceivedZipFileRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ReceivedZipFileRepository.java
@@ -21,6 +21,7 @@ public interface ReceivedZipFileRepository extends JpaRepository<Envelope, UUID>
             + "  payments.documentControlNumber AS paymentDCN, "
             + "  envelopes.rescanFor, "
             + "  Cast(envelopes.id as varchar) as envelopeId " // null means no envelope
+            // UUID by default it translates to a JDBC Binary type so cast to varchar
             + "FROM process_events "
             + "LEFT OUTER JOIN envelopes "
             + "  ON envelopes.container = process_events.container "

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ReceivedZipFileRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/ReceivedZipFileRepository.java
@@ -19,7 +19,8 @@ public interface ReceivedZipFileRepository extends JpaRepository<Envelope, UUID>
             + "  process_events.createdat AS processingStartedEventDate, "
             + "  scannable_items.documentControlNumber AS scannableItemDCN, "
             + "  payments.documentControlNumber AS paymentDCN, "
-            + "  envelopes.rescanFor "
+            + "  envelopes.rescanFor, "
+            + "  Cast(envelopes.id as varchar) as envelopeId " // null means no envelope
             + "FROM process_events "
             + "LEFT OUTER JOIN envelopes "
             + "  ON envelopes.container = process_events.container "

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverter.java
@@ -44,7 +44,8 @@ public class ReceivedZipFileConverter {
             receivedZipFilesList.get(0).getContainer(),
             receivedZipFilesList.get(0).getRescanFor(),
             new ArrayList<>(scannableItemDcns),
-            new ArrayList<>(paymentDcns)
+            new ArrayList<>(paymentDcns),
+            receivedZipFilesList.get(0).getEnvelopeId()
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/DiscrepancyType.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/DiscrepancyType.java
@@ -8,7 +8,8 @@ public enum DiscrepancyType {
     RECEIVED_BUT_NOT_REPORTED("received but not reported"),
     PAYMENT_DCNS_MISMATCH("payment dcns mismatch"),
     SCANNABLE_DOCUMENT_DCNS_MISMATCH("scannable document dcns mismatch"),
-    RESCAN_FOR_MISMATCH("rescan for file name mismatch");
+    RESCAN_FOR_MISMATCH("rescan for file name mismatch"),
+    REJECTED_ENVELOPE("envelope rejected");
 
     @JsonValue
     public final String text;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ReceivedZipFileData.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/models/ReceivedZipFileData.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models;
 
 import java.util.List;
+import java.util.UUID;
 
 public class ReceivedZipFileData {
     public final String zipFileName;
@@ -8,18 +9,21 @@ public class ReceivedZipFileData {
     public final String rescanFor;
     public final List<String> scannableItemDcns;
     public final List<String> paymentDcns;
+    public final UUID envelopeId;
 
     public ReceivedZipFileData(
         String zipFileName,
         String container,
         String rescanFor,
         List<String> scannableItemDcns,
-        List<String> paymentDcns
+        List<String> paymentDcns,
+        UUID envelopeId
     ) {
         this.zipFileName = zipFileName;
         this.container = container;
         this.rescanFor = rescanFor;
         this.scannableItemDcns = scannableItemDcns;
         this.paymentDcns = paymentDcns;
+        this.envelopeId = envelopeId;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileConverterTest.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.ReceivedZip
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -25,8 +26,9 @@ class ReceivedZipFileConverterTest {
     @Test
     void should_convert_files_without_scannable_documents_and_payments() {
         // given
-        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, null,  "file3");
-        ReceivedZipFile file2 = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, null,  null);
+        ReceivedZipFile file1 =
+            new ReceivedZipFileItem("file1", "c1", Instant.now(), null, null,  "file3", UUID.randomUUID());
+        ReceivedZipFile file2 = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, null,  null, null);
 
         // when
         List<ReceivedZipFileData> res = receivedZipFileConverter.convertReceivedZipFiles(asList(file1, file2));
@@ -35,18 +37,21 @@ class ReceivedZipFileConverterTest {
         assertThat(res)
             .usingFieldByFieldElementComparator()
             .containsExactlyInAnyOrder(
-                new ReceivedZipFileData("file1", "c1", "file3", emptyList(), emptyList()),
-                new ReceivedZipFileData("file2", "c2", null, emptyList(), emptyList())
+                new ReceivedZipFileData("file1", "c1", "file3", emptyList(), emptyList(), file1.getEnvelopeId()),
+                new ReceivedZipFileData("file2", "c2", null, emptyList(), emptyList(), null)
             );
     }
 
     @Test
     void should_convert_files_with_scannable_documents() {
         // given
-        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", null,  "file3");
-        ReceivedZipFile file2 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", null,  "file3");
-        ReceivedZipFile file3 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", null,  null);
-        ReceivedZipFile file4 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", null,  null);
+        var envelopeId2 = UUID.randomUUID();
+        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", null,  "file3", null);
+        ReceivedZipFile file2 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", null,  "file3", null);
+        ReceivedZipFile file3
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", null,  null, envelopeId2);
+        ReceivedZipFile file4
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", null,  null, envelopeId2);
 
         // when
         List<ReceivedZipFileData> res =
@@ -56,6 +61,7 @@ class ReceivedZipFileConverterTest {
         assertThat(res)
             .extracting(file ->
                             tuple(
+                                file.envelopeId,
                                 file.zipFileName,
                                 file.container,
                                 file.rescanFor,
@@ -64,18 +70,23 @@ class ReceivedZipFileConverterTest {
                             )
             )
             .containsExactlyInAnyOrder(
-                tuple("file1", "c1", "file3", asList("doc-1", "doc-2"), emptyList()),
-                tuple("file2", "c2", null, asList("doc-3", "doc-4"), emptyList())
+                tuple(null, "file1", "c1", "file3", asList("doc-1", "doc-2"), emptyList()),
+                tuple(envelopeId2, "file2", "c2", null, asList("doc-3", "doc-4"), emptyList())
             );
     }
 
     @Test
     void should_convert_files_with_payments() {
         // given
-        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, "pay-1",  null);
-        ReceivedZipFile file2 = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, "pay-2",  null);
-        ReceivedZipFile file3 = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, "pay-3",  "file5");
-        ReceivedZipFile file4 = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, "pay-4",  "file5");
+        var envelopeId1 = UUID.randomUUID();
+        ReceivedZipFile file1
+            = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, "pay-1",  null, envelopeId1);
+        ReceivedZipFile file2
+            = new ReceivedZipFileItem("file1", "c1", Instant.now(), null, "pay-2",  null, envelopeId1);
+        ReceivedZipFile file3
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, "pay-3",  "file5", null);
+        ReceivedZipFile file4
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), null, "pay-4",  "file5", null);
 
         // when
         List<ReceivedZipFileData> res =
@@ -85,6 +96,7 @@ class ReceivedZipFileConverterTest {
         assertThat(res)
             .extracting(file ->
                             tuple(
+                                file.envelopeId,
                                 file.zipFileName,
                                 file.container,
                                 file.rescanFor,
@@ -93,22 +105,32 @@ class ReceivedZipFileConverterTest {
                             )
             )
             .containsExactlyInAnyOrder(
-                tuple("file1", "c1", null, emptyList(), asList("pay-1", "pay-2")),
-                tuple("file2", "c2", "file5", emptyList(), asList("pay-3", "pay-4"))
+                tuple(envelopeId1, "file1", "c1", null, emptyList(), asList("pay-1", "pay-2")),
+                tuple(null, "file2", "c2", "file5", emptyList(), asList("pay-3", "pay-4"))
             );
     }
 
     @Test
     void should_convert_files_with_scannable_documents_and_payments() {
         // given
-        ReceivedZipFile file1 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", "pay-1",  null);
-        ReceivedZipFile file2 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", "pay-2",  null);
-        ReceivedZipFile file3 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", "pay-2",  null);
-        ReceivedZipFile file4 = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", "pay-2",  null);
-        ReceivedZipFile file5 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", "pay-3",  null);
-        ReceivedZipFile file6 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", "pay-3",  null);
-        ReceivedZipFile file7 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", "pay-4",  null);
-        ReceivedZipFile file8 = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", "pay-4",  null);
+        var envelopeId1 = UUID.randomUUID();
+        var envelopeId2 = UUID.randomUUID();
+        ReceivedZipFile file1
+            = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", "pay-1",  null, envelopeId1);
+        ReceivedZipFile file2
+            = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-1", "pay-2",  null, envelopeId1);
+        ReceivedZipFile file3
+            = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", "pay-2",  null, envelopeId1);
+        ReceivedZipFile file4
+            = new ReceivedZipFileItem("file1", "c1", Instant.now(), "doc-2", "pay-2",  null, envelopeId1);
+        ReceivedZipFile file5
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", "pay-3",  null, envelopeId2);
+        ReceivedZipFile file6
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-3", "pay-3",  null, envelopeId2);
+        ReceivedZipFile file7
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", "pay-4",  null, envelopeId2);
+        ReceivedZipFile file8
+            = new ReceivedZipFileItem("file2", "c2", Instant.now(), "doc-4", "pay-4",  null, envelopeId2);
 
         // when
         List<ReceivedZipFileData> res =
@@ -120,6 +142,7 @@ class ReceivedZipFileConverterTest {
         assertThat(res)
             .extracting(file ->
                             tuple(
+                                file.envelopeId,
                                 file.zipFileName,
                                 file.container,
                                 file.scannableItemDcns.stream().sorted().collect(toList()),
@@ -127,8 +150,8 @@ class ReceivedZipFileConverterTest {
                             )
             )
             .containsExactlyInAnyOrder(
-                tuple("file1", "c1", asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-                tuple("file2", "c2", asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+                tuple(envelopeId1, "file1", "c1", asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
+                tuple(envelopeId2, "file2", "c2", asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
             );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileItem.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReceivedZipFileItem.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscanprocessor.services.reports;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.ReceivedZipFile;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public class ReceivedZipFileItem implements ReceivedZipFile {
     private final String zipFileName;
@@ -11,6 +12,7 @@ public class ReceivedZipFileItem implements ReceivedZipFile {
     private final String scannableItemDcn;
     private final String paymentDcn;
     private final String rescanFor;
+    private final UUID envelopeId;
 
     public ReceivedZipFileItem(
         String zipFileName,
@@ -18,7 +20,8 @@ public class ReceivedZipFileItem implements ReceivedZipFile {
         Instant processingStartedEventDate,
         String scannableItemDcn,
         String paymentDcn,
-        String rescanFor
+        String rescanFor,
+        UUID envelopeId
     ) {
         this.zipFileName = zipFileName;
         this.container = container;
@@ -26,6 +29,7 @@ public class ReceivedZipFileItem implements ReceivedZipFile {
         this.scannableItemDcn = scannableItemDcn;
         this.paymentDcn = paymentDcn;
         this.rescanFor = rescanFor;
+        this.envelopeId = envelopeId;
     }
 
     @Override
@@ -56,5 +60,10 @@ public class ReceivedZipFileItem implements ReceivedZipFile {
     @Override
     public String getRescanFor() {
         return rescanFor;
+    }
+
+    @Override
+    public UUID getEnvelopeId() {
+        return envelopeId;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationServiceTest.java
@@ -18,10 +18,12 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.DiscrepancyType.PAYMENT_DCNS_MISMATCH;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.DiscrepancyType.RECEIVED_BUT_NOT_REPORTED;
+import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.DiscrepancyType.REJECTED_ENVELOPE;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.DiscrepancyType.REPORTED_BUT_NOT_RECEIVED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.DiscrepancyType.RESCAN_FOR_MISMATCH;
 import static uk.gov.hmcts.reform.bulkscanprocessor.services.reports.models.DiscrepancyType.SCANNABLE_DOCUMENT_DCNS_MISMATCH;
@@ -50,8 +52,8 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", "file4", null, null),
-            new ReceivedZipFileData("file2", "c2", null, null, null)
+            new ReceivedZipFileData("file1", "c1", "file4", null, null, randomUUID()),
+            new ReceivedZipFileData("file2", "c2", null, null, null, randomUUID())
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -75,7 +77,7 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = singletonList(
-            new ReceivedZipFileData("file1", "c1", null, null, null)
+            new ReceivedZipFileData("file1", "c1", null, null, null, randomUUID())
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -103,8 +105,8 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", "file4",null, null),
-            new ReceivedZipFileData("file2", "c2", null,null, null)
+            new ReceivedZipFileData("file1", "c1", "file4",null, null, randomUUID()),
+            new ReceivedZipFileData("file2", "c2", null,null, null, randomUUID())
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -131,8 +133,8 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file2", "c2", "file4", null, null),
-            new ReceivedZipFileData("file3", "c3", null, null, null)
+            new ReceivedZipFileData("file2", "c2", "file4", null, null, randomUUID()),
+            new ReceivedZipFileData("file3", "c3", null, null, null, randomUUID())
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -161,8 +163,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", "file4", asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                "file4",
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -186,8 +202,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                null,
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -211,8 +241,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                null,
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -240,8 +284,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                null,
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -269,8 +327,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                null,
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -298,8 +370,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                null,
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -327,8 +413,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, emptyList(), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", "file4", asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                emptyList(),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                "file4",
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -356,8 +456,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", "file4", asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                "file4",
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -385,8 +499,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                null,
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -414,8 +542,22 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), emptyList()),
-            new ReceivedZipFileData("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                emptyList(),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                null,
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            )
         );
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
 
@@ -442,11 +584,46 @@ class ReconciliationServiceTest {
         LocalDate date = LocalDate.now();
 
         final List<ReceivedZipFileData> receivedZipFileDataList = asList(
-            new ReceivedZipFileData("file1", "c1", null, asList("doc-1", "doc-2"), asList("pay-1", "pay-2")),
-            new ReceivedZipFileData("file2", "c2", "file4", asList("doc-3", "doc-4"), asList("pay-3", "pay-4")),
-            new ReceivedZipFileData("file3", "c3", "file5", null, null),
-            new ReceivedZipFileData("file4", "c4", "", null, null),
-            new ReceivedZipFileData("file5", "c5", null, null, null)
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1", "pay-2"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                "file4",
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file3",
+                "c3",
+                "file5",
+                null,
+                null,
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file4",
+                "c4",
+                "",
+                null,
+                null,
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file5",
+                "c5",
+                null,
+                null,
+                null,
+                randomUUID()
+            )
         );
 
         prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
@@ -469,6 +646,88 @@ class ReconciliationServiceTest {
             .containsExactlyInAnyOrder(
                 new Discrepancy("file2", "c2", RESCAN_FOR_MISMATCH, "file6", "file4"),
                 new Discrepancy("file3", "c3", RESCAN_FOR_MISMATCH, null, "file5")
+            );
+    }
+
+    @Test
+    void should_only_return_rejected_discrepancy_when_envelope_is_rejected() {
+        // given
+        LocalDate date = LocalDate.now();
+
+        final List<ReceivedZipFileData> receivedZipFileDataList = asList(
+            new ReceivedZipFileData(
+                "file1",
+                "c1",
+                null,
+                asList("doc-1", "doc-2"),
+                asList("pay-1"),
+                null
+            ),
+            new ReceivedZipFileData(
+                "file2",
+                "c2",
+                "",
+                asList("doc-3", "doc-4"),
+                asList("pay-3", "pay-4"),
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file3",
+                "c3",
+                "file5",
+                null,
+                null,
+                null
+            )
+        );
+
+        prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
+
+        List<ReportedZipFile> envelopes = asList(
+            new ReportedZipFile("file1", "c1", null, emptyList(), asList("pay-2")),
+            new ReportedZipFile("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4")),
+            new ReportedZipFile("file3", "c3", null, asList("doc-4"), null)
+        );
+        ReconciliationStatement statement = new ReconciliationStatement(date, envelopes);
+
+        // when
+        List<Discrepancy> discrepancies = reconciliationService.getReconciliationReport(statement);
+
+        // then
+        assertThat(discrepancies)
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new Discrepancy("file1", "c1", REJECTED_ENVELOPE),
+                new Discrepancy("file3", "c3", REJECTED_ENVELOPE)
+            );
+    }
+
+
+    @Test
+    void should_return_received_but_not_reported_even_envelope_rejected_when_envelope_not_reported() {
+        // given
+        LocalDate date = LocalDate.now();
+
+        final List<ReceivedZipFileData> receivedZipFileDataList = asList(
+            new ReceivedZipFileData("file1", "c1", null, asList("doc-2"), asList("pay-1"), null),
+            new ReceivedZipFileData("file2", "c2", "", asList("doc-3", "doc-4"), asList("pay-4"), randomUUID())
+        );
+
+        prepareReconciliationServiceBehaviour(date, receivedZipFileDataList);
+
+        List<ReportedZipFile> envelopes = asList(
+            new ReportedZipFile("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-4"))
+        );
+        ReconciliationStatement statement = new ReconciliationStatement(date, envelopes);
+
+        // when
+        List<Discrepancy> discrepancies = reconciliationService.getReconciliationReport(statement);
+
+        // then
+        assertThat(discrepancies)
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new Discrepancy("file1", "c1", RECEIVED_BUT_NOT_REPORTED)
             );
     }
 


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1403

### Change description ###

add rejected Discrepancy,
if it envelope is not in envelope table assume it is rejected.  
new 'envelopeId' field added to`ReceivedZipFileItem`.
if it is rejected and reported, creates rejected discrepancy. if it is rejected but not reported creates received_but_not_reported discrepancy.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
