### PR TITLE
DTSBPS-948 : Update scanning_date format to include milliseconds

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/Document.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentType;
@@ -21,6 +22,7 @@ public class Document {
     public final String subtype;
 
     @JsonProperty("scanned_at")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", timezone = "UTC")
     public final Instant scannedAt;
 
     @JsonProperty("uuid")

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/model/out/msg/DocumentTest.java
@@ -1,6 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanprocessor.entity.ScannableItem;
 import uk.gov.hmcts.reform.bulkscanprocessor.model.common.DocumentSubtype;
@@ -17,9 +21,72 @@ import static uk.gov.hmcts.reform.bulkscanprocessor.model.out.msg.Document.fromS
 
 class DocumentTest {
 
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Test
+    void fromScannableItem_should_serialize_scanningDate_milliSeconds_one_zero() throws JsonProcessingException {
+        Instant scanningDate = Instant.parse("2022-05-23T01:02:03.120Z");
+        ScannableItem scannableItem = scannableItem(DocumentType.COVERSHEET, scanningDate);
+
+        Document document = fromScannableItem(scannableItem);
+
+        String documentSerialized = objectMapper.writeValueAsString(document);
+        assertThat(documentSerialized.contains("2022-05-23T01:02:03.120000Z")).isTrue();
+    }
+
+    @Test
+    void fromScannableItem_should_serialize_scanningDate_milliSeconds_two_zeroes() throws JsonProcessingException {
+        Instant scanningDate = Instant.parse("2022-05-23T01:02:03.100Z");
+        ScannableItem scannableItem = scannableItem(DocumentType.COVERSHEET, scanningDate);
+
+        Document document = fromScannableItem(scannableItem);
+
+        String documentSerialized = objectMapper.writeValueAsString(document);
+        assertThat(documentSerialized.contains("2022-05-23T01:02:03.100000Z")).isTrue();
+    }
+
+    @Test
+    void fromScannableItem_should_serialize_scanningDate_milliSeconds_three_zeroes() throws JsonProcessingException {
+        Instant scanningDate = Instant.parse("2022-05-23T01:02:03.000Z");
+        ScannableItem scannableItem = scannableItem(DocumentType.COVERSHEET, scanningDate);
+
+        Document document = fromScannableItem(scannableItem);
+
+        String documentSerialized = objectMapper.writeValueAsString(document);
+        assertThat(documentSerialized.contains("2022-05-23T01:02:03.000000Z")).isTrue();
+    }
+
+    @Test
+    void fromScannableItem_should_serialize_scanningDate_milliSeconds_all_zeroes() throws JsonProcessingException {
+        Instant scanningDate = Instant.parse("2022-05-23T00:00:00.000Z");
+        ScannableItem scannableItem = scannableItem(DocumentType.COVERSHEET, scanningDate);
+
+        Document document = fromScannableItem(scannableItem);
+
+        String documentSerialized = objectMapper.writeValueAsString(document);
+        assertThat(documentSerialized.contains("2022-05-23T00:00:00.000000Z")).isTrue();
+    }
+
+    @Test
+    void fromScannableItem_should_serialize_scanningDate_milliSeconds_non_zeroes() throws JsonProcessingException {
+        Instant scanningDate = Instant.parse("2022-05-23T10:11:22.145Z");
+        ScannableItem scannableItem = scannableItem(DocumentType.COVERSHEET, scanningDate);
+
+        Document document = fromScannableItem(scannableItem);
+
+        String documentSerialized = objectMapper.writeValueAsString(document);
+        assertThat(documentSerialized.contains("2022-05-23T10:11:22.145000Z")).isTrue();
+    }
+
     @Test
     void fromScannableItem_maps_to_document_correctly() {
-        ScannableItem scannableItem = scannableItem(DocumentType.CHERISHED);
+        ScannableItem scannableItem = scannableItem(DocumentType.CHERISHED, Instant.now().minus(1, DAYS));
         Document document = fromScannableItem(scannableItem);
 
         assertThat(document.controlNumber).isEqualTo(scannableItem.getDocumentControlNumber());
@@ -30,12 +97,12 @@ class DocumentTest {
         assertThat(document.uuid).isEqualTo(scannableItem.getDocumentUuid());
     }
 
-    private ScannableItem scannableItem(DocumentType documentType) {
+    private ScannableItem scannableItem(DocumentType documentType, Instant scanningDate) {
         OcrData ocrData = new OcrData(singletonList(new OcrDataField(new TextNode("ocr"), new TextNode("data1"))));
 
         ScannableItem scannableItem = new ScannableItem(
             "1111001",
-            Instant.now(),
+            scanningDate,
             "ocrAccuracy1",
             "manualIntervention1",
             "nextAction1",

--- a/src/test/resources/metafiles/valid/envelope-with-ocr-data.json
+++ b/src/test/resources/metafiles/valid/envelope-with-ocr-data.json
@@ -10,7 +10,7 @@
   "scannable_items": [
     {
       "document_control_number": "1111001",
-      "scanning_date": "2017-02-24T00:00:00.000Z",
+      "scanning_date": "2017-02-24T10:12:22.445Z",
       "manual_intervention": "string",
       "next_action": "return",
       "next_action_date": "2017-02-24T00:00:00.000Z",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-948


### Change description ###
Envelope servicebus message is missing milliseconds in the document scanning_date attribute.
Specify the dataformat for scanning_date field

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
