### PR TITLE
Delete incorrect postgres v11 host secret

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -216,12 +216,6 @@ resource "azurerm_key_vault_secret" "POSTGRES-PASS-V11" {
   value        = "${module.bulk-scan-db-v11.postgresql_password}"
 }
 
-resource "azurerm_key_vault_secret" "POSTGRES_HOST-V11" {
-  key_vault_id = "${data.azurerm_key_vault.key_vault.id}"
-  name         = "${var.component}-POSTGRES-HOST-V11"
-  value        = "${module.bulk-scan-db-v11.host_name}"
-}
-
 resource "azurerm_key_vault_secret" "POSTGRES_PORT-V11" {
   key_vault_id = "${data.azurerm_key_vault.key_vault.id}"
   name         = "${var.component}-POSTGRES-PORT-V11"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-770


### Change description ###
Delete the keyvault secret for Postgres V11 as it has an incorrect value. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
