### PR TITLE
Check wait copy metadata

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirer.java
@@ -26,7 +26,7 @@ public class LeaseAcquirer {
 
     private final LeaseClientProvider leaseClientProvider;
     private final LeaseMetaDataChecker leaseMetaDataChecker;
-
+    public static final String META_DATA_WAIT_COPY =  "waitingCopy";
     public LeaseAcquirer(
         LeaseClientProvider leaseClientProvider,
         LeaseMetaDataChecker leaseMetaDataChecker
@@ -51,13 +51,24 @@ public class LeaseAcquirer {
     ) {
         try {
 
-            if (null != blobClient.getProperties().getCopyStatus()
-                && blobClient.getProperties().getCopyStatus() != SUCCESS) {
+            var blobProperties  = blobClient.getProperties();
+            if (null != blobProperties.getCopyStatus()
+                && blobProperties.getCopyStatus() != SUCCESS) {
                 logger.warn(
                     "Copy in progress skipping, file {} in container {}, copy status {}",
                     blobClient.getBlobName(),
                     blobClient.getContainerName(),
                     blobClient.getProperties().getCopyStatus()
+                );
+                return;
+            }
+
+            var metaData = blobProperties.getMetadata();
+            if (metaData.get(META_DATA_WAIT_COPY) !=null){
+                logger.warn(
+                    "Copy Source did not clean the meta data, skipping  file {} in container {}",
+                    blobClient.getBlobName(),
+                    blobClient.getContainerName()
                 );
                 return;
             }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirer.java
@@ -27,6 +27,7 @@ public class LeaseAcquirer {
     private final LeaseClientProvider leaseClientProvider;
     private final LeaseMetaDataChecker leaseMetaDataChecker;
     public static final String META_DATA_WAIT_COPY =  "waitingCopy";
+
     public LeaseAcquirer(
         LeaseClientProvider leaseClientProvider,
         LeaseMetaDataChecker leaseMetaDataChecker
@@ -64,7 +65,7 @@ public class LeaseAcquirer {
             }
 
             var metaData = blobProperties.getMetadata();
-            if (metaData.get(META_DATA_WAIT_COPY) !=null){
+            if (metaData.get(META_DATA_WAIT_COPY) != null) {
                 logger.warn(
                     "Copy Source did not clean the meta data, skipping  file {} in container {}",
                     blobClient.getBlobName(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirerTest.java
@@ -268,15 +268,14 @@ class LeaseAcquirerTest {
     @Test
     void should_skip_lease_when_meta_data_has_copy_waiting() {
         // given
-        var onSuccess = mock(Consumer.class);
-        var onFailure = mock(Consumer.class);
-
         BlobProperties blobItemProperties = mock(BlobProperties.class);
         given(blobItemProperties.getCopyStatus()).willReturn(null);
         given(blobClient.getProperties()).willReturn(blobItemProperties);
 
         given(blobItemProperties.getMetadata())
             .willReturn(Map.of("waitingCopy", "anyValue"));
+        var onSuccess = mock(Consumer.class);
+        var onFailure = mock(Consumer.class);
 
         // when
         leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure, false);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/LeaseAcquirerTest.java
@@ -265,6 +265,29 @@ class LeaseAcquirerTest {
 
     }
 
+    @Test
+    void should_skip_lease_when_meta_data_has_copy_waiting() {
+        // given
+        var onSuccess = mock(Consumer.class);
+        var onFailure = mock(Consumer.class);
+
+        BlobProperties blobItemProperties = mock(BlobProperties.class);
+        given(blobItemProperties.getCopyStatus()).willReturn(null);
+        given(blobClient.getProperties()).willReturn(blobItemProperties);
+
+        given(blobItemProperties.getMetadata())
+            .willReturn(Map.of("waitingCopy", "anyValue"));
+
+        // when
+        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure, false);
+
+        // then
+        verify(onSuccess, never()).accept(anyString());
+        verify(onFailure, never()).accept(any());
+        verifyNoMoreInteractions(leaseMetaDataChecker);
+
+    }
+
     private void setCopyStatus(CopyStatusType copyStatus) {
         BlobProperties blobItemProperties = mock(BlobProperties.class);
         given(blobItemProperties.getCopyStatus()).willReturn(copyStatus);


### PR DESCRIPTION

### Change description ###

Check wait copy metadata.
When large files gets copying into CFT there might be problem and processor should wait the source producer to finish copy and sort out the problem. Source producer first adds metadata and after that it copies the content and after finishing copy it removes the metadata, if processor see "waitingCopy" in metadata it should wait until it disappears.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
