### PR TITLE
DTSBPS-949: Fix CVE-2022-22970 and CVE-2022-22971

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,14 +227,21 @@ dependencyManagement {
     dependencySet(group: 'org.springframework.cloud', version: '3.1.2') {
       entry 'spring-cloud-starter-openfeign'
     }
-    // CVE-2022-22950
+    // CVE-2022-22970, CVE-2022-22971
     dependencySet(group: 'org.springframework', version: '5.3.20') {
       entry 'spring-aop'
+      entry 'spring-aspects'
       entry 'spring-beans'
       entry 'spring-context'
+      entry 'spring-context-support'
       entry 'spring-core'
       entry 'spring-expression'
       entry 'spring-jcl'
+      entry 'spring-jdbc'
+      entry 'spring-orm'
+      entry 'spring-tx'
+      entry 'spring-web'
+      entry 'spring-webmvc'
     }
     dependencySet(group: 'org.apache.logging.log4j', version: '2.17.2') {
       entry 'log4j-api'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-949


### Change description ###
Bump spring dependencies version to 5.3.20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
