### PR TITLE
ccd-action counts added

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/BlobProcessorTaskTestForFailedStatus.java
@@ -200,7 +200,7 @@ public class BlobProcessorTaskTestForFailedStatus extends ProcessorTestSuite {
     }
 
     @Test
-    public void should_reject_file_which_has_duplicate_cdn_number() throws Exception {
+    public void should_reject_file_which_has_duplicate_dcn_number() throws Exception {
         // given
         byte[] zipBytes = zipDir("zipcontents/ok");
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
@@ -29,16 +29,33 @@ public class ZipFilesSummaryReportListResponse {
 
     public ZipFilesSummaryReportListResponse(List<ZipFilesSummaryReportItem> items) {
         this.total = items.size();
-        this.totalCompleted = (int) items.stream().filter(
-            completed -> "COMPLETED".equalsIgnoreCase(completed.envelopeStatus)).count();
-        this.totalFailed = (int) items.stream().filter(
-            completed -> completed.envelopeStatus != null && completed.envelopeStatus.contains("FAILURE")).count();
-        this.exceptionRecord = (int) items.stream()
-            .filter(exRecord -> exRecord.ccdAction.equalsIgnoreCase("EXCEPTION_RECORD")).count();
-        this.autoCaseCreation = (int) items.stream()
-            .filter(autoCreatedCase -> autoCreatedCase.ccdAction.equalsIgnoreCase("AUTO_CREATED_CASE")).count();
-        this.autoAttachedToCase = (int) items.stream()
-            .filter(autoAttachedCase -> autoAttachedCase.ccdAction.equalsIgnoreCase("AUTO_ATTACHED_TO_CASE")).count();
         this.items = items;
+        int totalCompletedCount = 0, totalFailedCount = 0, exceptionRecordCount = 0;
+        int autoCaseCreationCount = 0, autoAttachedToCaseCount = 0;
+
+        for (var item : items)
+        {
+            if("COMPLETED".equalsIgnoreCase(item.envelopeStatus)){
+                totalCompletedCount += totalCompletedCount;
+            }
+            if(item.envelopeStatus != null && item.envelopeStatus.contains("FAILURE")){
+                totalFailedCount += totalFailedCount;
+            }
+            if(item.ccdAction.equalsIgnoreCase("EXCEPTION_RECORD")){
+                exceptionRecordCount += exceptionRecordCount;
+            }
+            if(item.ccdAction.equalsIgnoreCase("AUTO_CREATED_CASE")){
+                autoCaseCreationCount += autoCaseCreationCount;
+            }
+            if(item.ccdAction.equalsIgnoreCase("AUTO_ATTACHED_TO_CASE")){
+                autoAttachedToCaseCount += autoAttachedToCaseCount;
+            }
+        }
+
+        this.totalCompleted = totalCompletedCount;
+        this.totalFailed = totalFailedCount;
+        this.exceptionRecord = exceptionRecordCount;
+        this.autoCaseCreation = autoCaseCreationCount;
+        this.autoAttachedToCase = autoAttachedToCaseCount;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
@@ -15,15 +15,30 @@ public class ZipFilesSummaryReportListResponse {
     @JsonProperty("total_failed")
     public final int totalFailed;
 
+    @JsonProperty("exception_record")
+    public final int exceptionRecord;
+
+    @JsonProperty("auto_case_creation")
+    public final int autoCaseCreation;
+
+    @JsonProperty("auto_attached_to_case")
+    public final int autoAttachedToCase;
+
     @JsonProperty("data")
     public final List<ZipFilesSummaryReportItem> items;
 
     public ZipFilesSummaryReportListResponse(List<ZipFilesSummaryReportItem> items) {
         this.total = items.size();
-        this.totalCompleted = (int)items.stream().filter(
+        this.totalCompleted = (int) items.stream().filter(
             completed -> "COMPLETED".equalsIgnoreCase(completed.envelopeStatus)).count();
-        this.totalFailed = (int)items.stream().filter(
+        this.totalFailed = (int) items.stream().filter(
             completed -> completed.envelopeStatus != null && completed.envelopeStatus.contains("FAILURE")).count();
+        this.exceptionRecord = (int) items.stream()
+            .filter(exRecord -> exRecord.ccdAction.equalsIgnoreCase("EXCEPTION_RECORD")).count();
+        this.autoCaseCreation = (int) items.stream()
+            .filter(autoCreatedCase -> autoCreatedCase.ccdAction.equalsIgnoreCase("AUTO_CREATED_CASE")).count();
+        this.autoAttachedToCase = (int) items.stream()
+            .filter(autoAttachedCase -> autoAttachedCase.ccdAction.equalsIgnoreCase("AUTO_ATTACHED_TO_CASE")).count();
         this.items = items;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
@@ -24,13 +24,13 @@ public class ZipFilesSummaryReportListResponse {
     public final int totalFailed;
 
     @JsonProperty("exception_record")
-    public final int exceptionRecord;
+    public final Long exceptionRecord;
 
     @JsonProperty("auto_created_case")
-    public final int autoCreatedCase;
+    public final Long autoCreatedCase;
 
     @JsonProperty("auto_attached_to_case")
-    public final int autoAttachedToCase;
+    public final Long autoAttachedToCase;
 
     @JsonProperty("data")
     public final List<ZipFilesSummaryReportItem> items;
@@ -51,10 +51,10 @@ public class ZipFilesSummaryReportListResponse {
             .filter(envelope -> envelope.ccdAction != null)
             .collect(Collectors.groupingBy(envelope -> envelope.ccdAction, Collectors.counting()));
         this.exceptionRecord = ccdActionCount.containsKey(CCD_ACTION_EXCEPTION_RECORD)
-            ? Math.toIntExact(ccdActionCount.get(CCD_ACTION_EXCEPTION_RECORD)) : 0;
+            ? ccdActionCount.get(CCD_ACTION_EXCEPTION_RECORD) : 0;
         this.autoCreatedCase = ccdActionCount.containsKey(CCD_ACTION_AUTO_CREATED_CASE)
-            ? Math.toIntExact(ccdActionCount.get(CCD_ACTION_AUTO_CREATED_CASE)) : 0;
+            ? ccdActionCount.get(CCD_ACTION_AUTO_CREATED_CASE) : 0;
         this.autoAttachedToCase = ccdActionCount.containsKey(CCD_ACTION_AUTO_ATTACHED_TO_CASE)
-            ? Math.toIntExact(ccdActionCount.get(CCD_ACTION_AUTO_ATTACHED_TO_CASE)) : 0;
+            ? ccdActionCount.get(CCD_ACTION_AUTO_ATTACHED_TO_CASE) : 0;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/reports/ZipFilesSummaryReportListResponse.java
@@ -30,25 +30,29 @@ public class ZipFilesSummaryReportListResponse {
     public ZipFilesSummaryReportListResponse(List<ZipFilesSummaryReportItem> items) {
         this.total = items.size();
         this.items = items;
-        int totalCompletedCount = 0, totalFailedCount = 0, exceptionRecordCount = 0;
-        int autoCaseCreationCount = 0, autoAttachedToCaseCount = 0;
+        int totalCompletedCount = 0;
+        int totalFailedCount = 0;
+        int exceptionRecordCount = 0;
+        int autoCaseCreationCount = 0;
+        int autoAttachedToCaseCount = 0;
 
-        for (var item : items)
-        {
-            if("COMPLETED".equalsIgnoreCase(item.envelopeStatus)){
-                totalCompletedCount += totalCompletedCount;
+        for (var item : items) {
+            if (item.envelopeStatus != null && item.envelopeStatus.contains("COMPLETED")) {
+                totalCompletedCount = totalCompletedCount + 1;
             }
-            if(item.envelopeStatus != null && item.envelopeStatus.contains("FAILURE")){
-                totalFailedCount += totalFailedCount;
+            if (item.envelopeStatus != null && item.envelopeStatus.contains("FAILURE")) {
+                totalFailedCount = totalFailedCount + 1;
             }
-            if(item.ccdAction.equalsIgnoreCase("EXCEPTION_RECORD")){
-                exceptionRecordCount += exceptionRecordCount;
+            if (item.ccdAction.equalsIgnoreCase("EXCEPTION_RECORD")) {
+                exceptionRecordCount = exceptionRecordCount + 1;
+                continue;
             }
-            if(item.ccdAction.equalsIgnoreCase("AUTO_CREATED_CASE")){
-                autoCaseCreationCount += autoCaseCreationCount;
+            if (item.ccdAction.equalsIgnoreCase("AUTO_CREATED_CASE")) {
+                autoCaseCreationCount = autoCaseCreationCount + 1;
+                continue;
             }
-            if(item.ccdAction.equalsIgnoreCase("AUTO_ATTACHED_TO_CASE")){
-                autoAttachedToCaseCount += autoAttachedToCaseCount;
+            if (item.ccdAction.equalsIgnoreCase("AUTO_ATTACHED_TO_CASE")) {
+                autoAttachedToCaseCount = autoAttachedToCaseCount + 1;
             }
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -168,7 +168,7 @@ public class ReportsControllerTest {
             COMPLETED.toString(),
             EXCEPTION.name(),
             "ccd-id",
-            "ccd-action"
+            "AUTO_CREATED_CASE"
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan", null))
@@ -226,7 +226,7 @@ public class ReportsControllerTest {
             COMPLETED.toString(),
             SUPPLEMENTARY_EVIDENCE.name(),
             "ccd-id",
-            "ccd-action"
+            "AUTO_CREATED_CASE"
         );
 
         given(reportsService.getZipFilesSummary(localDate, "bulkscan", NEW_APPLICATION))
@@ -267,7 +267,7 @@ public class ReportsControllerTest {
             COMPLETED.toString(),
             SUPPLEMENTARY_EVIDENCE.name(),
             "ccd-id",
-            "ccd-action"
+            "AUTO_CREATED_CASE"
         );
 
         ZipFileSummaryResponse response2 = new ZipFileSummaryResponse(
@@ -281,7 +281,7 @@ public class ReportsControllerTest {
             UPLOAD_FAILURE.toString(),
             SUPPLEMENTARY_EVIDENCE.name(),
             "ccd-id",
-            "ccd-action"
+            "EXCEPTION_RECORD"
         );
 
         ZipFileSummaryResponse response3 = new ZipFileSummaryResponse(
@@ -295,7 +295,7 @@ public class ReportsControllerTest {
             CREATED.toString(),
             SUPPLEMENTARY_EVIDENCE.name(),
             "ccd-id",
-            "ccd-action"
+            "AUTO_ATTACHED_TO_CASE"
         );
 
         List<ZipFileSummaryResponse> response = Arrays.asList(response1, response2, response3);
@@ -309,7 +309,10 @@ public class ReportsControllerTest {
             .andExpect(content().contentType(APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.total").value(3))
             .andExpect(jsonPath("$.total_completed").value(1))
-            .andExpect(jsonPath("$.total_failed").value(1));
+            .andExpect(jsonPath("$.total_failed").value(1))
+            .andExpect(jsonPath("$.exception_record").value(1))
+            .andExpect(jsonPath("$.auto_case_creation").value(1))
+            .andExpect(jsonPath("$.auto_attached_to_case").value(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -256,6 +256,19 @@ public class ReportsControllerTest {
         LocalDate localDate = LocalDate.of(2021, 4, 8);
         LocalTime localTime = LocalTime.of(12, 30, 10, 0);
 
+        ZipFileSummaryResponse response0 = new ZipFileSummaryResponse(
+            "test1.zip",
+            localDate,
+            localTime,
+            localDate,
+            localTime.plusHours(1),
+            "bulkscan",
+            CONSUMED.toString(),
+            COMPLETED.toString(),
+            SUPPLEMENTARY_EVIDENCE.name(),
+            "ccd-id", null
+        );
+
         ZipFileSummaryResponse response1 = new ZipFileSummaryResponse(
             "test1.zip",
             localDate,
@@ -298,7 +311,7 @@ public class ReportsControllerTest {
             "AUTO_ATTACHED_TO_CASE"
         );
 
-        List<ZipFileSummaryResponse> response = Arrays.asList(response1, response2, response3);
+        List<ZipFileSummaryResponse> response = Arrays.asList(response0, response1, response2, response3);
         given(reportsService.getZipFilesSummary(localDate, "bulkscan", SUPPLEMENTARY_EVIDENCE))
             .willReturn(response);
 
@@ -307,11 +320,11 @@ public class ReportsControllerTest {
                              + "&classification=SUPPLEMENTARY_EVIDENCE"))
             .andExpect(status().isOk())
             .andExpect(content().contentType(APPLICATION_JSON_VALUE))
-            .andExpect(jsonPath("$.total").value(3))
-            .andExpect(jsonPath("$.total_completed").value(1))
+            .andExpect(jsonPath("$.total").value(4))
+            .andExpect(jsonPath("$.total_completed").value(2))
             .andExpect(jsonPath("$.total_failed").value(1))
             .andExpect(jsonPath("$.exception_record").value(1))
-            .andExpect(jsonPath("$.auto_case_creation").value(1))
+            .andExpect(jsonPath("$.auto_created_case").value(1))
             .andExpect(jsonPath("$.auto_attached_to_case").value(1));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -308,7 +308,7 @@ public class ReportsControllerTest {
             CREATED.toString(),
             SUPPLEMENTARY_EVIDENCE.name(),
             "ccd-id",
-            "AUTO_ATTACHED_TO_CASE"
+            null
         );
 
         List<ZipFileSummaryResponse> response = Arrays.asList(response0, response1, response2, response3);
@@ -325,7 +325,7 @@ public class ReportsControllerTest {
             .andExpect(jsonPath("$.total_failed").value(1))
             .andExpect(jsonPath("$.exception_record").value(1))
             .andExpect(jsonPath("$.auto_created_case").value(1))
-            .andExpect(jsonPath("$.auto_attached_to_case").value(1));
+            .andExpect(jsonPath("$.auto_attached_to_case").value(0));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/controller/ReportsControllerTest.java
@@ -177,7 +177,7 @@ public class ReportsControllerTest {
         String expectedContent = String.format(
             "Container,Zip File Name,Date Received,Time Received,Date Processed,Time Processed,"
                 + "Status,Classification,CCD Action,CCD ID\r\n"
-                + "bulkscan,test.zip,%s,%s,%s,%s,CONSUMED,EXCEPTION,ccd-action,ccd-id\r\n",
+                + "bulkscan,test.zip,%s,%s,%s,%s,CONSUMED,EXCEPTION,AUTO_CREATED_CASE,ccd-id\r\n",
             localDate.toString(), "12:30:10",
             localDate.toString(), "13:30:10"
         );


### PR DESCRIPTION
Total counts for ccd-actions(EXCEPTION_RECORD, AUTO_CREATED_CASE and AUTO_ATTACHED_TO_CASE) added. Affected ReportController test are updated as well.

The changes are made mainly in the ZipFilesSummaryReportListResponse class. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
