### PR TITLE
ZipFileFailureHandler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
@@ -10,6 +10,7 @@ public enum Status {
     CREATED,
     METADATA_FAILURE,   // when we are aware of envelope, but there are inconsistency among files and metadata info
     SIGNATURE_FAILURE,  // the zip archive failed signature verification
+    ZIP_PROCESSING_FAILURE,  // the zip archive failed signature verification
     UPLOADED,
     UPLOAD_FAILURE,
     NOTIFICATION_SENT,  // after notifying about a new envelope

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ZipFileFailureHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ZipFileFailureHandler.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
+
+import java.time.Instant;
+import javax.transaction.Transactional;
+
+import static java.util.Collections.emptyList;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.ZIP_PROCESSING_FAILURE;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification.EXCEPTION;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_FAILURE;
+
+@Component
+public class ZipFileFailureHandler {
+    private static final Logger log = LoggerFactory.getLogger(ZipFileFailureHandler.class);
+
+    private final EnvelopeProcessor envelopeProcessor;
+
+    private final EnvelopeRepository envelopeRepository;
+
+    public ZipFileFailureHandler(
+        EnvelopeProcessor envelopeProcessor,
+        EnvelopeRepository envelopeRepository
+    ) {
+        this.envelopeProcessor = envelopeProcessor;
+        this.envelopeRepository = envelopeRepository;
+    }
+
+    @Transactional
+    public void handleZipFileFailure(String containerName, String zipFileName, Exception ex) {
+        log.error("Failed to process file {} from container {}", zipFileName, containerName, ex);
+        envelopeProcessor.createEvent(
+            DOC_FAILURE,
+            containerName,
+            zipFileName,
+            ex.getMessage(),
+            null
+        );
+        Envelope envelope = createEnvelope(containerName, zipFileName);
+        envelope.setStatus(ZIP_PROCESSING_FAILURE);
+        envelopeRepository.saveAndFlush(envelope);
+    }
+
+    private Envelope createEnvelope(String containerName, String zipFileName) {
+        return new Envelope(
+            "",
+            "",
+            Instant.now(),
+            Instant.now(),
+            Instant.now(),
+            zipFileName,
+            "",
+            null,
+            EXCEPTION,
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            containerName,
+            ""
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ZipFileFailureHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/ZipFileFailureHandlerTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.Envelope;
+import uk.gov.hmcts.reform.bulkscanprocessor.entity.EnvelopeRepository;
+import uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor.EnvelopeProcessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.bulkscanprocessor.entity.Status.ZIP_PROCESSING_FAILURE;
+import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_FAILURE;
+
+@ExtendWith(MockitoExtension.class)
+class ZipFileFailureHandlerTest {
+    private ZipFileFailureHandler zipFileFailureHandler;
+
+    @Mock
+    private EnvelopeProcessor envelopeProcessor;
+
+    @Mock
+    private EnvelopeRepository envelopeRepository;
+
+    @BeforeEach
+    void setUp() {
+        zipFileFailureHandler = new ZipFileFailureHandler(envelopeProcessor, envelopeRepository);
+    }
+
+    @Test
+    void should_create_event_and_dummy_envelope() {
+        // given
+        Exception ex = new Exception("msg");
+        final String zipFileName = "file1.zip";
+        final String container = "container";
+
+        // when
+        zipFileFailureHandler.handleZipFileFailure(container, zipFileName, ex);
+
+        // then
+        verify(envelopeProcessor).createEvent(DOC_FAILURE, container, zipFileName, ex.getMessage(), null);
+        ArgumentCaptor<Envelope> envelopeCaptor = ArgumentCaptor.forClass(Envelope.class);
+        verify(envelopeRepository).saveAndFlush(envelopeCaptor.capture());
+        assertThat(envelopeCaptor.getValue().getZipFileName()).isEqualTo(zipFileName);
+        assertThat(envelopeCaptor.getValue().getContainer()).isEqualTo(container);
+        assertThat(envelopeCaptor.getValue().getStatus()).isEqualTo(ZIP_PROCESSING_FAILURE);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-356


### Change description ###
ZipFileFailureHandler will be called from FileContentProcessor when catching generic exception in processZipFileContent method (in the next PR). 

Envelope record (with the newly introduced `ZIP_PROCESSING_FAILURE` status) is created in db in order to make the failure visible in `/stale-incomplete-blobs` endpoint, the zip file causing the problem will be moved to rejected container without sending error notification (also in the next PR).

After verifying the problem (based on the result of `/stale-incomplete-blobs` endpoint) and possible reporting it to the provider the envelope can be moved to COMPLETED status with help of devops.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
