### PR TITLE
DTSBPS-131 Eliminated DOC_SIGNATURE_FAILURE event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/Status.java
@@ -8,7 +8,6 @@ public enum Status {
 
     CREATED,
     METADATA_FAILURE,   // when we are aware of envelope, but there are inconsistency among files and metadata info
-    SIGNATURE_FAILURE,  // the zip archive failed signature verification
     UPLOADED,
     UPLOAD_FAILURE,
     NOTIFICATION_SENT,  // after notifying about a new envelope
@@ -18,8 +17,6 @@ public enum Status {
         switch (event) {
             case DOC_FAILURE:
                 return Optional.of(METADATA_FAILURE);
-            case DOC_SIGNATURE_FAILURE:
-                return Optional.of(SIGNATURE_FAILURE);
             case DOC_UPLOADED:
                 return Optional.of(UPLOADED);
             case DOC_UPLOAD_FAILURE:
@@ -30,5 +27,4 @@ public enum Status {
                 return Optional.empty();
         }
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/common/Event.java
@@ -7,7 +7,6 @@ public enum Event {
     DOC_FAILURE, // generic failure while processing zip file. before uploading to document management
     FILE_VALIDATION_FAILURE,
     DISABLED_SERVICE_FAILURE,
-    DOC_SIGNATURE_FAILURE, // Signature verification failure while processing zip file
     DOC_UPLOADED,
     DOC_UPLOAD_FAILURE,
     DOC_PROCESSED_NOTIFICATION_SENT, // when document processed notification is posted (to servicebus queue)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-131


### Change description ###
Eliminated unused SIGNATURE_FAILURE envelope status and DOC_SIGNATURE_FAILURE event. 
DOC_SIGNATURE_FAILURE still left in RejectedZipFileRepository and EnvelopeCountSummaryRepository because this event exists in the database.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
