### PR TITLE
getCompleteAndNotifiedEnvelopes method

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepositoryTest.java
@@ -234,6 +234,26 @@ public class EnvelopeRepositoryTest {
             .containsExactlyInAnyOrder("A.zip", "D.zip");
     }
 
+    @Test
+    public void should_get_complete_and_notified_envelopes() {
+        // given
+        dbHas(
+            envelope("A.zip", "X", Status.UPLOADED),
+            envelope("B.zip", "Y", Status.COMPLETED),
+            envelope("C.zip", "Z", Status.UPLOAD_FAILURE),
+            envelope("D.zip", "Z", Status.NOTIFICATION_SENT),
+            envelope("E.zip", "Z", Status.COMPLETED)
+        );
+
+        // when
+        List<Envelope> result = repo.getCompleteAndNotifiedEnvelopes();
+
+        // then
+        assertThat(result)
+            .extracting(Envelope::getZipFileName)
+            .containsExactlyInAnyOrder("B.zip", "D.zip", "E.zip");
+    }
+
     private Envelope envelopeWithFailureCount(int failCount) {
         Envelope envelope = envelope("X", Status.UPLOAD_FAILURE);
         envelope.setUploadFailureCount(failCount);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeRepository.java
@@ -94,4 +94,9 @@ public interface EnvelopeRepository extends JpaRepository<Envelope, UUID> {
             + "WHERE createdat < :datetime AND status != 'COMPLETED'"
     )
     List<Envelope> getIncompleteEnvelopesBefore(@Param("datetime") LocalDateTime dateTime);
+
+    @Query("select e from Envelope e \n"
+            + "WHERE status = 'COMPLETED' OR status = 'NOTIFICATION_SENT'"
+    )
+    List<Envelope> getCompleteAndNotifiedEnvelopes();
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-317


### Change description ###
We need to delete envelopes with both NOTIFICATION_SENT and COMPLETED status. If deleting only NOTIFICATION_SENT - envelope can quickly change its status to COMPLETED and deletion job will miss it.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
