### PR TITLE
fix: bump testcontainers version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,10 +330,10 @@ dependencies {
     exclude group: 'com.github.tomakehurst', module: 'wiremock-jre8-standalone'
   }
   integrationTestImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.26.3'
-  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.14.3', {
+  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.15.0-rc2', {
     exclude group: 'junit', module: 'junit'
   }
-  integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.14.3'
+  integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.15.0-rc2'
   integrationTestImplementation group: 'com.revinate', name: 'assertj-json', version: '1.2.0'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestWithAcquireLease.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks;
 
 import com.google.common.collect.ImmutableMap;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
@@ -55,11 +54,10 @@ public class BlobProcessorTaskTestWithAcquireLease extends ProcessorTestSuite {
         // and
         List<ProcessEvent> processEvents = processEventRepository.findAll();
         assertThat(processEvents)
-            .extracting(event -> event.getEvent())
+            .extracting(ProcessEvent::getEvent)
             .containsExactlyInAnyOrder(Event.ZIPFILE_PROCESSING_STARTED);
     }
 
-    @NotNull
     private List<Future<Void>> processBlobUsingExecutor() {
         List<Future<Void>> tasks = new ArrayList<>();
 


### PR DESCRIPTION
* the new version fixes the Docker 2.4.0 problem

### Change description ###

The new version of testcontainers fixes the problem with the Docker 2.4.0 upgrade. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
