### PR TITLE
idam updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,8 @@ dependencyCheck {
 }
 
 def versions = [
-  reformLogging: '6.1.9',
+  reformLogging: '8.0.0',
+  reformLoggingAppInsights: '6.1.9',
   flyway: "$flywayVersion",
   postgresql: "$postgresqlVersion"
 ]
@@ -192,7 +193,7 @@ dependencies {
   implementation group: 'org.apache.httpcomponents.core5', name: 'httpcore5-h2', version: '5.4.2'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.17'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLoggingAppInsights
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.4'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'

--- a/charts/bulk-scan-processor/Chart.yaml
+++ b/charts/bulk-scan-processor/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-processor
 apiVersion: v2
 home: https://github.com/hmcts/bulk-scan-processor
-version: 1.0.35
+version: 1.0.36
 description: HMCTS Bulk scan processor service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-processor/values.preview.template.yaml
+++ b/charts/bulk-scan-processor/values.preview.template.yaml
@@ -44,7 +44,7 @@ java:
     UPLOAD_TASK_DELAY: "2000"
     DELETE_COMPLETE_FILES_CRON: "0/10 * * * * *"
     S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-    IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"
+    IDAM_API_URL: "https://idam-web-public.aat.platform.hmcts.net"
     CDAM_URL: "http://ccd-case-document-am-api-aat.service.core-compute-aat.internal"
   keyVaults:
     "bulk-scan":

--- a/charts/bulk-scan-processor/values.yaml
+++ b/charts/bulk-scan-processor/values.yaml
@@ -48,7 +48,7 @@ java:
     QUEUE_NOTIFICATIONS_NAME: "notifications"
     QUEUE_NOTIFICATIONS_NAMESPACE: reform-scan-servicebus-{{ .Values.global.environment }}-premium
     NOTIFICATION_STALE_TIMEOUT_HR: 48
-    IDAM_API_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
+    IDAM_API_URL: "https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net"
     IDAM_CLIENT_REDIRECT_URI: "https://bulk-scan-orchestrator-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback"
     CDAM_URL: "http://ccd-case-document-am-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     JMS_ENABLED: false

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/health/IdamHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanprocessor/health/IdamHealthIndicator.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.health;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.idam.AuthenticationChecker;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.idam.JurisdictionConfigurationStatus;
+
+import java.util.List;
+
+@Component("idam")
+public class IdamHealthIndicator implements HealthIndicator {
+
+    private final AuthenticationChecker authenticationChecker;
+
+    public IdamHealthIndicator(AuthenticationChecker authenticationChecker) {
+        this.authenticationChecker = authenticationChecker;
+    }
+
+    @Override
+    public Health health() {
+        List<JurisdictionConfigurationStatus> statuses = authenticationChecker.checkSignInForAllJurisdictions();
+
+        return statuses.stream().allMatch(status -> status.isCorrect)
+            ? Health.up().build()
+            : Health.down().build();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ management:
       show-details: always
       group:
         readiness:
-          include: db
+          include: db, idam
   endpoints:
     web:
       base-path: /

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/health/IdamHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanprocessor/health/IdamHealthIndicatorTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.bulkscanprocessor.health;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.idam.AuthenticationChecker;
+import uk.gov.hmcts.reform.bulkscanprocessor.services.idam.JurisdictionConfigurationStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class IdamHealthIndicatorTest {
+
+    @Mock
+    private AuthenticationChecker authenticationChecker;
+
+    @Test
+    void should_return_up_when_all_configured_idam_users_can_authenticate() {
+        given(authenticationChecker.checkSignInForAllJurisdictions()).willReturn(List.of(
+            new JurisdictionConfigurationStatus("bulkscan", true)
+        ));
+
+        Health health = new IdamHealthIndicator(authenticationChecker).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    void should_return_down_when_a_configured_idam_user_cannot_authenticate() {
+        given(authenticationChecker.checkSignInForAllJurisdictions()).willReturn(List.of(
+            new JurisdictionConfigurationStatus("bulkscan", true),
+            new JurisdictionConfigurationStatus("sscs", false)
+        ));
+
+        Health health = new IdamHealthIndicator(authenticationChecker).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    }
+}


### PR DESCRIPTION
• - Changed IDAM_API_URL from idam-api to idam-web-public in Helm values:
      - charts/bulk-scan-processor/values.yaml
      - charts/bulk-scan-processor/values.preview.template.yaml

  - Added idam to the readiness healthcheck group in src/main/resources/application.yaml.
  - Added a small IdamHealthIndicator that reuses the existing AuthenticationChecker.
  - Confirmed there are no repo references to deprecated /details or /oauth2/authorize endpoints.
  - Verified with the focused readiness integration test.

