### PR TITLE
FACT-2003 - updates azure storage blob version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ dependencies {
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.14.0'
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: '5.14.0'
 
-  implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.25.4'
+  implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.28.1'
 
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.5'
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/GetSasTokenTest.java
@@ -137,7 +137,7 @@ public class GetSasTokenTest extends BaseFunctionalTest  {
         Date tokenExpiry = DateUtil.parseDatetime(queryParams.get("se"));
         assertThat(tokenExpiry).isNotNull();
         assertThat(queryParams.get("sig")).isNotNull(); //this is a generated hash of the resource string
-        assertThat(queryParams.get("sv")).contains("2023-11-03"); //azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2024-11-04"); //azure api version is latest
         assertThat(queryParams.get("sp")).contains("wl"); //access permissions(write-w,list-l)
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/EnvelopeControllerTest.java
@@ -114,7 +114,8 @@ public class EnvelopeControllerTest {
     private BlobContainerClient testContainer;
 
     private static GenericContainer<?> dockerComposeContainer =
-        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT);
+        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT)
+            .withCommand("azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck");
 
     private static String dockerHost;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/SasTokenControllerTest.java
@@ -67,7 +67,7 @@ public class SasTokenControllerTest {
 
         assertThat(queryParams.get("sig")).isNotNull();//this is a generated hash of the resource string
         assertThat(queryParams.get("se")).startsWith(currentDate);//the expiry date/time for the signature
-        assertThat(queryParams.get("sv")).contains("2023-11-03");//azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2024-11-04");//azure api version is latest
         assertThat(queryParams.get("sp")).contains("wl");//access permissions(write-w,list-l)
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ZipStatusControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/controllers/ZipStatusControllerTest.java
@@ -105,7 +105,8 @@ class ZipStatusControllerTest {
 
 
     private static GenericContainer<?> dockerComposeContainer =
-        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT);
+        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT)
+            .withCommand("azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck");
 
     private static String dockerHost;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/reports/RejectedFilesReportServiceTest.java
@@ -31,7 +31,8 @@ public class RejectedFilesReportServiceTest {
     private BlobManager blobManager;
 
     private static GenericContainer<?> dockerComposeContainer =
-        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT);
+        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT)
+            .withCommand("azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck");
 
     private static String dockerHost;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/OcrValidationRetryManagerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/services/storage/OcrValidationRetryManagerTest.java
@@ -34,7 +34,8 @@ class OcrValidationRetryManagerTest {
     private OcrValidationRetryManager ocrValidationRetryManager;
 
     private static GenericContainer<?> dockerComposeContainer =
-        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT);
+        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT)
+            .withCommand("azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck");
 
     private static String dockerHost;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/CleanUpRejectedFilesTaskTest.java
@@ -47,7 +47,8 @@ public class CleanUpRejectedFilesTaskTest {
     private BlobManager blobManager;
 
     private static GenericContainer<?> dockerComposeContainer =
-        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT);
+        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT)
+            .withCommand("azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck");
 
     private static String dockerHost;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/ProcessorTestSuite.java
@@ -127,7 +127,8 @@ public abstract class ProcessorTestSuite {
     protected BlobContainerClient rejectedContainer;
 
     private static GenericContainer<?> dockerComposeContainer =
-        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT);
+        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT)
+            .withCommand("azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck");
 
     private static String dockerHost;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TestStorageHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanprocessor/util/TestStorageHelper.java
@@ -26,7 +26,8 @@ public class TestStorageHelper {
     private BlobContainerClient testContainer;
 
     private static GenericContainer<?> DOCKER_COMPOSE_CONTAINER =
-        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT);
+        new GenericContainer<>(AZURE_TEST_CONTAINER).withExposedPorts(CONTAINER_PORT)
+            .withCommand("azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck");
 
     private TestStorageHelper() {
         // empty constructor

--- a/src/integrationTest/resources/docker-compose.yml
+++ b/src/integrationTest/resources/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '3'
-services:
-  azure-storage:
-    image: mcr.microsoft.com/azure-storage/azurite:3.29.0
-    ports:
-        - 10000:10000
-    environment:
-        - executable=blob

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/services/SasTokenGeneratorServiceTest.java
@@ -60,7 +60,7 @@ class SasTokenGeneratorServiceTest {
 
         assertThat(queryParams.get("sig")).isNotNull();//this is a generated hash of the resource string
         assertThat(queryParams.get("se")).startsWith(currentDate);//the expiry date/time for the signature
-        assertThat(queryParams.get("sv")).contains("2023-11-03");//azure api version is latest
+        assertThat(queryParams.get("sv")).contains("2024-11-04");//azure api version is latest
         assertThat(queryParams.get("sp")).contains("rwl");//access permissions(write-w,list-l)
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/tasks/processor/BlobManagerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscanprocessor.tasks.processor;
 
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.http.rest.PagedIterable;
@@ -201,7 +202,8 @@ class BlobManagerTest {
         given(response.getStatusCode()).willReturn(412);
         HttpHeaders httpHeaders =  mock(HttpHeaders.class);
         given(response.getHeaders()).willReturn(httpHeaders);
-        given(httpHeaders.getValue(ERROR_CODE)).willReturn(BlobErrorCode.LEASE_LOST.toString());
+        given(httpHeaders.getValue(HttpHeaderName.fromString(ERROR_CODE)))
+            .willReturn(String.valueOf(BlobErrorCode.LEASE_LOST));
 
 
         willThrow(new BlobStorageException(BlobErrorCode.LEASE_LOST.toString(), response, null))


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-2003

### Change description ###

- Updates azure storage blob
- Due to Azurite issues with version 3.30.0 a skip Azure API check has been put in building the Azurite image for the integration test container as Azurite cannot be updated to a version that supports the new version of azure storage blob
- Test had to be updated to reflect changes in how azure deals with blob error code
- Removes unneeded docker compose

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
