### PR TITLE
Added simplified envelopes report

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryRepository;
-import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
@@ -23,7 +22,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_FAILURE;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/EnvelopeCountSummaryRepositoryTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummary
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.reports.EnvelopeCountSummaryRepository;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.EnvelopeCreator;
 import uk.gov.hmcts.reform.bulkscanprocessor.helper.reports.countsummary.Item;
+import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Classification;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event;
 
 import java.time.Instant;
@@ -17,8 +18,12 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import static java.time.Instant.now;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.UUID.randomUUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.COMPLETED;
 import static uk.gov.hmcts.reform.bulkscanprocessor.model.common.Event.DOC_FAILURE;
@@ -38,6 +43,7 @@ class EnvelopeCountSummaryRepositoryTest {
 
     @Autowired private EnvelopeCountSummaryRepository reportRepo;
     @Autowired private ProcessEventRepository eventRepo;
+    @Autowired private EnvelopeRepository envelopeRepo;
 
     @Test
     void should_group_by_container() {
@@ -461,12 +467,60 @@ class EnvelopeCountSummaryRepositoryTest {
                 ));
     }
 
+    @Test
+    void envelope_summary_report_should_provide_counts_for_date() {
+        // given
+        dbHas(
+                envelope("service_A", Status.COMPLETED, Instant.parse("2021-07-02T10:15:30Z")),
+                envelope("service_A", Status.METADATA_FAILURE, Instant.parse("2021-07-02T10:15:31Z")),
+                envelope("service_B", Status.COMPLETED, Instant.parse("2021-07-02T10:15:32Z")),
+                envelope("service_B", Status.COMPLETED, Instant.parse("2021-07-02T10:15:33Z")),
+                envelope("service_B", Status.UPLOAD_FAILURE, Instant.parse("2021-07-02T10:15:34Z")),
+                envelope("service_B", Status.NOTIFICATION_SENT, Instant.parse("2021-07-02T10:15:35Z")),
+
+                // next day
+                envelope("service_B", Status.COMPLETED, Instant.parse("2021-07-03T10:15:36Z"))
+        );
+
+        // when
+        List<EnvelopeCountSummaryItem> result = reportRepo.getEnvelopeCountSummary(SUMMARY_DATE);
+
+        // then
+        assertThat(result)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyElementsOf(asList(
+                        new Item(SUMMARY_DATE, "service_A", 2, 1),
+                        new Item(SUMMARY_DATE, "service_B", 4, 1)
+                ));
+    }
+
     private void dbHas(ProcessEvent... events) {
         eventRepo.saveAll(asList(events));
     }
 
-    private Envelope envelope(String container) {
-        return EnvelopeCreator.envelope("X", Status.COMPLETED, container);
+    private void dbHas(Envelope... envelopes) {
+        envelopeRepo.saveAll(asList(envelopes));
+    }
+
+    private Envelope envelope(String container, Status status, Instant zipfilecreateddate) {
+        Envelope envelope = new Envelope(
+                "SSCSPO",
+                "X",
+                now(),
+                now(),
+                zipfilecreateddate,
+                randomUUID() + ".zip",
+                "1111222233334446",
+                "123654789",
+                Classification.EXCEPTION,
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                container,
+                null
+        );
+        envelope.setStatus(status);
+        return envelope;
     }
 
     private ProcessEvent event(String container, Instant createdAt, Event type) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/EnvelopeCountSummaryRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/entity/reports/EnvelopeCountSummaryRepository.java
@@ -68,4 +68,17 @@ public interface EnvelopeCountSummaryRepository extends JpaRepository<Envelope, 
                 + "GROUP BY first_events.container\n"
     )
     List<EnvelopeCountSummaryItem> getSummaryReportFor(@Param("date") LocalDate date);
+
+    @Query(
+        nativeQuery = true,
+            value = "SELECT\n"
+                + "    container,\n"
+                + "    date(:date) AS date,\n"
+                + "    count(*) AS received,\n"
+                + "    SUM(CASE WHEN status IN ('METADATA_FAILURE', 'UPLOAD_FAILURE') THEN 1 ELSE 0 END) AS rejected\n"
+                + "FROM envelopes\n"
+                + "WHERE date(zipfilecreateddate)=date(:date)\n"
+                + "GROUP BY container\n"
+    )
+    List<EnvelopeCountSummaryItem> getEnvelopeCountSummary(@Param("date") LocalDate date);
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-843


### Change description ###
Currently query called from /count-summary endpoint very frequently causes `504 Gateway timeout` response due to complexity of the query. 
This PR introduces simplified query which includes `envelopes` table rather than `process_events`. The logic of this new query is straightforward and uses only `zipfilecreated` field, this will give inaccurate results in case of overnight envelope processing; but it will give good results in most cases for further analysis if necessary.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
