### PR TITLE
fix null & empty list handling in reconciliation detail report

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationService.java
@@ -146,11 +146,9 @@ public class ReconciliationService {
         List<String> receivedList,
         DiscrepancyType discrepancyType
     ) {
-        boolean bothEmptyLists =
-            (receivedList == null || receivedList.isEmpty())
-                && (reportedList == null || reportedList.isEmpty());
-
-        if (bothEmptyLists) {
+        if ((receivedList == null || receivedList.isEmpty())
+            && (reportedList == null || reportedList.isEmpty())) {
+            // both list empty or null
             return;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationService.java
@@ -146,9 +146,18 @@ public class ReconciliationService {
         List<String> receivedList,
         DiscrepancyType discrepancyType
     ) {
-        if (reportedList == null && receivedList != null
-            || reportedList != null
-            && !new HashSet<>(reportedList).equals(new HashSet<>(receivedList))) {
+        boolean bothEmptyLists =
+            (receivedList == null || receivedList.isEmpty())
+                && (reportedList == null || reportedList.isEmpty());
+
+        if (bothEmptyLists) {
+            return;
+        }
+
+        if ((reportedList == null && receivedList != null)
+            || (reportedList != null
+                && (receivedList == null || !new HashSet<>(reportedList).equals(new HashSet<>(receivedList))))
+        ) {
             discrepancies.add(
                 new Discrepancy(
                     receivedZipFile.zipFileName,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationService.java
@@ -154,9 +154,8 @@ public class ReconciliationService {
             return;
         }
 
-        if ((reportedList == null && receivedList != null)
-            || (reportedList != null
-                && (receivedList == null || !new HashSet<>(reportedList).equals(new HashSet<>(receivedList))))
+        if ((reportedList == null)
+            || (receivedList == null || !new HashSet<>(reportedList).equals(new HashSet<>(receivedList)))
         ) {
             discrepancies.add(
                 new Discrepancy(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/ReconciliationServiceTest.java
@@ -342,6 +342,22 @@ class ReconciliationServiceTest {
                 asList("doc-3", "doc-4"),
                 asList("pay-3", "pay-4"),
                 randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file3",
+                "c3",
+                null,
+                emptyList(),
+                null,
+                randomUUID()
+            ),
+            new ReceivedZipFileData(
+                "file4",
+                "c4",
+                null,
+                null,
+                asList("doc-8", "doc-9"),
+                randomUUID()
             )
         );
 
@@ -349,7 +365,9 @@ class ReconciliationServiceTest {
 
         List<ReportedZipFile> envelopes = asList(
             new ReportedZipFile("file1", "c1", null, null, asList("pay-1", "pay-2")),
-            new ReportedZipFile("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4"))
+            new ReportedZipFile("file2", "c2", null, asList("doc-3", "doc-4"), asList("pay-3", "pay-4")),
+            new ReportedZipFile("file3", "c3", null, null, emptyList()),
+            new ReportedZipFile("file4", "c4", null, asList("doc-6", "doc-7"), null)
         );
         ReconciliationStatement statement = new ReconciliationStatement(date, envelopes);
 
@@ -360,7 +378,9 @@ class ReconciliationServiceTest {
         assertThat(discrepancies)
             .usingRecursiveFieldByFieldElementComparator()
             .containsExactlyInAnyOrder(
-                new Discrepancy("file1", "c1", SCANNABLE_DOCUMENT_DCNS_MISMATCH, null, "[doc-1, doc-2]")
+                new Discrepancy("file1", "c1", SCANNABLE_DOCUMENT_DCNS_MISMATCH, null, "[doc-1, doc-2]"),
+                new Discrepancy("file4", "c4", PAYMENT_DCNS_MISMATCH, null, "[doc-8, doc-9]"),
+                new Discrepancy("file4", "c4", SCANNABLE_DOCUMENT_DCNS_MISMATCH, "[doc-6, doc-7]", null)
             );
     }
 


### PR DESCRIPTION

### Change description ###

fix null & empty list handling
if they submit null and if we receive empty list currently we catch it as a discrepancy but it should not be a  discrepancy

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
