### PR TITLE
Adds flyway-postgres library to buildscript block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,13 +249,17 @@ ext.libraries = [
 ]
 ext["rest-assured.version"] = '5.4.0'
 
+buildscript {
+  dependencies {
+    classpath("org.flywaydb:flyway-database-postgresql:10.13.0")
+  }
+}
+
 dependencies {
 
   def withoutJavaxMailApi = {
     exclude group: 'javax.mail', module: 'mailapi'
   }
-
-  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.13.0'
 
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.10.2'
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '5.10.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
   dependencies {
+    classpath("org.postgresql:postgresql:42.7.3")
     classpath("org.flywaydb:flyway-database-postgresql:10.13.0")
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -261,6 +261,8 @@ dependencies {
     exclude group: 'javax.mail', module: 'mailapi'
   }
 
+  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.13.0'
+
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.10.2'
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '5.10.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+  dependencies {
+    classpath("org.flywaydb:flyway-database-postgresql:10.13.0")
+  }
+}
+
 plugins {
   id 'application'
   id 'checkstyle'
@@ -248,12 +254,6 @@ ext.libraries = [
   ]
 ]
 ext["rest-assured.version"] = '5.4.0'
-
-buildscript {
-  dependencies {
-    classpath("org.flywaydb:flyway-database-postgresql:10.13.0")
-  }
-}
 
 dependencies {
 


### PR DESCRIPTION
### Change description ###

Attempts to fix `migratePostgresDatabase - No database found to handle jdbc:postgresql` in master from merging in https://github.com/hmcts/bulk-scan-processor/pull/3270

Flyway-postgres library is already present in dependencies `runtimeOnly` but this PR adds it and the postgresql library to being in the build script block. In the hopes it will be accessible to the DB migration build step.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
