### PR TITLE
FACT 1698 Renovate Dependency Updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.50.0'
   id 'org.sonarqube' version '4.4.1.3373'
   id 'info.solidsoft.pitest' version '1.15.0'
-  id 'au.com.dius.pact' version '4.6.5'
+  id 'au.com.dius.pact' version '4.3.14'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.4'
-  id 'org.flywaydb.flyway' version '9.22.3'
+  id 'org.flywaydb.flyway' version '10.13.0'
   id 'org.springframework.boot' version '3.2.3'
   id 'org.owasp.dependencycheck' version '9.0.9'
   id 'com.github.ben-manes.versions' version '0.50.0'
@@ -255,6 +255,8 @@ dependencies {
     exclude group: 'javax.mail', module: 'mailapi'
   }
 
+  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.13.0'
+
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.10.2'
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '5.10.2'
 
@@ -278,7 +280,7 @@ dependencies {
 
   implementation group: 'com.github.java-json-tools', name: 'json-schema-validator', version: '2.2.14', withoutJavaxMailApi
 
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.22.3'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.13.0'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
   // review following dependency after integrating db structure
   implementation group: 'io.hypersistence', name: 'hypersistence-utils-hibernate-63', version: '3.7.3'

--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: bspteam@hmcts.net
 dependencies:
   - name: java
-    version: 5.0.0
+    version: 5.2.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
     version: 1.0.4

--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-processor
 apiVersion: v2
 home: https://github.com/hmcts/bulk-scan-processor
-version: 1.0.23
+version: 1.0.24
 description: HMCTS Bulk scan processor service
 maintainers:
   - name: HMCTS BSP Team

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
@@ -137,7 +137,7 @@ public class GetSasTokenTest extends BaseFunctionalTest  {
         Date tokenExpiry = DateUtil.parseDatetime(queryParams.get("se"));
         assertThat(tokenExpiry).isNotNull();
         assertThat(queryParams.get("sig")).isNotNull(); //this is a generated hash of the resource string
-        assertThat(queryParams.get("sv")).contains("2021-12-02"); //azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2023-11-03"); //azure api version is latest
         assertThat(queryParams.get("sp")).contains("wl"); //access permissions(write-w,list-l)
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
@@ -67,7 +67,7 @@ public class SasTokenControllerTest {
 
         assertThat(queryParams.get("sig")).isNotNull();//this is a generated hash of the resource string
         assertThat(queryParams.get("se")).startsWith(currentDate);//the expiry date/time for the signature
-        assertThat(queryParams.get("sv")).contains("2021-12-02");//azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2023-11-03");//azure api version is latest
         assertThat(queryParams.get("sp")).contains("wl");//access permissions(write-w,list-l)
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
@@ -60,7 +60,7 @@ class SasTokenGeneratorServiceTest {
 
         assertThat(queryParams.get("sig")).isNotNull();//this is a generated hash of the resource string
         assertThat(queryParams.get("se")).startsWith(currentDate);//the expiry date/time for the signature
-        assertThat(queryParams.get("sv")).contains("2021-12-02");//azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2023-11-03");//azure api version is latest
         assertThat(queryParams.get("sp")).contains("rwl");//access permissions(write-w,list-l)
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-1698

### Change description ###

Pact has been downgraded to the same version as Bulk Scan Orchestrator to get past build failures. 

Tests that check the latest Azure Storage version have been updated to reflect new version date.

All relevant Renovate dependency updates have been merged in except:

- Pact, ticket [here](https://tools.hmcts.net/jira/browse/FACT-1721)

**Major Version Changes**

Flyway V9 to V10

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
